### PR TITLE
[bcs / type tag] Fix some bugs, add error handling, full testing

### DIFF
--- a/bcs/bcs_test.go
+++ b/bcs/bcs_test.go
@@ -173,12 +173,48 @@ func Test_Struct(t *testing.T) {
 	// Deserializer
 	for i, input := range serialized {
 		bytes, _ := hex.DecodeString(input)
-		deserializer := &Deserializer{source: bytes}
+		deserializer := NewDeserializer(bytes)
 		st := TestStruct{}
 		deserializer.Struct(&st)
 		assert.Equal(t, deserialized[i], st)
 		assert.NoError(t, deserializer.Error())
 	}
+}
+
+func Test_Deserializer(t *testing.T) {
+	serialized, _ := hex.DecodeString("00010002")
+	des := NewDeserializer(serialized)
+	assert.Equal(t, 4, des.Remaining())
+	assert.Equal(t, uint8(0), des.U8())
+	assert.Equal(t, 3, des.Remaining())
+	assert.Equal(t, uint16(1), des.U16())
+	assert.Equal(t, 1, des.Remaining())
+	des.U16()
+	assert.Error(t, des.Error())
+	des.SetError(nil)
+	des.Bool()
+	assert.Error(t, des.Error())
+	des.SetError(nil)
+	des.ReadFixedBytes(2)
+	assert.Error(t, des.Error())
+	des.SetError(nil)
+	des.U16()
+	assert.Error(t, des.Error())
+	des.SetError(nil)
+	des.U32()
+	assert.Error(t, des.Error())
+	des.SetError(nil)
+	des.U64()
+	assert.Error(t, des.Error())
+	des.SetError(nil)
+	des.U128()
+	assert.Error(t, des.Error())
+	des.SetError(nil)
+	des.U256()
+	assert.Error(t, des.Error())
+	des.SetError(nil)
+	des.U256()
+	assert.Error(t, des.Error())
 }
 
 func helper[TYPE uint8 | uint16 | uint32 | uint64 | bool | []byte | string](t *testing.T, serialized []string, deserialized []TYPE, serialize func(serializer *Serializer, val TYPE), deserialize func(deserializer *Deserializer) TYPE) {
@@ -195,7 +231,7 @@ func helper[TYPE uint8 | uint16 | uint32 | uint64 | bool | []byte | string](t *t
 	// Deserializer
 	for i, input := range serialized {
 		bytes, _ := hex.DecodeString(input)
-		deserializer := &Deserializer{source: bytes}
+		deserializer := NewDeserializer(bytes)
 		assert.Equal(t, deserialized[i], deserialize(deserializer))
 		assert.NoError(t, deserializer.Error())
 	}
@@ -216,7 +252,7 @@ func helperBigInt(t *testing.T, serialized []string, deserialized []*big.Int, se
 	// Deserializer
 	for i, input := range serialized {
 		bytes, _ := hex.DecodeString(input)
-		deserializer := &Deserializer{source: bytes}
+		deserializer := NewDeserializer(bytes)
 		actual := deserialize(deserializer)
 		assert.NoError(t, deserializer.Error())
 		assert.Equal(t, 0, deserialized[i].Cmp(&actual))

--- a/bcs/deserializer.go
+++ b/bcs/deserializer.go
@@ -2,6 +2,7 @@ package bcs
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/big"
 )
@@ -52,6 +53,10 @@ func (des *Deserializer) Remaining() int {
 // Bool deserializes a single byte as a bool
 func (des *Deserializer) Bool() bool {
 	out := false
+	if des.pos >= len(des.source) {
+		des.SetError(errors.New("not enough bytes remaining to deserialize u8"))
+		return out
+	}
 	switch des.source[des.pos] {
 	case 0:
 		out = false
@@ -65,6 +70,10 @@ func (des *Deserializer) Bool() bool {
 
 // U8 deserializes a single unsigned 8-bit integer
 func (des *Deserializer) U8() uint8 {
+	if des.pos >= len(des.source) {
+		des.SetError(errors.New("not enough bytes remaining to deserialize u8"))
+		return 0
+	}
 	out := des.source[des.pos]
 	des.pos++
 	return out
@@ -72,6 +81,10 @@ func (des *Deserializer) U8() uint8 {
 
 // U16 deserializes a single unsigned 16-bit integer
 func (des *Deserializer) U16() uint16 {
+	if des.pos+1 >= len(des.source) {
+		des.SetError(errors.New("not enough bytes remaining to deserialize u16"))
+		return 0
+	}
 	out := binary.LittleEndian.Uint16(des.source[des.pos : des.pos+2])
 	des.pos += 2
 	return out
@@ -79,6 +92,10 @@ func (des *Deserializer) U16() uint16 {
 
 // U32 deserializes a single unsigned 32-bit integer
 func (des *Deserializer) U32() uint32 {
+	if des.pos+3 >= len(des.source) {
+		des.SetError(errors.New("not enough bytes remaining to deserialize u32"))
+		return 0
+	}
 	out := binary.LittleEndian.Uint32(des.source[des.pos : des.pos+4])
 	des.pos += 4
 	return out
@@ -86,6 +103,10 @@ func (des *Deserializer) U32() uint32 {
 
 // U64 deserializes a single unsigned 64-bit integer
 func (des *Deserializer) U64() uint64 {
+	if des.pos+7 >= len(des.source) {
+		des.SetError(errors.New("not enough bytes remaining to deserialize u64"))
+		return 0
+	}
 	out := binary.LittleEndian.Uint64(des.source[des.pos : des.pos+8])
 	des.pos += 8
 	return out
@@ -93,6 +114,10 @@ func (des *Deserializer) U64() uint64 {
 
 // U128 deserializes a single unsigned 128-bit integer
 func (des *Deserializer) U128() big.Int {
+	if des.pos+15 >= len(des.source) {
+		des.SetError(errors.New("not enough bytes remaining to deserialize u128"))
+		return *big.NewInt(-1)
+	}
 	var bytesBigEndian [16]byte
 	copy(bytesBigEndian[:], des.source[des.pos:des.pos+16])
 	des.pos += 16
@@ -104,6 +129,10 @@ func (des *Deserializer) U128() big.Int {
 
 // U256 deserializes a single unsigned 256-bit integer
 func (des *Deserializer) U256() big.Int {
+	if des.pos+31 >= len(des.source) {
+		des.SetError(errors.New("not enough bytes remaining to deserialize u256"))
+		return *big.NewInt(-1)
+	}
 	var bytesBigEndian [32]byte
 	copy(bytesBigEndian[:], des.source[des.pos:des.pos+32])
 	des.pos += 32
@@ -119,6 +148,11 @@ func (des *Deserializer) Uleb128() uint32 {
 	shift := 0
 
 	for {
+		if des.pos >= len(des.source) {
+			des.SetError(errors.New("not enough bytes remaining to deserialize uleb128"))
+			return 0
+		}
+
 		val := des.source[des.pos]
 		out = out | (uint32(val&0x7f) << shift)
 		des.pos++
@@ -138,6 +172,10 @@ func (des *Deserializer) ReadBytes() []byte {
 	if des.err != nil {
 		return nil
 	}
+	if des.pos+int(length)-1 >= len(des.source) {
+		des.SetError(errors.New("not enough bytes remaining to deserialize bytes"))
+		return nil
+	}
 	out := make([]byte, length)
 	copy(out, des.source[des.pos:des.pos+int(length)])
 	des.pos += int(length)
@@ -151,15 +189,22 @@ func (des *Deserializer) ReadString() string {
 
 // ReadFixedBytes reads bytes not-prefixed with a length
 func (des *Deserializer) ReadFixedBytes(length int) []byte {
+	if des.pos+length-1 >= len(des.source) {
+		des.SetError(errors.New("not enough bytes remaining to deserialize fixedBytes"))
+		return nil
+	}
 	out := make([]byte, length)
-	copy(out, des.source[des.pos:des.pos+length])
-	des.pos += length
+	des.ReadFixedBytesInto(out)
 	return out
 }
 
 // ReadFixedBytesInto reads bytes not-prefixed with a length into a byte array
 func (des *Deserializer) ReadFixedBytesInto(dest []byte) {
 	length := len(dest)
+	if des.pos+length-1 >= len(des.source) {
+		des.SetError(errors.New("not enough bytes remaining to deserialize fixedBytes"))
+		return
+	}
 	copy(dest, des.source[des.pos:des.pos+length])
 	des.pos += length
 }

--- a/bcs/serializer.go
+++ b/bcs/serializer.go
@@ -38,9 +38,9 @@ func (ser *Serializer) SetError(err error) {
 // Bool serialize a bool into a single byte
 func (ser *Serializer) Bool(v bool) {
 	if v {
-		ser.out.WriteByte(1)
+		ser.U8(1)
 	} else {
-		ser.out.WriteByte(0)
+		ser.U8(0)
 	}
 }
 

--- a/cmd/goclient/goclient.go
+++ b/cmd/goclient/goclient.go
@@ -285,7 +285,7 @@ func main() {
 					},
 					Function: "transfer",
 					// ArgTypes: []aptos.TypeTag{
-					// 	aptos.TypeTag{Value: &aptos.AccountAddressTag{Value: dest}},
+					// 	aptos.TypeTag{Value: &aptos.AddressTag{Value: dest}},
 					// 	aptos.TypeTag{Value: &aptos.U64Tag{Value: amount}},
 					// },
 					ArgTypes: []aptos.TypeTag{},

--- a/nodeClient_test.go
+++ b/nodeClient_test.go
@@ -18,6 +18,6 @@ func TestPollForTransaction(t *testing.T) {
 	dt := time.Now().Sub(start)
 
 	assert.GreaterOrEqual(t, dt, 9*time.Millisecond)
-	assert.Less(t, dt, 15*time.Millisecond)
+	assert.Less(t, dt, 20*time.Millisecond)
 	assert.Error(t, err)
 }

--- a/typetag_test.go
+++ b/typetag_test.go
@@ -1,10 +1,61 @@
 package aptos
 
 import (
+	"github.com/aptos-labs/aptos-go-sdk/bcs"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestTypeTag(t *testing.T) {
+	// This is unfortunate with references
+	nested := NewTypeTag(NewOptionTag(NewVectorTag(NewObjectTag(NewStringTag()))))
+
+	assert.Equal(t, "0x1::option::Option<vector<0x1::object::Object<0x1::string::String>>>", nested.String())
+
+	ser := &bcs.Serializer{}
+	ser.Struct(&nested)
+	assert.NoError(t, ser.Error())
+
+	bytes := ser.ToBytes()
+
+	des := bcs.NewDeserializer(bytes)
+	tag := &TypeTag{}
+	des.Struct(tag)
+	assert.NoError(t, des.Error())
+
+	// Check the deserialized is correct
+	assert.Equal(t, &nested, tag)
+}
+
+func TestTypeTagIdentities(t *testing.T) {
+	checkVariant(t, &AddressTag{}, TypeTagAddress, "address")
+	checkVariant(t, &SignerTag{}, TypeTagSigner, "signer")
+	checkVariant(t, &BoolTag{}, TypeTagBool, "bool")
+	checkVariant(t, &U8Tag{}, TypeTagU8, "u8")
+	checkVariant(t, &U16Tag{}, TypeTagU16, "u16")
+	checkVariant(t, &U32Tag{}, TypeTagU32, "u32")
+	checkVariant(t, &U64Tag{}, TypeTagU64, "u64")
+	checkVariant(t, &U128Tag{}, TypeTagU128, "u128")
+	checkVariant(t, &U256Tag{}, TypeTagU256, "u256")
+
+	checkVariant(t, NewVectorTag(&U8Tag{}), TypeTagVector, "vector<u8>")
+	checkVariant(t, NewStringTag(), TypeTagStruct, "0x1::string::String")
+}
+
+func checkVariant[T TypeTagImpl](t *testing.T, tag T, expectedType TypeTagType, expectedString string) {
+	assert.Equal(t, expectedType, tag.GetType())
+	assert.Equal(t, expectedString, tag.String())
+
+	// Serialize and deserialize test
+	tt := NewTypeTag(tag)
+	bytes, err := bcs.Serialize(&tt)
+	assert.NoError(t, err)
+	var newTag TypeTag
+	err = bcs.Deserialize(&newTag, bytes)
+	assert.NoError(t, err)
+	assert.Equal(t, tt, newTag)
+}
 
 func TestStructTag(t *testing.T) {
 	st := StructTag{


### PR DESCRIPTION
High coverage now on BCS and TypeTag core parts of the code.  This includes:
1. Fixing a bug with bool in deserialization
2. Adding errors for when deserialization but you run off the end of the buffer
3. Adding TypeTag support for signer, U128, U256, Vector, and removed extra data
4. Lots more testing!

![Screenshot 2024-05-15 at 5 56 43 PM](https://github.com/aptos-labs/aptos-go-sdk/assets/1335270/565e0769-3f9e-4a51-b3d5-dc15a1ee10d6)
