### PR TITLE
[events] Fix event GUID parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 - [`Fix`] Parse GenesisTransaction properly
 - [`Fix`] Ensure if no block transactions are requested, it doesn't fail to fetch a block
 - [`Doc`] Fix comment from milliseconds to microseconds
+- [`Fix`] Fix GUID parsing for events
 
 # v0.6.0 (6/28/2024)
 - [`Breaking`] Change type from Transaction to CommittedTransaction for cases that it's known they're committed

--- a/api/events.go
+++ b/api/events.go
@@ -11,10 +11,8 @@ import "encoding/json"
 //	{
 //	  "type": "0x1::coin::WithdrawEvent",
 //	  "guid": {
-//	    "id": {
-//	      "addr": "0x810026ca8291dd88b5b30a1d3ca2edd683d33d06c4a7f7c451d96f6d47bc5e8b",
-//	      "creation_num": "3"
-//	    }
+//	    "addr": "0x810026ca8291dd88b5b30a1d3ca2edd683d33d06c4a7f7c451d96f6d47bc5e8b",
+//	    "creation_num": "3"
 //	  },
 //	  "sequence_number": "0",
 //	  "data": {
@@ -27,10 +25,8 @@ import "encoding/json"
 //	{
 //	  "type": "0x1::fungible_asset::Withdraw",
 //	  "guid": {
-//	    "id": {
-//	      "addr": "0x0",
-//	      "creation_num": "0"
-//	    }
+//	    "addr": "0x0",
+//	    "creation_num": "0"
 //	  },
 //	  "sequence_number": "0",
 //	  "data": {

--- a/api/events_test.go
+++ b/api/events_test.go
@@ -11,10 +11,8 @@ func TestEvent_V1(t *testing.T) {
 	testJson := `{
 		"type": "0x1::coin::WithdrawEvent",
 		"guid": {
-			"id": {
-				"account_address": "0x810026ca8291dd88b5b30a1d3ca2edd683d33d06c4a7f7c451d96f6d47bc5e8b",
-				"creation_number": "3"
-			}
+            "account_address": "0x810026ca8291dd88b5b30a1d3ca2edd683d33d06c4a7f7c451d96f6d47bc5e8b",
+		    "creation_number": "3"
 		},
 		"sequence_number": "0",
 		"data": {
@@ -27,22 +25,20 @@ func TestEvent_V1(t *testing.T) {
 	assert.Equal(t, "0x1::coin::WithdrawEvent", data.Type)
 	assert.Equal(t, uint64(0), data.SequenceNumber)
 	assert.Equal(t, "1000", data.Data["amount"].(string))
-	assert.Equal(t, uint64(3), data.Guid.Id.CreationNumber)
+	assert.Equal(t, uint64(3), data.Guid.CreationNumber)
 
 	addr := &types.AccountAddress{}
 	err = addr.ParseStringRelaxed("0x810026ca8291dd88b5b30a1d3ca2edd683d33d06c4a7f7c451d96f6d47bc5e8b")
 	assert.NoError(t, err)
-	assert.Equal(t, addr, data.Guid.Id.AccountAddress)
+	assert.Equal(t, addr, data.Guid.AccountAddress)
 }
 
 func TestEvent_V2(t *testing.T) {
 	testJson := `	{
 		"type": "0x1::fungible_asset::Withdraw",
 		"guid": {
-			"id": {
-				"account_address": "0x0",
-				"creation_number": "0"
-			}
+            "account_address": "0x0",
+			"creation_number": "0"
 		},
 		"sequence_number": "0",
 		"data": {
@@ -58,6 +54,6 @@ func TestEvent_V2(t *testing.T) {
 	assert.Equal(t, uint64(0), data.SequenceNumber)
 	assert.Equal(t, "1000", data.Data["amount"].(string))
 	assert.Equal(t, "0x1234123412341234123412341234123412341234123412341234123412341234", data.Data["store"].(string))
-	assert.Equal(t, uint64(0), data.Guid.Id.CreationNumber)
-	assert.Equal(t, &types.AccountZero, data.Guid.Id.AccountAddress)
+	assert.Equal(t, uint64(0), data.Guid.CreationNumber)
+	assert.Equal(t, &types.AccountZero, data.Guid.AccountAddress)
 }

--- a/api/util.go
+++ b/api/util.go
@@ -7,18 +7,15 @@ import (
 )
 
 // GUID describes a GUID associated with things like V1 events
+//
+// Note that this can only be used to deserialize events in the `events` field, and not the `GUID` resource in `changes`.
 type GUID struct {
-	Id GUIDId `json:"id"` // An internal type for the GUID as represented on-chain
-}
-
-// GUIDId is the internal representation of a [GUID] on-chain, which is listed as "id" in JSON
-type GUIDId struct {
 	CreationNumber uint64                // CreationNumber is the number of the GUID
 	AccountAddress *types.AccountAddress // AccountAddress is the account address of the creator of the GUID
 }
 
 // UnmarshalJSON deserializes a JSON data blob into a [GUIDId]
-func (o *GUIDId) UnmarshalJSON(b []byte) error {
+func (o *GUID) UnmarshalJSON(b []byte) error {
 	type inner struct {
 		CreationNumber U64                   `json:"creation_number"`
 		AccountAddress *types.AccountAddress `json:"account_address"`


### PR DESCRIPTION
### Description
There are two formats, one for resources, and one for events.  I wrongly formatted the resource format to parse the event format.  This fixes it.  Thanks @jmmcatee for pointing it out!

### Test Plan
Fixed the event tests accordingly to match the other copied test inputs.

### Related Links
Closes https://github.com/aptos-labs/aptos-go-sdk/issues/75
