### PR TITLE
nodeClient.go: assign body at NewRequest

### DIFF
--- a/nodeClient.go
+++ b/nodeClient.go
@@ -186,36 +186,16 @@ func (rc *NodeClient) GetBCS(getUrl string) (*http.Response, error) {
 }
 
 func (rc *NodeClient) Post(postUrl string, contentType string, body io.Reader) (resp *http.Response, err error) {
-	req, err := http.NewRequest("POST", postUrl, nil)
+	if body == nil {
+		body = http.NoBody
+	}
+	req, err := http.NewRequest("POST", postUrl, body)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set(ClientHeader, ClientHeaderValue)
-	if body == nil {
-		req.Body = &nilBodySingleton
-	} else {
-		readCloser, ok := body.(io.ReadCloser)
-		if ok {
-			req.Body = readCloser
-		} else {
-			req.Body = io.NopCloser(body)
-		}
-	}
 	return rc.client.Do(req)
-}
-
-// NilBody empty io.ReadCloser
-type NilBody struct {
-}
-
-var nilBodySingleton NilBody
-
-func (nb *NilBody) Read(_ []byte) (n int, err error) {
-	return 0, io.EOF
-}
-func (nb *NilBody) Close() error {
-	return nil
 }
 
 // AccountResourcesBCS fetches account resources as raw Move struct BCS blobs in AccountResourceRecord.Data []byte


### PR DESCRIPTION
`SubmitTransaction` fails on some of our tests with:

```{"error": "HttpError POST \"http://172.254.0.101:8080/v1/transactions\" -> \"411 Length Required\" \"{\\\"message\\\":\\\"missing `Content-Length` header\\\",\\\"error_code\\\":\\\"web_framework_error\\\",\\\"vm_error_code\\\":null}\""}```

from [NewRequest](https://pkg.go.dev/net/http#NewRequestWithContext) docs:

> If body is of type [*bytes.Buffer](https://pkg.go.dev/bytes#Buffer), [*bytes.Reader](https://pkg.go.dev/bytes#Reader), or [*strings.Reader](https://pkg.go.dev/strings#Reader), the returned request's ContentLength is set to its exact value (instead of -1), GetBody is populated (so 307 and 308 redirects can replay the body), and Body is set to [NoBody](https://pkg.go.dev/net/http#NoBody) if the ContentLength is 0.

from the source, it seems the custom `NopCloser` logic is also already handled at construction:
https://cs.opensource.google/go/go/+/refs/tags/go1.22.3:src/net/http/request.go;l=916

so assign the body at request constructor rather than with `req.Body` afterwards to include the `Content-Length` header automatically and to setup the `NopCloser`. also use `http.NoBody` instead of the custom `NilBody`.
