### PR TITLE
[events] Allow for events to be non structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 
 # Unreleased
 
+- [`Fix`] Non struct events, will have a field named `__any_data__` that contains the actual data of the struct
+
 # v1.4.0 (12/09/2024)
 
 - [`Breaking`] SignedTransaction can only contain `RawTransaction`.  Note, this is technically breaking, but should not change any user behavior or code.

--- a/api/events_test.go
+++ b/api/events_test.go
@@ -57,3 +57,24 @@ func TestEvent_V2(t *testing.T) {
 	assert.Equal(t, uint64(0), data.Guid.CreationNumber)
 	assert.Equal(t, &types.AccountZero, data.Guid.AccountAddress)
 }
+
+func TestEvent_V2_Other(t *testing.T) {
+	testJson := `	{
+		"type": "vector<u64>",
+		"guid": {
+            "account_address": "0x0",
+			"creation_number": "0"
+		},
+		"sequence_number": "0",
+		"data": ["0","1","2"]
+	}`
+	data := &Event{}
+	err := json.Unmarshal([]byte(testJson), &data)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "vector<u64>", data.Type)
+	assert.Equal(t, uint64(0), data.SequenceNumber)
+	assert.Equal(t, []any{"0", "1", "2"}, data.Data[AnyDataName].([]any))
+	assert.Equal(t, uint64(0), data.Guid.CreationNumber)
+	assert.Equal(t, &types.AccountZero, data.Guid.AccountAddress)
+}


### PR DESCRIPTION
### Description
Moves non-compliant data structures to `__any_data__` for events

### Test Plan
See tests

### Related Links
<!-- Please link to any relevant issues or pull requests! -->