### PR TITLE
[bcs] Add optional bcs serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Aptos Go SDK will be captured in this file. This chan
 adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+- Add BCS support for optional values
 
 # v1.1.0 (11/07/2024)
 - Add icon uri and project uri to FA client, reduce duplicated code

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # aptos-go-sdk
 
-An SDK for the Aptos blockchain in Go. The SDK is currently in Beta.
+An SDK for the Aptos blockchain in Go.
 
 ## Getting started
 
@@ -69,3 +69,8 @@ You can read more about the Go SDK documentation on [aptos.dev](https://aptos.de
 - [ ] More testing around API parsing
 - [ ] TypeTag string parsing
 - [x] Add examples into the documentation
+
+
+# How to publish
+1. Update changelog with a pull request
+2. Create a new tag via e.g. v1.1.0 with the list of changes

--- a/bcs/bcs_test.go
+++ b/bcs/bcs_test.go
@@ -415,6 +415,32 @@ func Test_ConvenienceFunctions(t *testing.T) {
 	assert.Equal(t, []byte{0x01, 0x05}, serializedBytes)
 }
 
+func Test_SerializeOptional(t *testing.T) {
+	ser := Serializer{}
+	someValue := uint8(0xFF)
+	SerializeOption(&ser, &someValue, func(ser *Serializer, val uint8) {
+		ser.U8(val)
+	})
+	assert.Equal(t, []byte{0x01, 0xFF}, ser.ToBytes())
+	des := NewDeserializer(ser.ToBytes())
+	desValue := DeserializeOption(des, func(des *Deserializer, out *uint8) {
+		*out = des.U8()
+	})
+	assert.Equal(t, &someValue, desValue)
+
+	ser2 := Serializer{}
+	SerializeOption(&ser2, nil, func(ser *Serializer, val uint8) {
+		ser.U8(val)
+	})
+	assert.Equal(t, []byte{0x00}, ser2.ToBytes())
+
+	des2 := NewDeserializer(ser2.ToBytes())
+	desValue2 := DeserializeOption(des2, func(des *Deserializer, out *uint8) {
+		*out = des.U8()
+	})
+	assert.Nil(t, desValue2)
+}
+
 func Test_NilStructs(t *testing.T) {
 	ser := Serializer{}
 	ser.Struct(nil)

--- a/bcs/serializer.go
+++ b/bcs/serializer.go
@@ -324,3 +324,31 @@ func SerializeSingle(marshal func(ser *Serializer)) (bytes []byte, err error) {
 	bytes = ser.ToBytes()
 	return bytes, nil
 }
+
+// SerializeOption serializes an optional value
+//
+// # Under the hood, this is represented as a 0 or 1 length array
+//
+// Here's an example for handling an optional value:
+//
+//	// For a Some(10) value
+//	input := uint8(10)
+//	ser := &Serializer{}
+//	bytes, _ := SerializeOption(ser, &input, func(ser *Serializer, item uint8) {
+//		ser.U8(item)
+//	})
+//	// bytes == []byte{0x01,0x0A}
+//
+//	// For a None value
+//	ser2 := &Serializer{}
+//	bytes2, _ := SerializeOption(ser2, nil, func(ser *Serializer, item uint8) {
+//		ser.U8(item)
+//	})
+//	// bytes2 == []byte{0x00}
+func SerializeOption[T any](ser *Serializer, input *T, serialize func(ser *Serializer, item T)) {
+	if input == nil {
+		SerializeSequenceWithFunction([]T{}, ser, serialize)
+	} else {
+		SerializeSequenceWithFunction([]T{*input}, ser, serialize)
+	}
+}


### PR DESCRIPTION
### Description
Adds optional helper function for serializing values e.g. Option<String>

### Test Plan
Added unit test for uint8, the rest are comparable since it does not add pre-created functions.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->