### PR TITLE
Fix bytecode JSON unmarshalling

### DIFF
--- a/api/module.go
+++ b/api/module.go
@@ -6,7 +6,7 @@ import (
 
 // MoveBytecode describes a module, or script, and it's associated ABI
 type MoveBytecode struct {
-	Bytecode []byte      `json:"bytecode"`
+	Bytecode HexBytes    `json:"bytecode"`
 	Abi      *MoveModule `json:"abi,omitempty"` // Optional
 }
 
@@ -24,7 +24,7 @@ type MoveModule struct {
 
 // MoveScript is the representation of a compiled script.  The API may not fill in the ABI field
 type MoveScript struct {
-	Bytecode []byte        `json:"bytecode"`
+	Bytecode HexBytes      `json:"bytecode"`
 	Abi      *MoveFunction `json:"abi,omitempty"` // Optional
 }
 

--- a/api/module_test.go
+++ b/api/module_test.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aptos-labs/aptos-go-sdk/internal/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModule_MoveBytecode(t *testing.T) {
+	testJson := `{
+		"bytecode": "0xa11ceb0b060000000901000202020403060f0515"
+	}`
+	data := &MoveBytecode{}
+	err := json.Unmarshal([]byte(testJson), &data)
+	assert.NoError(t, err)
+	expectedRes, _ := util.ParseHex("0xa11ceb0b060000000901000202020403060f0515")
+	assert.Equal(t, HexBytes(expectedRes), data.Bytecode)
+}
+
+func TestModule_MoveScript(t *testing.T) {
+	testJson := `{
+		"bytecode": "0xa11ceb0b060000000901000202020403060f0515"
+	}`
+	data := &MoveScript{}
+	err := json.Unmarshal([]byte(testJson), &data)
+	assert.NoError(t, err)
+	expectedRes, _ := util.ParseHex("0xa11ceb0b060000000901000202020403060f0515")
+	assert.Equal(t, HexBytes(expectedRes), data.Bytecode)
+}

--- a/api/writeSet.go
+++ b/api/writeSet.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/aptos-labs/aptos-go-sdk/internal/types"
 )
 
@@ -117,7 +118,7 @@ type WriteSetChangeDeleteResource struct {
 type WriteSetChangeWriteModule struct {
 	Type         string                `json:"type"`
 	Address      *types.AccountAddress `json:"address"`
-	StateKeyHash string                `json:"state_key_hash"`
+	StateKeyHash Hash                  `json:"state_key_hash"`
 	Data         *MoveBytecode         `json:"data"`
 }
 


### PR DESCRIPTION
### Description
There was a bug in parsing the bytecode field from Aptos API responses (error: `illegal base64 data at input byte ...`. This was tracked down to the attempt to unmarshal `bytecode` which is a JSON hex string into a byte array. This should use the existing HexBytes type instead.

Also changed WriteSetChangeWriteModule.StateKeyHash to `Hash` type to be consistent with the other `WriteSet` types

### Test Plan
Added some basic tests to validate unmarshaling works as intended.

Running the `TestModule_MoveBytecode` test with the old implementation (`Bytecode []byte`) throws an error: `illegal base64 data at input byte 40`. 

