### PR TITLE
Incorrect Use of secp256k1 Methods

### DIFF
--- a/crypto/secp256k1.go
+++ b/crypto/secp256k1.go
@@ -3,10 +3,10 @@ package crypto
 import (
 	"crypto/ecdsa"
 	"fmt"
+
 	"github.com/aptos-labs/aptos-go-sdk/bcs"
 	"github.com/aptos-labs/aptos-go-sdk/internal/util"
 	ethCrypto "github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 )
 
 //region Secp256k1PrivateKey
@@ -45,7 +45,7 @@ func (key *Secp256k1PrivateKey) VerifyingKey() VerifyingKey {
 func (key *Secp256k1PrivateKey) SignMessage(msg []byte) (sig Signature, err error) {
 	hash := util.Sha3256Hash([][]byte{msg})
 	// TODO: The eth library doesn't protect against malleability issues, so we need to handle those
-	signature, err := secp256k1.Sign(hash, key.Bytes())
+	signature, err := ethCrypto.Sign(hash, key.Inner)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func (key *Secp256k1PublicKey) Verify(msg []byte, sig Signature) bool {
 	case *Secp256k1Signature:
 		typedSig := sig.(*Secp256k1Signature)
 
-		return secp256k1.VerifySignature(key.Bytes(), msg, typedSig.Bytes())
+		return ethCrypto.VerifySignature(key.Bytes(), msg, typedSig.Bytes())
 	default:
 		return false
 	}

--- a/crypto/secp256k1.go
+++ b/crypto/secp256k1.go
@@ -44,7 +44,7 @@ func (key *Secp256k1PrivateKey) VerifyingKey() VerifyingKey {
 
 func (key *Secp256k1PrivateKey) SignMessage(msg []byte) (sig Signature, err error) {
 	hash := util.Sha3256Hash([][]byte{msg})
-	// TODO: The eth library doesn't protect against malleability issues, so we need to handle those
+	// TODO: The eth library doesn't protect against malleability issues, so we need to handle those.
 	signature, err := ethCrypto.Sign(hash, key.Inner)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
There are incorrect usage of `secp256k1` methods instead of the go-ethereum crypto package (`ethCrypto`) methods in the implementation of `Secp256k1PrivateKey` and `Secp256k1PublicKey` within the Aptos Go SDK here: 
https://github.com/aptos-labs/aptos-go-sdk/blob/main/crypto/secp256k1.go


## Problem
File: https://github.com/aptos-labs/aptos-go-sdk/blob/main/crypto/secp256k1.go
#### Function: `SignMessage`
**Current code**: 
```go
func (key *Secp256k1PrivateKey) SignMessage(msg []byte) (sig Signature, err error) {
	hash := util.Sha3256Hash([][]byte{msg})
	// TODO: The eth library doesn't protect against malleability issues, so we need to handle those
	signature, err := secp256k1.Sign(hash, key.Bytes())
	if err != nil {
		return nil, err
	}

	// Strip the recovery bit
	return &Secp256k1Signature{
		signature[0:64],
	}, nil
}
```
- **Issue**: The` Sign` method from `secp256k1` is used instead of `ethCrypto`

#### Function: `Verify`
**Current Code**: 
```go 
func (key *Secp256k1PublicKey) Verify(msg []byte, sig Signature) bool {
	switch sig.(type) {
	case *Secp256k1Signature:
		typedSig := sig.(*Secp256k1Signature)

		return secp256k1.VerifySignature(key.Bytes(), msg, typedSig.Bytes())
	default:
		return false
	}
}
```
- **Issue**: The `VerifySignature` method from `secp256k1` is used instead of `ethCrypto`.
## Proposed solution
`SignMessage` function 
```go
func (key *Secp256k1PrivateKey) SignMessage(msg []byte) (sig Signature, err error) {
	hash := util.Sha3256Hash([][]byte{msg})
	// TODO: The eth library doesn't protect against malleability issues, so we need to handle those
	signature, err := ethCrypto.Sign(hash, key.Inner)
	if err != nil {
		return nil, err
	}

	// Strip the recovery bit
	return &Secp256k1Signature{
		signature[0:64],
	}, nil
}
```

 `VerifySignature`  function
```go
func (key *Secp256k1PublicKey) Verify(msg []byte, sig Signature) bool {
	switch sig.(type) {
	case *Secp256k1Signature:
		typedSig := sig.(*Secp256k1Signature)

		return ethCrypto.VerifySignature(key.Bytes(), msg, typedSig.Bytes())
	default:
		return false
	}
}
```

## Additional improvement
#### **Type assertion warning**:
- Current:
```go
switch sig.(type) {
```
- Improved:
```go
switch sig := sig.(type) {
```