### PR TITLE
Update faucet client

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,7 +3,6 @@ package aptos
 import (
 	"errors"
 	"github.com/aptos-labs/aptos-go-sdk/core"
-	"net/url"
 	"time"
 )
 
@@ -83,11 +82,6 @@ func NewClientFromNetworkName(networkName string) (client *Client, err error) {
 
 // NewClient Creates a new client with a specific network config that can be extended in the future
 func NewClient(config NetworkConfig) (client *Client, err error) {
-	faucetUrl, err := url.Parse(config.FaucetUrl)
-	if err != nil {
-		return nil, err
-	}
-
 	// TODO: add indexer
 
 	nodeClient, err := NewNodeClient(config.NodeUrl, config.ChainId)
@@ -95,14 +89,14 @@ func NewClient(config NetworkConfig) (client *Client, err error) {
 		return nil, err
 	}
 
+	faucetClient, err := NewFaucetClient(nodeClient, config.FaucetUrl)
+	if err != nil {
+		return nil, err
+	}
+
 	// Fetch the chain Id if it isn't in the config
 	if config.ChainId == 0 {
 		_, _ = nodeClient.GetChainId()
-	}
-
-	faucetClient := &FaucetClient{
-		nodeClient,
-		*faucetUrl,
 	}
 
 	client = &Client{

--- a/faucet.go
+++ b/faucet.go
@@ -8,46 +8,7 @@ import (
 	"log/slog"
 	"net/url"
 	"strconv"
-	"strings"
 )
-
-func truthy(x any) bool {
-	switch v := x.(type) {
-	case nil:
-		return false
-	case bool:
-		return v
-	case int:
-		return v != 0
-	case int8:
-		return v != 0
-	case int16:
-		return v != 0
-	case int32:
-		return v != 0
-	case int64:
-		return v != 0
-	case uint:
-		return v != 0
-	case uint8:
-		return v != 0
-	case uint16:
-		return v != 0
-	case uint32:
-		return v != 0
-	case uint64:
-		return v != 0
-	case float32:
-		return v != 0
-	case float64:
-		return v != 0
-	case string:
-		v = strings.ToLower(v)
-		return (v == "t") || (v == "true")
-	default:
-		return false
-	}
-}
 
 type FaucetClient struct {
 	nodeClient *NodeClient

--- a/faucet.go
+++ b/faucet.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aptos-labs/aptos-go-sdk/core"
 	"log/slog"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 )
@@ -52,7 +51,18 @@ func truthy(x any) bool {
 
 type FaucetClient struct {
 	nodeClient *NodeClient
-	url        url.URL
+	url        *url.URL
+}
+
+func NewFaucetClient(nodeClient *NodeClient, faucetUrl string) (*FaucetClient, error) {
+	url, err := url.Parse(faucetUrl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse faucet url '%s': %+w", faucetUrl, err)
+	}
+	return &FaucetClient{
+		nodeClient,
+		url,
+	}, nil
 }
 
 // Fund account with the given amount of AptosCoin
@@ -60,8 +70,7 @@ func (faucetClient *FaucetClient) Fund(address core.AccountAddress, amount uint6
 	if faucetClient.nodeClient == nil {
 		return errors.New("faucet's node-client not initialized")
 	}
-	mintUrl := faucetClient.url
-	mintUrl.Path = path.Join(mintUrl.Path, "mint")
+	mintUrl := faucetClient.url.JoinPath("mint")
 	params := url.Values{}
 	params.Set("amount", strconv.FormatUint(amount, 10))
 	params.Set("address", address.String())

--- a/nodeClient.go
+++ b/nodeClient.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aptos-labs/aptos-go-sdk/bcs"
@@ -641,4 +642,42 @@ func (rc *NodeClient) View(payload *ViewPayload) (data []any, err error) {
 	_ = response.Body.Close()
 	err = json.Unmarshal(blob, &data)
 	return
+}
+
+func truthy(x any) bool {
+	switch v := x.(type) {
+	case nil:
+		return false
+	case bool:
+		return v
+	case int:
+		return v != 0
+	case int8:
+		return v != 0
+	case int16:
+		return v != 0
+	case int32:
+		return v != 0
+	case int64:
+		return v != 0
+	case uint:
+		return v != 0
+	case uint8:
+		return v != 0
+	case uint16:
+		return v != 0
+	case uint32:
+		return v != 0
+	case uint64:
+		return v != 0
+	case float32:
+		return v != 0
+	case float64:
+		return v != 0
+	case string:
+		v = strings.ToLower(v)
+		return (v == "t") || (v == "true")
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
- add a `NewFaucetClient` constructor, allowing creation of `FaucetClient` independent of `Client`
- use `*url.URL` and `JoinPath`
- move `truthy` into `nodeClient.go` where it is used