### PR TITLE
[multikey] Fix multikey serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,23 @@ All notable changes to the Aptos Go SDK will be captured in this file. This chan
 adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+
+- [`Fix`][`Breaking`] Fix MultiKey implementation to be more consistent with the rest of the SDKs
 - Add BCS support for optional values
 
 # v1.1.0 (11/07/2024)
+
 - Add icon uri and project uri to FA client, reduce duplicated code
 - Add better error messages around script argument parsing
 - Add example for scripts with FA
 
 # v1.0.0 (10/28/2024)
+
 - [`Fix`] Paginate transactions properly if no given start version
 - Add account transactions API
 
 # v0.7.0 (8/19/2024)
+
 - [`Fix`] Parse GenesisTransaction properly
 - [`Fix`] Ensure if no block transactions are requested, it doesn't fail to fetch a block
 - [`Doc`] Fix comment from milliseconds to microseconds
@@ -24,6 +29,7 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 - [`Fix`] Fix MultiKey signature verification and building to work with any keys
 
 # v0.6.0 (6/28/2024)
+
 - [`Breaking`] Change type from Transaction to CommittedTransaction for cases that it's known they're committed
 - [`Fix`] Fix secp256k1 signing and verification to be correctly used
 - [`Fix`] Fix supply view function for FungibleAssetClient
@@ -42,11 +48,13 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 - Change signers to have simulation authenticators by default
 
 # v0.5.0 (6/21/2024)
+
 - [`Fix`] Fix sponsored transactions, and add example for sponsored transactions
 - Add examples to CI
 - Add node health check API to client
 
 # v0.4.1 (6/18/2024)
+
 - [`Fix`] Make examples more portable / not rely on internal packages
 
 # v0.4.0 (6/17/2024)

--- a/client_test.go
+++ b/client_test.go
@@ -47,6 +47,10 @@ func initSigners() {
 		signer, err := NewMultiKeyTestSigner(3, 2)
 		return any(signer).(TransactionSigner), err
 	}
+	TestSigners["5-of-32 MultiKey"] = func() (TransactionSigner, error) {
+		signer, err := NewMultiKeyTestSigner(32, 5)
+		return any(signer).(TransactionSigner), err
+	}
 	/* TODO: MultiEd25519 is not supported ATM
 	TestSigners["MultiEd25519"] = func() (TransactionSigner, error) {
 		signer, err := NewMultiEd25519Signer(3, 2)

--- a/crypto/multiKey_test.go
+++ b/crypto/multiKey_test.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"encoding/hex"
 	"github.com/aptos-labs/aptos-go-sdk/bcs"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -83,6 +84,18 @@ func TestMultiKeySerialization(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, auth, authDeserialized)
 
+}
+
+func TestMultiKey_Serialization_CrossPlatform(t *testing.T) {
+	serialized := "020140118d6ebe543aaf3a541453f98a5748ab5b9e3f96d781b8c0a43740af2b65c03529fdf62b7de7aad9150770e0994dc4e0714795fdebf312be66cd0550c607755e00401a90421453aa53fa5a7aa3dfe70d913823cbf087bf372a762219ccc824d3a0eeecccaa9d34f22db4366aec61fb6c204d2440f4ed288bc7cc7e407b766723a60901c0"
+	serializedBytes, err := hex.DecodeString(serialized)
+	assert.NoError(t, err)
+	signature := &MultiKeySignature{}
+	assert.NoError(t, bcs.Deserialize(signature, serializedBytes))
+
+	reserialized, err := bcs.Serialize(signature)
+	assert.NoError(t, err)
+	assert.Equal(t, serializedBytes, reserialized)
 }
 
 func createMultiKey(t *testing.T) (


### PR DESCRIPTION
### Description
There was a slight difference in implementation, where the bitmap was not being variable length, though it was meant to be variable length.

This fixes it and adds a python generated output as a comparison.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Adds a test for compatibility, along with existing submission tests in examples

### Related Links
<!-- Please link to any relevant issues or pull requests! -->