### PR TITLE
[init] Fix initializaiton bug for setting params based off of build info

### DIFF
--- a/client_util.go
+++ b/client_util.go
@@ -18,8 +18,10 @@ func init() {
 	vcsMod := ""
 	goArch := ""
 	goOs := ""
+	params := url.Values{}
 	buildInfo, ok := debug.ReadBuildInfo()
 	if ok {
+		params.Set("go", buildInfo.GoVersion)
 		for _, setting := range buildInfo.Settings {
 			switch setting.Key {
 			case "vcs.revision":
@@ -34,11 +36,9 @@ func init() {
 			}
 		}
 	}
-	params := url.Values{}
 	if vcsMod == "true" {
 		params.Set("m", "t")
 	}
-	params.Set("go", buildInfo.GoVersion)
 	if goArch != "" {
 		params.Set("a", goArch)
 	}


### PR DESCRIPTION

### Description
There's an ordering issue here in the assumptions of which values are available or not.  I've never come upon this issue, but it's probably based on the build system.

Resolves https://github.com/aptos-labs/aptos-go-sdk/issues/114

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->