### PR TITLE
[ed25519] Fix number of bytes in ed25519 signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 - Add block APIs
 - Add private key imports, and authentication key
 - Add signed transaction hashes
+- [`Fix`] Private key imports without public key
 
 # v0.1.0 (5/7/2024)
 

--- a/account.go
+++ b/account.go
@@ -116,7 +116,7 @@ func NewEd25519Account() (*Account, error) {
 }
 
 // Sign signs a message, returning an appropriate authenticator for the signer
-func (account *Account) Sign(message []byte) (authenticator crypto.Authenticator, err error) {
+func (account *Account) Sign(message []byte) (authenticator *crypto.Authenticator, err error) {
 	return account.Signer.Sign(message)
 }
 

--- a/crypto/authenticator_test.go
+++ b/crypto/authenticator_test.go
@@ -57,15 +57,16 @@ func Test_AuthenticatorSerialization(t *testing.T) {
 	authenticator, err := privateKey.Sign(msg)
 	assert.NoError(t, err)
 
-	serialized, err := bcs.Serialize(&authenticator)
+	serialized, err := bcs.Serialize(authenticator)
 	assert.NoError(t, err)
 	assert.Equal(t, uint8(AuthenticatorEd25519), serialized[0])
 	assert.Len(t, serialized, 1+(1+ed25519.PublicKeySize)+(1+ed25519.SignatureSize))
 
-	newAuthenticator := Authenticator{}
-	err = bcs.Deserialize(&newAuthenticator, serialized)
+	newAuthenticator := &Authenticator{}
+	err = bcs.Deserialize(newAuthenticator, serialized)
 	assert.NoError(t, err)
-	assert.Equal(t, authenticator, newAuthenticator)
+	assert.Equal(t, authenticator.Kind, newAuthenticator.Kind)
+	assert.Equal(t, authenticator.Auth, newAuthenticator.Auth)
 }
 
 func Test_AuthenticatorVerification(t *testing.T) {

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -1,5 +1,7 @@
 package crypto
 
+import "github.com/aptos-labs/aptos-go-sdk/bcs"
+
 // Signer a generic interface for any kind of signing
 type Signer interface {
 	// ToHex if a private key, it's bytes, if it's not a private key
@@ -7,19 +9,17 @@ type Signer interface {
 	ToHex
 
 	// Sign signs a transaction and returns an associated authenticator
-	Sign(msg []byte) (authenticator Authenticator, err error)
+	Sign(msg []byte) (authenticator *Authenticator, err error)
 
 	// AuthKey gives the AuthenticationKey associated with the signer
 	AuthKey() *AuthenticationKey
 }
 
 // PrivateKey a generic interface for a signing private key
+// This is not serializable, because this doesn't go on-chain
 type PrivateKey interface {
 	Signer
-	ToHex
-	FromHex
-	ToBytes
-	FromBytes
+	CryptoMaterial
 
 	// PubKey Retrieve the public key for signature verification
 	PubKey() PublicKey
@@ -27,6 +27,8 @@ type PrivateKey interface {
 
 // PublicKey a generic interface for a public key associated with the private key
 type PublicKey interface {
+	bcs.Struct
+	CryptoMaterial
 	ToHex
 	FromHex
 	ToBytes
@@ -37,6 +39,13 @@ type PublicKey interface {
 
 	// Verify verifies a message with the public key
 	Verify(msg []byte, sig []byte) bool
+}
+
+type CryptoMaterial interface {
+	ToHex
+	FromHex
+	ToBytes
+	FromBytes
 }
 
 type FromHex interface {
@@ -54,6 +63,6 @@ type FromBytes interface {
 }
 
 type ToBytes interface {
-	// Bytes loads the key from bytes
+	// CryptoMaterial loads the key from bytes
 	Bytes() []byte
 }

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -53,10 +53,10 @@ func (key *Ed25519PrivateKey) FromHex(hexStr string) (err error) {
 }
 
 func (key *Ed25519PrivateKey) FromBytes(bytes []byte) (err error) {
-	if len(bytes) != ed25519.PrivateKeySize {
-		return errors.New("invalid ed25519 private key size")
+	if len(bytes) != ed25519.SeedSize {
+		return fmt.Errorf("invalid ed25519 private key size %d", len(bytes))
 	}
-	key.inner = bytes
+	key.inner = ed25519.NewKeyFromSeed(bytes)
 	return nil
 }
 

--- a/crypto/ed25519_test.go
+++ b/crypto/ed25519_test.go
@@ -1,0 +1,94 @@
+package crypto
+
+import (
+	"crypto/ed25519"
+	"github.com/aptos-labs/aptos-go-sdk/bcs"
+	"github.com/aptos-labs/aptos-go-sdk/internal/util"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const testEd25519PrivateKey = "0xc5338cd251c22daa8c9c9cc94f498cc8a5c7e1d2e75287a5dda91096fe64efa5"
+const testEd25519PublicKey = "0xde19e5d1880cac87d57484ce9ed2e84cf0f9599f12e7cc3a52e4e7657a763f2c"
+const testEd25519Address = "0x978c213990c4833df71548df7ce49d54c759d6b6d932de22b24d56060b7af2aa"
+const testEd25519Message = "0x68656c6c6f20776f726c64"
+const testEd25519Signature = "0x9e653d56a09247570bb174a389e85b9226abd5c403ea6c504b386626a145158cd4efd66fc5e071c0e19538a96a05ddbda24d3c51e1e6a9dacc6bb1ce775cce07"
+
+func TestEd25519Keys(t *testing.T) {
+	testEd25519PrivateKeyBytes := []byte{0xc5, 0x33, 0x8c, 0xd2, 0x51, 0xc2, 0x2d, 0xaa, 0x8c, 0x9c, 0x9c, 0xc9, 0x4f, 0x49, 0x8c, 0xc8, 0xa5, 0xc7, 0xe1, 0xd2, 0xe7, 0x52, 0x87, 0xa5, 0xdd, 0xa9, 0x10, 0x96, 0xfe, 0x64, 0xef, 0xa5}
+
+	// First ensure bytes and hex are the same
+	readBytes, err := util.ParseHex(testEd25519PrivateKey)
+	assert.NoError(t, err)
+	assert.Equal(t, testEd25519PrivateKeyBytes, readBytes)
+
+	// Either bytes or hex should work
+	privateKey := &Ed25519PrivateKey{}
+	err = privateKey.FromHex(testEd25519PrivateKey)
+	assert.NoError(t, err)
+	privateKey2 := &Ed25519PrivateKey{}
+	err = privateKey2.FromBytes(testEd25519PrivateKeyBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, privateKey, privateKey2)
+
+	// The outputs should match as well
+	assert.Equal(t, privateKey.Bytes(), testEd25519PrivateKeyBytes)
+	assert.Equal(t, privateKey.ToHex(), testEd25519PrivateKey)
+
+	// Auth key should match
+	assert.Equal(t, testEd25519Address, privateKey.AuthKey().ToHex())
+
+	// Test signature
+	message, err := util.ParseHex(testEd25519Message)
+	assert.NoError(t, err)
+	authenticator, err := privateKey.Sign(message)
+	assert.NoError(t, err)
+
+	// Check public keys
+	publicKey := authenticator.PublicKey()
+	assert.Equal(t, testEd25519PublicKey, privateKey.PubKey().ToHex())
+	assert.Equal(t, testEd25519PublicKey, publicKey.ToHex())
+
+	// Check signature
+	expectedSignature, err := util.ParseHex(testEd25519Signature)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedSignature, authenticator.Signature())
+
+	// Verify signature with the key and the authenticator directly
+	assert.True(t, authenticator.Verify(message))
+	assert.True(t, publicKey.Verify(message, authenticator.Signature()))
+
+	// Verify serialization of public key
+	publicKeyBytes, err := bcs.Serialize(publicKey)
+	assert.NoError(t, err)
+	expectedPublicKeyBytes, err := util.ParseHex(testEd25519PublicKey)
+	assert.NoError(t, err)
+	// Need to prepend the length
+	expectedBcsPublicKeyBytes := []byte{ed25519.PublicKeySize}
+	expectedBcsPublicKeyBytes = append(expectedBcsPublicKeyBytes, expectedPublicKeyBytes[:]...)
+	assert.Equal(t, expectedBcsPublicKeyBytes, publicKeyBytes)
+
+	publicKey2 := &Ed25519PublicKey{}
+	err = bcs.Deserialize(publicKey2, publicKeyBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, publicKey, publicKey2)
+
+	// Check from bytes and from hex
+	publicKey3 := &Ed25519PublicKey{}
+	err = publicKey3.FromHex(testEd25519PublicKey)
+	assert.NoError(t, err)
+	publicKey4 := &Ed25519PublicKey{}
+	err = publicKey4.FromBytes(expectedPublicKeyBytes)
+	assert.NoError(t, err)
+
+	assert.Equal(t, publicKey, publicKey3)
+	assert.Equal(t, publicKey, publicKey4)
+
+	// Test serialization and deserialization of authenticator
+	authenticatorBytes, err := bcs.Serialize(authenticator)
+	assert.NoError(t, err)
+	authenticator2 := &Authenticator{}
+	err = bcs.Deserialize(authenticator2, authenticatorBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, authenticator, authenticator2)
+}

--- a/signedTransaction.go
+++ b/signedTransaction.go
@@ -9,7 +9,7 @@ import (
 // SignedTransaction a raw transaction plus its authenticator for a fully verifiable message
 type SignedTransaction struct {
 	Transaction   RawTransaction
-	Authenticator crypto.Authenticator
+	Authenticator *crypto.Authenticator
 }
 
 func (txn *SignedTransaction) MarshalBCS(bcs *bcs.Serializer) {


### PR DESCRIPTION
The ed25519 library refers to the "private key" as the private and public key together.  The private key alone is referred to as the "seed".  So, this fixes it accordingly.

Additionally, fixes some consistency issues for authentication keys