### PR TITLE
[transactionPayload] Support scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 - Refactored all pieces into new packages, this may break previous users
 - [`Fix`] Misspelling of expiration time
 - Added documentation for many functions and structs
+- Added all remaining Type tags
+- [`Fix`] Improved type tag parsing and printing for all types, including vector
+- [`Fix`] Fixed bug in deserializing bools
+- Added significantly more test coverage, including for scripts
 
 # v0.1.0 (5/7/2024)
 

--- a/client_util.go
+++ b/client_util.go
@@ -1,8 +1,8 @@
 package aptos
 
 import (
-	"encoding/binary"
 	"fmt"
+	"github.com/aptos-labs/aptos-go-sdk/bcs"
 	"net/url"
 	"runtime/debug"
 )
@@ -51,8 +51,10 @@ func init() {
 //
 // options may be: MaxGasAmount, GasUnitPrice, ExpirationSeconds, ValidUntil, SequenceNumber, ChainIdOption
 func APTTransferTransaction(client *Client, sender *Account, dest AccountAddress, amount uint64, options ...any) (signedTxn *SignedTransaction, err error) {
-	var amountBytes [8]byte
-	binary.LittleEndian.PutUint64(amountBytes[:], amount)
+	// TODO: Make this easier
+	ser := &bcs.Serializer{}
+	ser.U64(amount)
+	amountBytes := ser.ToBytes()
 
 	rawTxn, err := client.BuildTransaction(sender.Address,
 		TransactionPayload{Payload: &EntryFunction{
@@ -64,7 +66,7 @@ func APTTransferTransaction(client *Client, sender *Account, dest AccountAddress
 			ArgTypes: []TypeTag{},
 			Args: [][]byte{
 				dest[:],
-				amountBytes[:],
+				amountBytes,
 			},
 		}}, options...)
 	if err != nil {

--- a/script.go
+++ b/script.go
@@ -25,6 +25,7 @@ func (sc *Script) UnmarshalBCS(deserializer *bcs.Deserializer) {
 }
 
 // ScriptArgument a Move script argument, which encodes its type with it
+// TODO: improve typing
 type ScriptArgument struct {
 	Variant ScriptArgumentVariant
 	Value   any

--- a/transactionPayload.go
+++ b/transactionPayload.go
@@ -60,10 +60,10 @@ type ModuleBundle struct {
 }
 
 func (txn *ModuleBundle) MarshalBCS(bcs *bcs.Serializer) {
-	bcs.SetError(errors.New("ModuleBunidle unimplemented"))
+	bcs.SetError(errors.New("ModuleBundle unimplemented"))
 }
 func (txn *ModuleBundle) UnmarshalBCS(bcs *bcs.Deserializer) {
-	bcs.SetError(errors.New("ModuleBunidle unimplemented"))
+	bcs.SetError(errors.New("ModuleBundle unimplemented"))
 }
 
 // EntryFunction call a single published entry function

--- a/util.go
+++ b/util.go
@@ -4,8 +4,15 @@ import (
 	"github.com/aptos-labs/aptos-go-sdk/internal/util"
 )
 
+// -- Note these are copied from internal/util/util.go to prevent package loops, but still allow devs to use it
+
 // ParseHex Convenience function to deal with 0x at the beginning of hex strings
 func ParseHex(hexStr string) ([]byte, error) {
 	// This had to be redefined separately to get around a package loop
 	return util.ParseHex(hexStr)
+}
+
+// SHA3_256Hash takes a hash of the given sets of bytes
+func SHA3_256Hash(bytes [][]byte) (output []byte) {
+	return util.SHA3_256Hash(bytes)
 }

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,25 @@
+package aptos
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSHA3_256Hash(t *testing.T) {
+	input := [][]byte{{0x1}, {0x2}, {0x3}}
+	expected, err := ParseHex("fd1780a6fc9ee0dab26ceb4b3941ab03e66ccd970d1db91612c66df4515b0a0a")
+	assert.NoError(t, err)
+	assert.Equal(t, expected, SHA3_256Hash(input))
+}
+
+func TestParseHex(t *testing.T) {
+	// TODO: Last case is very weird, unsure if we want to allow that
+	inputs := []string{"0x012345", "012345", "0x"}
+	expected := [][]byte{{0x01, 0x23, 0x45}, {0x01, 0x23, 0x45}, {}}
+
+	for i, input := range inputs {
+		val, err := ParseHex(input)
+		assert.NoError(t, err)
+		assert.Equal(t, expected[i], val)
+	}
+}


### PR DESCRIPTION
Added testing for Scripts, and some util functions.  Built on top of https://github.com/aptos-labs/aptos-go-sdk/pull/28