### PR TITLE
[deserialization] Fix SignedTransaction deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 
 # Unreleased
 
+- [`Breaking`] SignedTransaction can only contain `RawTransaction`.  Note, this is technically breaking, but should not change any user behavior or code.
 - [`Fix`] SignedTransaction deserialization will properly initialized `nil` fields before deserializing.
 
 # v1.3.0 (11/25/2024)

--- a/signedTransaction.go
+++ b/signedTransaction.go
@@ -28,7 +28,7 @@ const UserTransactionVariant SignedTransactionVariant = 0
 
 // SignedTransaction a raw transaction plus its authenticator for a fully verifiable message
 type SignedTransaction struct {
-	Transaction   RawTransactionImpl        // The transaction either [RawTransaction] or [RawTransactionWithData]
+	Transaction   *RawTransaction           // The transaction here is always a [RawTransaction], the rest of the information is in the authenticator
 	Authenticator *TransactionAuthenticator // The authenticator for a transaction (can't be be a standalone [crypto.AccountAuthenticator])
 }
 
@@ -75,13 +75,9 @@ func (txn *SignedTransaction) MarshalBCS(ser *bcs.Serializer) {
 	txn.Authenticator.MarshalBCS(ser)
 }
 func (txn *SignedTransaction) UnmarshalBCS(des *bcs.Deserializer) {
-	if txn.Transaction == nil {
-		txn.Transaction = &RawTransaction{}
-	}
-	if txn.Authenticator == nil {
-		txn.Authenticator = &TransactionAuthenticator{}
-	}
+	txn.Transaction = &RawTransaction{}
 	txn.Transaction.UnmarshalBCS(des)
+	txn.Authenticator = &TransactionAuthenticator{}
 	txn.Authenticator.UnmarshalBCS(des)
 }
 


### PR DESCRIPTION
### Description
SignedTransaction deserialization will properly initialize the `nil`  `Transaction` or `Authenticator` fields before deserializing.

**Note: This does not account for MultiAgent raw transactions but brings the deserialization behavior to parity with the ts-sdk**

### Test Plan
```go
package main

import (
	"fmt"

	"github.com/aptos-labs/aptos-go-sdk"
	"github.com/aptos-labs/aptos-go-sdk/bcs"
	"github.com/aptos-labs/aptos-go-sdk/crypto"
)

func example(networkConfig aptos.NetworkConfig) {
	client, err := aptos.NewClient(networkConfig)
	if err != nil {
		panic("Failed to create client:" + err.Error())
	}

	privateKey := &crypto.Ed25519PrivateKey{}
	err = privateKey.FromHex("ed25519-priv-<KEY>")
	if err != nil {
		panic("Failed to create private key:" + err.Error())
	}

	// Create accounts locally for alice and bob
	alice, err := aptos.NewAccountFromSigner(privateKey)
	if err != nil {
		panic("Failed to create alice:" + err.Error())
	}

	// // Build transaction
	accountBytes, err := bcs.Serialize(&alice.Address)
	if err != nil {
		panic("Failed to serialize bob's address:" + err.Error())
	}

	amountBytes, err := bcs.SerializeU64(1_000)
	if err != nil {
		panic("Failed to serialize transfer amount:" + err.Error())
	}
	rawTxn, err := client.BuildTransaction(alice.Address, aptos.TransactionPayload{
		Payload: &aptos.EntryFunction{
			Module: aptos.ModuleId{
				Address: aptos.AccountOne,
				Name:    "aptos_account",
			},
			Function: "transfer",
			ArgTypes: []aptos.TypeTag{},
			Args: [][]byte{
				accountBytes,
				amountBytes,
			},
		}},
	)
	if err != nil {
		panic("Failed to build transaction:" + err.Error())
	}

	// // Sign transaction
	signedTxn, err := rawTxn.SignedTransaction(alice)
	if err != nil {
		panic("Failed to sign transaction:" + err.Error())
	}

	signedTransactionBytes, _ := bcs.Serialize(signedTxn)
	var deserializedSignedTransaction aptos.SignedTransaction
	_ = bcs.Deserialize(&deserializedSignedTransaction, signedTransactionBytes)
}

func main() {
	example(aptos.DevnetConfig)
}
```

### Related Links
N/A