### PR TITLE
Make NodeClient satisfy AptosRpcClient interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -871,5 +871,5 @@ func (client *Client) GetCoinBalances(address AccountAddress) ([]CoinBalance, er
 
 // NodeAPIHealthCheck checks if the node is within durationSecs of the current time, if not provided the node default is used
 func (client *Client) NodeAPIHealthCheck(durationSecs ...uint64) (api.HealthCheckResponse, error) {
-	return client.nodeClient.NodeHealthCheck(durationSecs...)
+	return client.nodeClient.NodeAPIHealthCheck(durationSecs...)
 }

--- a/client.go
+++ b/client.go
@@ -348,7 +348,7 @@ type AptosRpcClient interface {
 	//		}
 	//	}
 	//	submitResponse, err := client.BuildSignAndSubmitTransaction(sender, txnPayload)
-	BuildSignAndSubmitTransaction(sender *Account, payload TransactionPayload, options ...any) (data *api.SubmitTransactionResponse, err error)
+	BuildSignAndSubmitTransaction(sender TransactionSigner, payload TransactionPayload, options ...any) (data *api.SubmitTransactionResponse, err error)
 
 	// View Runs a view function on chain returning a list of return values.
 	//
@@ -797,7 +797,7 @@ func (client *Client) BuildTransactionMultiAgent(sender AccountAddress, payload 
 //		}
 //	}
 //	submitResponse, err := client.BuildSignAndSubmitTransaction(sender, txnPayload)
-func (client *Client) BuildSignAndSubmitTransaction(sender *Account, payload TransactionPayload, options ...any) (data *api.SubmitTransactionResponse, err error) {
+func (client *Client) BuildSignAndSubmitTransaction(sender TransactionSigner, payload TransactionPayload, options ...any) (data *api.SubmitTransactionResponse, err error) {
 	return client.nodeClient.BuildSignAndSubmitTransaction(sender, payload, options...)
 }
 

--- a/nodeClient.go
+++ b/nodeClient.go
@@ -1006,10 +1006,10 @@ func (rc *NodeClient) BuildSignAndSubmitTransaction(sender TransactionSigner, pa
 	return rc.SubmitTransaction(signedTxn)
 }
 
-// NodeHealthCheck performs a health check on the node
+// NodeAPIHealthCheck performs a health check on the node
 //
 // Returns a HealthCheckResponse if successful, returns error if not.
-func (rc *NodeClient) NodeHealthCheck(durationSecs ...uint64) (api.HealthCheckResponse, error) {
+func (rc *NodeClient) NodeAPIHealthCheck(durationSecs ...uint64) (api.HealthCheckResponse, error) {
 	au := rc.baseUrl.JoinPath("-/healthy")
 	if len(durationSecs) > 0 {
 		params := url.Values{}
@@ -1017,6 +1017,15 @@ func (rc *NodeClient) NodeHealthCheck(durationSecs ...uint64) (api.HealthCheckRe
 		au.RawQuery = params.Encode()
 	}
 	return Get[api.HealthCheckResponse](rc, au.String())
+}
+
+// NodeHealthCheck performs a health check on the node
+//
+// Returns a HealthCheckResponse if successful, returns error if not.
+//
+// Deprecated: Use NodeAPIHealthCheck instead
+func (rc *NodeClient) NodeHealthCheck(durationSecs ...uint64) (api.HealthCheckResponse, error) {
+	return rc.NodeAPIHealthCheck(durationSecs...)
 }
 
 // Get makes a GET request to the endpoint and parses the response into the given type with JSON


### PR DESCRIPTION
### Description
The `AptosRpcClient` interface is supposed to be implemented by `NodeClient`:

> // AptosRpcClient is an interface for all functionality on the Client that is Node RPC related.  Its main implementation
// is [NodeClient]

But doesn't actually satisfy the interface due to two methods:
1. NodeAPIHealthCheck
```
methods are missing: NodeAPIHealthCheck(durationSecs ...uint64) (api. HealthCheckResponse, error)
```
I wasn't sure if you'd want to break compatibility by renaming the method and added a new method `NodeAPIHealthCheck` and kept the old one `NodeHealthCheck` while marking it as deprecated.

2. BuildSignAndSubmitTransaction
```
need the method: BuildSignAndSubmitTransaction(sender *Account, payload TransactionPayload, options ...any) (data *api. SubmitTransactionResponse, err error)
have the method: BuildSignAndSubmitTransaction(sender TransactionSigner, payload TransactionPayload, options ...any) (data *api. SubmitTransactionResponse, err error)
```
`NodeClient` already accepted the `TransactionSigner` interface and I lifted its usage to the `AptosRpcClient` interface. This should not break compatibility as `*Account` can still be passed.


### Test Plan
Ran all tests with `go test ./...`

### Related Links
These interfaces were requested in https://github.com/aptos-labs/aptos-go-sdk/issues/94 and added in https://github.com/aptos-labs/aptos-go-sdk/pull/97