### PR TITLE
rearrange concurrency in Test_Concurrent_Submission

### DIFF
--- a/client.go
+++ b/client.go
@@ -277,8 +277,8 @@ func (client *Client) PollForTransactions(txnHashes []string, options ...any) er
 }
 
 // WaitForTransaction Do a long-GET for one transaction and wait for it to complete
-func (client *Client) WaitForTransaction(txnHash string) (data *api.UserTransaction, err error) {
-	return client.nodeClient.WaitForTransaction(txnHash)
+func (client *Client) WaitForTransaction(txnHash string, options ...any) (data *api.UserTransaction, err error) {
+	return client.nodeClient.WaitForTransaction(txnHash, options...)
 }
 
 // Transactions Get recent transactions.

--- a/client_test.go
+++ b/client_test.go
@@ -477,11 +477,8 @@ func Test_Concurrent_Submission(t *testing.T) {
 		assert.NoError(t, response.Err)
 		assert.True(t, (response.Result != nil) && response.Result.Success)
 		if response.Result != nil {
-			t.Logf("[%d] %d ok", i, response.Result.SequenceNumber)
 			txnMap[response.Result.SequenceNumber] = true
 			txnGoodEvents++
-		} else {
-			t.Logf("[%d] err %d resu %#v", i, response.Err, response.Result)
 		}
 		i++
 		if i >= numTxns {
@@ -494,10 +491,16 @@ func Test_Concurrent_Submission(t *testing.T) {
 	wg.Wait()
 
 	// Check all transactions were successful from [0-numTxns)
-	t.Logf("got %d(%d) successful txns of %d attempted", len(txnMap), txnGoodEvents, numTxns)
+	t.Logf("got %d(%d) successful txns of %d attempted, error submission indexes:", len(txnMap), txnGoodEvents, numTxns)
+	allTrue := true
 	for i := uint64(0); i < numTxns; i++ {
-		assert.True(t, txnMap[i])
+		allTrue = allTrue && txnMap[i]
+		if !txnMap[i] {
+			t.Logf("%d", i)
+		}
 	}
+	assert.True(t, allTrue, "all txns successful")
+	assert.Equal(t, len(txnMap), numTxns, "num txns successful == num txns sent")
 }
 
 func TestClient_BlockByHeight(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -394,7 +394,7 @@ func concurrentTxnWaiter(
 		responseCount++
 		assert.NoError(t, response.Err)
 
-		waitResponse, err := client.WaitForTransaction(response.Response.Hash, PollTimeout(20*time.Second))
+		waitResponse, err := client.WaitForTransaction(response.Response.Hash, PollTimeout(21*time.Second))
 		if err != nil {
 			t.Logf("%s err %s", response.Response.Hash, err)
 		} else if waitResponse == nil {
@@ -431,7 +431,7 @@ func Test_Concurrent_Submission(t *testing.T) {
 	// start submission goroutine
 	payloads := make(chan TransactionSubmissionPayload, 50)
 	results := make(chan TransactionSubmissionResponse, 50)
-	go client.nodeClient.BuildSignAndSubmitTransactions(account1, payloads, results)
+	go client.nodeClient.BuildSignAndSubmitTransactions(account1, payloads, results, ExpirationSeconds(20))
 
 	transferAmount, err := bcs.SerializeU64(100)
 	assert.NoError(t, err)
@@ -507,7 +507,7 @@ func Test_Concurrent_Submission(t *testing.T) {
 		}
 	}
 	assert.True(t, allTrue, "all txns successful")
-	assert.Equal(t, len(txnMap), numTxns, "num txns successful == num txns sent")
+	assert.Equal(t, len(txnMap), int(numTxns), "num txns successful == num txns sent")
 }
 
 func TestClient_BlockByHeight(t *testing.T) {

--- a/nodeClient.go
+++ b/nodeClient.go
@@ -250,6 +250,9 @@ func getTransactionPollOptions(defaultPeriod, defaultTimeout time.Duration, opti
 	return
 }
 
+// PollForTransaction waits up to 10 seconds for a transaction to be done, polling at 10Hz
+// Accepts options PollPeriod and PollTimeout which should wrap time.Duration values.
+// Not just a degenerate case of PollForTransactions, it may return additional information for the single transaction polled.
 func (rc *NodeClient) PollForTransaction(hash string, options ...any) (*api.UserTransaction, error) {
 	period, timeout, err := getTransactionPollOptions(100*time.Millisecond, 10*time.Second, options...)
 	if err != nil {
@@ -259,7 +262,7 @@ func (rc *NodeClient) PollForTransaction(hash string, options ...any) (*api.User
 	deadline := start.Add(timeout)
 	for {
 		if time.Now().After(deadline) {
-			return nil, errors.New("timeout waiting for faucet transactions")
+			return nil, errors.New("PollForTransaction timeout")
 		}
 		time.Sleep(period)
 		txn, err := rc.TransactionByHash(hash)
@@ -290,7 +293,7 @@ func (rc *NodeClient) PollForTransactions(txnHashes []string, options ...any) er
 	deadline := start.Add(timeout)
 	for len(hashSet) > 0 {
 		if time.Now().After(deadline) {
-			return errors.New("timeout waiting for faucet transactions")
+			return errors.New("PollForTransactions timeout")
 		}
 		time.Sleep(period)
 		for _, hash := range txnHashes {


### PR DESCRIPTION
use different client for submission and N different clients for txn status waiting close channels when they're done
simplify channel consuming syntax
WaitGroup-s for intra-function goroutines

### Description
cleaner/stricter goroutine/chan usage

### Test Plan
This is a test

### Related Links
