### PR TITLE
[secp256k1] Fix verification

### DIFF
--- a/crypto/secp256k1.go
+++ b/crypto/secp256k1.go
@@ -3,7 +3,6 @@ package crypto
 import (
 	"crypto/ecdsa"
 	"fmt"
-
 	"github.com/aptos-labs/aptos-go-sdk/bcs"
 	"github.com/aptos-labs/aptos-go-sdk/internal/util"
 	ethCrypto "github.com/ethereum/go-ethereum/crypto"
@@ -104,6 +103,8 @@ func (key *Secp256k1PublicKey) Verify(msg []byte, sig Signature) bool {
 	case *Secp256k1Signature:
 		typedSig := sig.(*Secp256k1Signature)
 
+		// Verification requires to pass the SHA-256 hash of the message
+		msg = util.Sha3256Hash([][]byte{msg})
 		return ethCrypto.VerifySignature(key.Bytes(), msg, typedSig.Bytes())
 	default:
 		return false

--- a/crypto/secp256k1_test.go
+++ b/crypto/secp256k1_test.go
@@ -61,9 +61,8 @@ func TestSecp256k1Keys(t *testing.T) {
 	assert.Equal(t, testSecp256k1Signature, actualSignature.Signature.(*Secp256k1Signature).ToHex())
 
 	// Verify signature with the key and the authenticator directly
-	// FIXME verification not working, but transaction submission is
-	//assert.True(t, authenticator.Verify(message))
-	//assert.True(t, publicKey.Verify(message, actualSignature))
+	assert.True(t, authenticator.Verify(message))
+	assert.True(t, publicKey.Verify(message, actualSignature))
 
 	// Verify serialization of public key
 	publicKeyBytes, err := bcs.Serialize(publicKey)


### PR DESCRIPTION
### Description
Finally sat down and realized the Go SDK wasn't hashing the payloads, which is why verification wasn't working before.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->