### PR TITLE
[ed25519] Use ed25519 consensus for verification of signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 - [`Fix`] Parse GenesisTransaction properly
 - [`Fix`] Ensure if no block transactions are requested, it doesn't fail to fetch a block
 - [`Doc`] Fix comment from milliseconds to microseconds
+- Use ed25519-consensus to ensure signatures are verified in a ZIP215 compatible way
 
 # v0.6.0 (6/28/2024)
 - [`Breaking`] Change type from Transaction to CommittedTransaction for cases that it's known they're committed

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/aptos-labs/aptos-go-sdk/bcs"
 	"github.com/aptos-labs/aptos-go-sdk/internal/util"
+	"github.com/hdevalence/ed25519consensus"
 	"io"
 )
 
@@ -209,7 +210,7 @@ type Ed25519PublicKey struct {
 func (key *Ed25519PublicKey) Verify(msg []byte, sig Signature) bool {
 	switch sig := sig.(type) {
 	case *Ed25519Signature:
-		return ed25519.Verify(key.Inner, msg, sig.Bytes())
+		return ed25519consensus.Verify(key.Inner, msg, sig.Bytes())
 	default:
 		return false
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,13 @@ require (
 	github.com/cucumber/godog v0.14.1
 	github.com/ethereum/go-ethereum v1.14.5
 	github.com/hasura/go-graphql-client v0.12.1
+	github.com/hdevalence/ed25519consensus v0.2.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.24.0
 )
 
 require (
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.3 // indirect
 	github.com/cucumber/gherkin/go/v26 v26.2.0 // indirect
 	github.com/cucumber/messages/go/v21 v21.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/btcsuite/btcd/btcec/v2 v2.3.3 h1:6+iXlDKE8RMtKsvK0gshlXIuPbyWM/h84Ensb7o3sC0=
 github.com/btcsuite/btcd/btcec/v2 v2.3.3/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
@@ -38,6 +40,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hasura/go-graphql-client v0.12.1 h1:tL+BCoyubkYYyaQ+tJz+oPe/pSxYwOJHwe5SSqqi6WI=
 github.com/hasura/go-graphql-client v0.12.1/go.mod h1:F4N4kR6vY8amio3gEu3tjSZr8GPOXJr3zj72DKixfLE=
+github.com/hdevalence/ed25519consensus v0.2.0 h1:37ICyZqdyj0lAZ8P4D1d1id3HqbbG1N3iBb1Tb4rdcU=
+github.com/hdevalence/ed25519consensus v0.2.0/go.mod h1:w3BHWjwJbFU29IRHL1Iqkw3sus+7FctEyM4RqDxYNzo=
 github.com/holiman/uint256 v1.2.4 h1:jUc4Nk8fm9jZabQuqr2JzednajVmBpC+oiTiXZJEApU=
 github.com/holiman/uint256 v1.2.4/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=


### PR DESCRIPTION
Ed25519 consensus uses ZIP215 to ensure that the signatures are verified in the same way.

Closes: https://github.com/aptos-labs/aptos-go-sdk/issues/14