### PR TITLE
[crypto] Refactor crypto to be generic / pull ed25519 out of transaction logic

### DIFF
--- a/cmd/goclient/goclient.go
+++ b/cmd/goclient/goclient.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/ed25519"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -213,14 +212,14 @@ func main() {
 			amount := uint64(200_000_000)
 			err = client.Fund(alice.Address, amount)
 			maybefail(err, "faucet err: %s", err)
-			fmt.Fprintf(os.Stdout, "new account %s funded for %d, privkey = %s\n", alice.Address.String(), amount, hex.EncodeToString(alice.PrivateKey.(ed25519.PrivateKey)[:]))
+			fmt.Fprintf(os.Stdout, "new account %s funded for %d, privkey = %s\n", alice.Address.String(), amount, hex.EncodeToString(alice.PrivateKey.Bytes()))
 
 			bob, err := aptos.NewAccount()
 			maybefail(err, "new account: %s", err)
 			//amount = uint64(10_000_000)
 			err = client.Fund(bob.Address, amount)
 			maybefail(err, "faucet err: %s", err)
-			fmt.Fprintf(os.Stdout, "new account %s funded for %d, privkey = %s\n", bob.Address.String(), amount, hex.EncodeToString(bob.PrivateKey.(ed25519.PrivateKey)[:]))
+			fmt.Fprintf(os.Stdout, "new account %s funded for %d, privkey = %s\n", bob.Address.String(), amount, hex.EncodeToString(bob.PrivateKey.Bytes()))
 
 			time.Sleep(2 * time.Second)
 			stxn, err := aptos.APTTransferTransaction(client, alice, bob.Address, 42)

--- a/crypto.go
+++ b/crypto.go
@@ -1,0 +1,27 @@
+package aptos
+
+// Signer a generic interface for any kind of signing
+type Signer interface {
+	Sign(msg []byte) (authenticator Authenticator, err error)
+}
+
+// PrivateKey a generic interface for a signing private key
+type PrivateKey interface {
+	Signer
+
+	/// PubKey Retrieve the public key for signature verification
+	PubKey() PublicKey
+}
+
+// PublicKey a generic interface for a public key associated with the private key
+type PublicKey interface {
+	// BCSStruct The public key must be serializable or it will not be used in transactions
+	BCSStruct
+
+	// Bytes the raw bytes for an authenticator
+	Bytes() []byte
+	// Scheme The scheme used for address derivation
+	Scheme() uint8
+
+	// TODO: add verify
+}

--- a/crypto.go
+++ b/crypto.go
@@ -11,6 +11,8 @@ type PrivateKey interface {
 
 	/// PubKey Retrieve the public key for signature verification
 	PubKey() PublicKey
+
+	Bytes() []byte
 }
 
 // PublicKey a generic interface for a public key associated with the private key

--- a/ed25519.go
+++ b/ed25519.go
@@ -1,0 +1,64 @@
+package aptos
+
+import (
+	"crypto/ed25519"
+)
+
+type Ed25519PrivateKey struct {
+	inner ed25519.PrivateKey
+}
+
+func GenerateEd5519Keys() (privkey Ed25519PrivateKey, pubkey Ed25519PublicKey, err error) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		return
+	}
+	privkey = Ed25519PrivateKey{priv}
+	pubkey = Ed25519PublicKey{pub}
+	return
+}
+
+func (key *Ed25519PrivateKey) PubKey() PublicKey {
+	pubkey := key.inner.Public()
+	return Ed25519PublicKey{
+		pubkey.(ed25519.PublicKey),
+	}
+}
+
+func (key *Ed25519PrivateKey) Sign(msg []byte) (authenticator Authenticator, err error) {
+	publicKeyBytes := key.PubKey().Bytes()
+	signature := ed25519.Sign(key.inner, msg)
+
+	auth := &Ed25519Authenticator{}
+	copy(auth.PublicKey[:], publicKeyBytes[:])
+	copy(auth.Signature[:], signature[:]) // TODO: Signature type?
+	authenticator = Authenticator{
+		AuthenticatorEd25519,
+		auth,
+	}
+	return
+}
+
+type Ed25519PublicKey struct {
+	inner ed25519.PublicKey
+}
+
+func (key Ed25519PublicKey) Bytes() []byte {
+	return key.inner[:]
+}
+func (key Ed25519PublicKey) Scheme() uint8 {
+	return Ed25519Scheme
+}
+
+func (key Ed25519PublicKey) MarshalBCS(bcs *Serializer) {
+	bcs.FixedBytes(key.inner[:])
+}
+
+func (key Ed25519PublicKey) UnmarshalBCS(bcs *Deserializer) {
+	key = Ed25519PublicKey{}
+	bytes := bcs.ReadFixedBytes(32)
+	if bcs.Error() != nil {
+		return
+	}
+	copy(key.inner[:], bytes)
+}

--- a/ed25519.go
+++ b/ed25519.go
@@ -25,6 +25,10 @@ func (key *Ed25519PrivateKey) PubKey() PublicKey {
 	}
 }
 
+func (key *Ed25519PrivateKey) Bytes() []byte {
+	return key.inner[:]
+}
+
 func (key *Ed25519PrivateKey) Sign(msg []byte) (authenticator Authenticator, err error) {
 	publicKeyBytes := key.PubKey().Bytes()
 	signature := ed25519.Sign(key.inner, msg)

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -1,7 +1,6 @@
 package aptos
 
 import (
-	"crypto/ed25519"
 	"encoding/binary"
 	"testing"
 
@@ -40,7 +39,7 @@ func TestRawTransactionSign(t *testing.T) {
 		ChainId:                   4,
 	}
 
-	stxn, err := txn.SignEd25519(sender.PrivateKey.(ed25519.PrivateKey))
+	stxn, err := txn.Sign(sender.PrivateKey)
 	assert.NoError(t, err)
 
 	_, ok := stxn.Authenticator.Auth.(*Ed25519Authenticator)

--- a/util.go
+++ b/util.go
@@ -1,7 +1,6 @@
 package aptos
 
 import (
-	"crypto/ed25519"
 	"encoding/binary"
 	"time"
 )
@@ -51,6 +50,6 @@ func APTTransferTransaction(client *Client, sender *Account, dest AccountAddress
 		ChainId:                   chainId,
 	}
 
-	stxn, err = txn.SignEd25519(sender.PrivateKey.(ed25519.PrivateKey))
+	stxn, err = txn.Sign(sender.PrivateKey)
 	return stxn, err
 }


### PR DESCRIPTION
Pulls ed25519 into separate files, makes signing generic