### PR TITLE
[multikey] Fix verification and building of multikey signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 - [`Doc`] Fix comment from milliseconds to microseconds
 - [`Fix`] Fix GUID parsing for events
 - Use ed25519-consensus to ensure signatures are verified in a ZIP215 compatible way
+- [`Fix`] Fix MultiKey signature verification and building to work with any keys
 
 # v0.6.0 (6/28/2024)
 - [`Breaking`] Change type from Transaction to CommittedTransaction for cases that it's known they're committed


### PR DESCRIPTION
### Description
Multikey signatures before didn't allow for gaps in the signatures, and required always to have the keys in order.  This fixes it accordingly.  It now matches the Rust implementation.

### Test Plan
See tests which now test gaps, mixed signatures, and different orders.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->