### PR TITLE
Expose context.Context

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package aptos
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -105,10 +106,10 @@ type AptosRpcClient interface {
 	RemoveHeader(key string)
 
 	// Info Retrieves the node info about the network and it's current state
-	Info() (info NodeInfo, err error)
+	Info(ctx context.Context) (info NodeInfo, err error)
 
 	// Account Retrieves information about the account such as [SequenceNumber] and [crypto.AuthenticationKey]
-	Account(address AccountAddress, ledgerVersion ...uint64) (info AccountInfo, err error)
+	Account(ctx context.Context, address AccountAddress, ledgerVersion ...uint64) (info AccountInfo, err error)
 
 	// AccountResource Retrieves a single resource given its struct name.
 	//
@@ -119,7 +120,7 @@ type AptosRpcClient interface {
 	//
 	//	address := AccountOne
 	//	dataMap, _ := client.AccountResource(address, "0x1::coin::CoinStore", 1)
-	AccountResource(address AccountAddress, resourceType string, ledgerVersion ...uint64) (data map[string]any, err error)
+	AccountResource(ctx context.Context, address AccountAddress, resourceType string, ledgerVersion ...uint64) (data map[string]any, err error)
 
 	// AccountResources fetches resources for an account into a JSON-like map[string]any in AccountResourceInfo.Data
 	// For fetching raw Move structs as BCS, See #AccountResourcesBCS
@@ -131,10 +132,10 @@ type AptosRpcClient interface {
 	//
 	//	address := AccountOne
 	//	dataMap, _ := client.AccountResource(address, 1)
-	AccountResources(address AccountAddress, ledgerVersion ...uint64) (resources []AccountResourceInfo, err error)
+	AccountResources(ctx context.Context, address AccountAddress, ledgerVersion ...uint64) (resources []AccountResourceInfo, err error)
 
 	// AccountResourcesBCS fetches account resources as raw Move struct BCS blobs in AccountResourceRecord.Data []byte
-	AccountResourcesBCS(address AccountAddress, ledgerVersion ...uint64) (resources []AccountResourceRecord, err error)
+	AccountResourcesBCS(ctx context.Context, address AccountAddress, ledgerVersion ...uint64) (resources []AccountResourceRecord, err error)
 
 	// BlockByHeight fetches a block by height
 	//
@@ -143,7 +144,7 @@ type AptosRpcClient interface {
 	// Can also fetch with transactions
 	//
 	//	block, _ := client.BlockByHeight(1, true)
-	BlockByHeight(blockHeight uint64, withTransactions bool) (data *api.Block, err error)
+	BlockByHeight(ctx context.Context, blockHeight uint64, withTransactions bool) (data *api.Block, err error)
 
 	// BlockByVersion fetches a block by ledger version
 	//
@@ -152,7 +153,7 @@ type AptosRpcClient interface {
 	// Can also fetch with transactions
 	//
 	//	block, _ := client.BlockByVersion(123, true)
-	BlockByVersion(ledgerVersion uint64, withTransactions bool) (data *api.Block, err error)
+	BlockByVersion(ctx context.Context, ledgerVersion uint64, withTransactions bool) (data *api.Block, err error)
 
 	// TransactionByHash gets info on a transaction
 	// The transaction may be pending or recently committed.
@@ -169,7 +170,7 @@ type AptosRpcClient interface {
 	//			// known to local mempool, but not committed yet
 	//		}
 	//	}
-	TransactionByHash(txnHash string) (data *api.Transaction, err error)
+	TransactionByHash(ctx context.Context, txnHash string) (data *api.Transaction, err error)
 
 	// TransactionByVersion gets info on a transaction from its LedgerVersion.  It must have been
 	// committed to have a ledger version
@@ -182,7 +183,7 @@ type AptosRpcClient interface {
 	//			}
 	//		}
 	//	}
-	TransactionByVersion(version uint64) (data *api.CommittedTransaction, err error)
+	TransactionByVersion(ctx context.Context, version uint64) (data *api.CommittedTransaction, err error)
 
 	// PollForTransactions Waits up to 10 seconds for transactions to be done, polling at 10Hz
 	// Accepts options PollPeriod and PollTimeout which should wrap time.Duration values.
@@ -194,12 +195,12 @@ type AptosRpcClient interface {
 	//
 	//	hashes := []string{"0x1234", "0x4567"}
 	//	err := client.PollForTransactions(hashes, PollPeriod(500 * time.Milliseconds), PollTimeout(5 * time.Seconds))
-	PollForTransactions(txnHashes []string, options ...any) error
+	PollForTransactions(ctx context.Context, txnHashes []string, options ...any) error
 
 	// WaitForTransaction Do a long-GET for one transaction and wait for it to complete
 	//
 	//	data, err := client.WaitForTransaction("0x1234")
-	WaitForTransaction(txnHash string, options ...any) (data *api.UserTransaction, err error)
+	WaitForTransaction(ctx context.Context, txnHash string, options ...any) (data *api.UserTransaction, err error)
 
 	// Transactions Get recent transactions.
 	// Start is a version number. Nil for most recent transactions.
@@ -207,7 +208,7 @@ type AptosRpcClient interface {
 	//
 	//	client.Transactions(0, 2)   // Returns 2 transactions
 	//	client.Transactions(1, 100) // Returns 100 transactions
-	Transactions(start *uint64, limit *uint64) (data []*api.CommittedTransaction, err error)
+	Transactions(ctx context.Context, start *uint64, limit *uint64) (data []*api.CommittedTransaction, err error)
 
 	// AccountTransactions Get transactions associated with an account.
 	// Start is a version number. Nil for most recent transactions.
@@ -215,7 +216,7 @@ type AptosRpcClient interface {
 	//
 	//	client.AccountTransactions(AccountOne, 0, 2)   // Returns 2 transactions for 0x1
 	//	client.AccountTransactions(AccountOne, 1, 100) // Returns 100 transactions for 0x1
-	AccountTransactions(address AccountAddress, start *uint64, limit *uint64) (data []*api.CommittedTransaction, err error)
+	AccountTransactions(ctx context.Context, address AccountAddress, start *uint64, limit *uint64) (data []*api.CommittedTransaction, err error)
 
 	// SubmitTransaction Submits an already signed transaction to the blockchain
 	//
@@ -237,7 +238,7 @@ type AptosRpcClient interface {
 	//	rawTxn, _ := client.BuildTransaction(sender.AccountAddress(), txnPayload)
 	//	signedTxn, _ := sender.SignTransaction(rawTxn)
 	//	submitResponse, err := client.SubmitTransaction(signedTxn)
-	SubmitTransaction(signedTransaction *SignedTransaction) (data *api.SubmitTransactionResponse, err error)
+	SubmitTransaction(ctx context.Context, signedTransaction *SignedTransaction) (data *api.SubmitTransactionResponse, err error)
 
 	// BatchSubmitTransaction submits a collection of signed transactions to the network in a single request
 	//
@@ -262,7 +263,7 @@ type AptosRpcClient interface {
 	//	rawTxn, _ := client.BuildTransaction(sender.AccountAddress(), txnPayload)
 	//	signedTxn, _ := sender.SignTransaction(rawTxn)
 	//	submitResponse, err := client.BatchSubmitTransaction([]*SignedTransaction{signedTxn})
-	BatchSubmitTransaction(signedTxns []*SignedTransaction) (response *api.BatchSubmitTransactionResponse, err error)
+	BatchSubmitTransaction(ctx context.Context, signedTxns []*SignedTransaction) (response *api.BatchSubmitTransactionResponse, err error)
 
 	// SimulateTransaction Simulates a raw transaction without sending it to the blockchain
 	//
@@ -283,11 +284,11 @@ type AptosRpcClient interface {
 	//	}
 	//	rawTxn, _ := client.BuildTransaction(sender.AccountAddress(), txnPayload)
 	//	simResponse, err := client.SimulateTransaction(rawTxn, sender)
-	SimulateTransaction(rawTxn *RawTransaction, sender TransactionSigner, options ...any) (data []*api.UserTransaction, err error)
+	SimulateTransaction(ctx context.Context, rawTxn *RawTransaction, sender TransactionSigner, options ...any) (data []*api.UserTransaction, err error)
 
 	// GetChainId Retrieves the ChainId of the network
 	// Note this will be cached forever, or taken directly from the config
-	GetChainId() (chainId uint8, err error)
+	GetChainId(ctx context.Context) (chainId uint8, err error)
 
 	// BuildTransaction Builds a raw transaction from the payload and fetches any necessary information from on-chain
 	//
@@ -307,7 +308,7 @@ type AptosRpcClient interface {
 	//		}
 	//	}
 	//	rawTxn, err := client.BuildTransaction(sender.AccountAddress(), txnPayload)
-	BuildTransaction(sender AccountAddress, payload TransactionPayload, options ...any) (rawTxn *RawTransaction, err error)
+	BuildTransaction(ctx context.Context, sender AccountAddress, payload TransactionPayload, options ...any) (rawTxn *RawTransaction, err error)
 
 	// BuildTransactionMultiAgent Builds a raw transaction for MultiAgent or FeePayer from the payload and fetches any necessary information from on-chain
 	//
@@ -327,7 +328,7 @@ type AptosRpcClient interface {
 	//		}
 	//	}
 	//	rawTxn, err := client.BuildTransactionMultiAgent(sender.AccountAddress(), txnPayload, FeePayer(AccountZero))
-	BuildTransactionMultiAgent(sender AccountAddress, payload TransactionPayload, options ...any) (rawTxn *RawTransactionWithData, err error)
+	BuildTransactionMultiAgent(ctx context.Context, sender AccountAddress, payload TransactionPayload, options ...any) (rawTxn *RawTransactionWithData, err error)
 
 	// BuildSignAndSubmitTransaction Convenience function to do all three in one
 	// for more configuration, please use them separately
@@ -348,7 +349,7 @@ type AptosRpcClient interface {
 	//		}
 	//	}
 	//	submitResponse, err := client.BuildSignAndSubmitTransaction(sender, txnPayload)
-	BuildSignAndSubmitTransaction(sender TransactionSigner, payload TransactionPayload, options ...any) (data *api.SubmitTransactionResponse, err error)
+	BuildSignAndSubmitTransaction(ctx context.Context, sender TransactionSigner, payload TransactionPayload, options ...any) (data *api.SubmitTransactionResponse, err error)
 
 	// View Runs a view function on chain returning a list of return values.
 	//
@@ -364,23 +365,23 @@ type AptosRpcClient interface {
 	//		}
 	//		vals, err := client.aptosClient.View(payload)
 	//		balance := StrToU64(vals.(any[])[0].(string))
-	View(payload *ViewPayload, ledgerVersion ...uint64) (vals []any, err error)
+	View(ctx context.Context, payload *ViewPayload, ledgerVersion ...uint64) (vals []any, err error)
 
 	// EstimateGasPrice Retrieves the gas estimate from the network.
-	EstimateGasPrice() (info EstimateGasInfo, err error)
+	EstimateGasPrice(ctx context.Context) (info EstimateGasInfo, err error)
 
 	// AccountAPTBalance retrieves the APT balance in the account
-	AccountAPTBalance(address AccountAddress, ledgerVersion ...uint64) (uint64, error)
+	AccountAPTBalance(ctx context.Context, address AccountAddress, ledgerVersion ...uint64) (uint64, error)
 
 	// NodeAPIHealthCheck checks if the node is within durationSecs of the current time, if not provided the node default is used
-	NodeAPIHealthCheck(durationSecs ...uint64) (api.HealthCheckResponse, error)
+	NodeAPIHealthCheck(ctx context.Context, durationSecs ...uint64) (api.HealthCheckResponse, error)
 }
 
 // AptosFaucetClient is an interface for all functionality on the Client that is Faucet related.  Its main implementation
 // is [FaucetClient]
 type AptosFaucetClient interface {
 	// Fund Uses the faucet to fund an address, only applies to non-production networks
-	Fund(address AccountAddress, amount uint64) error
+	Fund(ctx context.Context, address AccountAddress, amount uint64) error
 }
 
 // AptosIndexerClient is an interface for all functionality on the Client that is Indexer related.  Its main implementation
@@ -413,13 +414,13 @@ type AptosIndexerClient interface {
 	//	}
 	//
 	//	return out, nil
-	QueryIndexer(query any, variables map[string]any, options ...graphql.Option) error
+	QueryIndexer(ctx context.Context, query any, variables map[string]any, options ...graphql.Option) error
 
 	// GetProcessorStatus returns the ledger version up to which the processor has processed
-	GetProcessorStatus(processorName string) (uint64, error)
+	GetProcessorStatus(ctx context.Context, processorName string) (uint64, error)
 
 	// GetCoinBalances gets the balances of all coins associated with a given address
-	GetCoinBalances(address AccountAddress) ([]CoinBalance, error)
+	GetCoinBalances(ctx context.Context, address AccountAddress) ([]CoinBalance, error)
 }
 
 // Client is a facade over the multiple types of underlying clients, as the user doesn't actually care where the data
@@ -478,7 +479,7 @@ func NewClient(config NetworkConfig, options ...any) (client *Client, err error)
 
 	// Fetch the chain Id if it isn't in the config
 	if config.ChainId == 0 {
-		_, _ = nodeClient.GetChainId()
+		_, _ = nodeClient.GetChainId(context.Background())
 	}
 
 	client = &Client{
@@ -487,13 +488,6 @@ func NewClient(config NetworkConfig, options ...any) (client *Client, err error)
 		indexerClient,
 	}
 	return
-}
-
-// SetTimeout adjusts the HTTP client timeout
-//
-//	client.SetTimeout(5 * time.Millisecond)
-func (client *Client) SetTimeout(timeout time.Duration) {
-	client.nodeClient.SetTimeout(timeout)
 }
 
 // SetHeader sets the header for all future requests
@@ -511,13 +505,13 @@ func (client *Client) RemoveHeader(key string) {
 }
 
 // Info Retrieves the node info about the network and it's current state
-func (client *Client) Info() (info NodeInfo, err error) {
-	return client.nodeClient.Info()
+func (client *Client) Info(ctx context.Context) (info NodeInfo, err error) {
+	return client.nodeClient.Info(ctx)
 }
 
 // Account Retrieves information about the account such as [SequenceNumber] and [crypto.AuthenticationKey]
-func (client *Client) Account(address AccountAddress, ledgerVersion ...uint64) (info AccountInfo, err error) {
-	return client.nodeClient.Account(address, ledgerVersion...)
+func (client *Client) Account(ctx context.Context, address AccountAddress, ledgerVersion ...uint64) (info AccountInfo, err error) {
+	return client.nodeClient.Account(ctx, address, ledgerVersion...)
 }
 
 // AccountResource Retrieves a single resource given its struct name.
@@ -529,8 +523,8 @@ func (client *Client) Account(address AccountAddress, ledgerVersion ...uint64) (
 //
 //	address := AccountOne
 //	dataMap, _ := client.AccountResource(address, "0x1::coin::CoinStore", 1)
-func (client *Client) AccountResource(address AccountAddress, resourceType string, ledgerVersion ...uint64) (data map[string]any, err error) {
-	return client.nodeClient.AccountResource(address, resourceType, ledgerVersion...)
+func (client *Client) AccountResource(ctx context.Context, address AccountAddress, resourceType string, ledgerVersion ...uint64) (data map[string]any, err error) {
+	return client.nodeClient.AccountResource(ctx, address, resourceType, ledgerVersion...)
 }
 
 // AccountResources fetches resources for an account into a JSON-like map[string]any in AccountResourceInfo.Data
@@ -543,13 +537,13 @@ func (client *Client) AccountResource(address AccountAddress, resourceType strin
 //
 //	address := AccountOne
 //	dataMap, _ := client.AccountResource(address, 1)
-func (client *Client) AccountResources(address AccountAddress, ledgerVersion ...uint64) (resources []AccountResourceInfo, err error) {
-	return client.nodeClient.AccountResources(address, ledgerVersion...)
+func (client *Client) AccountResources(ctx context.Context, address AccountAddress, ledgerVersion ...uint64) (resources []AccountResourceInfo, err error) {
+	return client.nodeClient.AccountResources(ctx, address, ledgerVersion...)
 }
 
 // AccountResourcesBCS fetches account resources as raw Move struct BCS blobs in AccountResourceRecord.Data []byte
-func (client *Client) AccountResourcesBCS(address AccountAddress, ledgerVersion ...uint64) (resources []AccountResourceRecord, err error) {
-	return client.nodeClient.AccountResourcesBCS(address, ledgerVersion...)
+func (client *Client) AccountResourcesBCS(ctx context.Context, address AccountAddress, ledgerVersion ...uint64) (resources []AccountResourceRecord, err error) {
+	return client.nodeClient.AccountResourcesBCS(ctx, address, ledgerVersion...)
 }
 
 // BlockByHeight fetches a block by height
@@ -559,8 +553,8 @@ func (client *Client) AccountResourcesBCS(address AccountAddress, ledgerVersion 
 // Can also fetch with transactions
 //
 //	block, _ := client.BlockByHeight(1, true)
-func (client *Client) BlockByHeight(blockHeight uint64, withTransactions bool) (data *api.Block, err error) {
-	return client.nodeClient.BlockByHeight(blockHeight, withTransactions)
+func (client *Client) BlockByHeight(ctx context.Context, blockHeight uint64, withTransactions bool) (data *api.Block, err error) {
+	return client.nodeClient.BlockByHeight(ctx, blockHeight, withTransactions)
 }
 
 // BlockByVersion fetches a block by ledger version
@@ -570,8 +564,8 @@ func (client *Client) BlockByHeight(blockHeight uint64, withTransactions bool) (
 // Can also fetch with transactions
 //
 //	block, _ := client.BlockByVersion(123, true)
-func (client *Client) BlockByVersion(ledgerVersion uint64, withTransactions bool) (data *api.Block, err error) {
-	return client.nodeClient.BlockByVersion(ledgerVersion, withTransactions)
+func (client *Client) BlockByVersion(ctx context.Context, ledgerVersion uint64, withTransactions bool) (data *api.Block, err error) {
+	return client.nodeClient.BlockByVersion(ctx, ledgerVersion, withTransactions)
 }
 
 // TransactionByHash gets info on a transaction
@@ -589,8 +583,8 @@ func (client *Client) BlockByVersion(ledgerVersion uint64, withTransactions bool
 //			// known to local mempool, but not committed yet
 //		}
 //	}
-func (client *Client) TransactionByHash(txnHash string) (data *api.Transaction, err error) {
-	return client.nodeClient.TransactionByHash(txnHash)
+func (client *Client) TransactionByHash(ctx context.Context, txnHash string) (data *api.Transaction, err error) {
+	return client.nodeClient.TransactionByHash(ctx, txnHash)
 }
 
 // TransactionByVersion gets info on a transaction from its LedgerVersion.  It must have been
@@ -604,8 +598,8 @@ func (client *Client) TransactionByHash(txnHash string) (data *api.Transaction, 
 //			}
 //		}
 //	}
-func (client *Client) TransactionByVersion(version uint64) (data *api.CommittedTransaction, err error) {
-	return client.nodeClient.TransactionByVersion(version)
+func (client *Client) TransactionByVersion(ctx context.Context, version uint64) (data *api.CommittedTransaction, err error) {
+	return client.nodeClient.TransactionByVersion(ctx, version)
 }
 
 // PollForTransactions Waits up to 10 seconds for transactions to be done, polling at 10Hz
@@ -618,15 +612,15 @@ func (client *Client) TransactionByVersion(version uint64) (data *api.CommittedT
 //
 //	hashes := []string{"0x1234", "0x4567"}
 //	err := client.PollForTransactions(hashes, PollPeriod(500 * time.Milliseconds), PollTimeout(5 * time.Seconds))
-func (client *Client) PollForTransactions(txnHashes []string, options ...any) error {
-	return client.nodeClient.PollForTransactions(txnHashes, options...)
+func (client *Client) PollForTransactions(ctx context.Context, txnHashes []string, options ...any) error {
+	return client.nodeClient.PollForTransactions(ctx, txnHashes, options...)
 }
 
 // WaitForTransaction Do a long-GET for one transaction and wait for it to complete
 //
 //	data, err := client.WaitForTransaction("0x1234")
-func (client *Client) WaitForTransaction(txnHash string, options ...any) (data *api.UserTransaction, err error) {
-	return client.nodeClient.WaitForTransaction(txnHash, options...)
+func (client *Client) WaitForTransaction(ctx context.Context, txnHash string, options ...any) (data *api.UserTransaction, err error) {
+	return client.nodeClient.WaitForTransaction(ctx, txnHash, options...)
 }
 
 // Transactions Get recent transactions.
@@ -635,8 +629,8 @@ func (client *Client) WaitForTransaction(txnHash string, options ...any) (data *
 //
 //	client.Transactions(0, 2)   // Returns 2 transactions
 //	client.Transactions(1, 100) // Returns 100 transactions
-func (client *Client) Transactions(start *uint64, limit *uint64) (data []*api.CommittedTransaction, err error) {
-	return client.nodeClient.Transactions(start, limit)
+func (client *Client) Transactions(ctx context.Context, start *uint64, limit *uint64) (data []*api.CommittedTransaction, err error) {
+	return client.nodeClient.Transactions(ctx, start, limit)
 }
 
 // AccountTransactions Get transactions associated with an account.
@@ -645,8 +639,8 @@ func (client *Client) Transactions(start *uint64, limit *uint64) (data []*api.Co
 //
 //	client.AccountTransactions(AccountOne, 0, 2)   // Returns 2 transactions for 0x1
 //	client.AccountTransactions(AccountOne, 1, 100) // Returns 100 transactions for 0x1
-func (client *Client) AccountTransactions(address AccountAddress, start *uint64, limit *uint64) (data []*api.CommittedTransaction, err error) {
-	return client.nodeClient.AccountTransactions(address, start, limit)
+func (client *Client) AccountTransactions(ctx context.Context, address AccountAddress, start *uint64, limit *uint64) (data []*api.CommittedTransaction, err error) {
+	return client.nodeClient.AccountTransactions(ctx, address, start, limit)
 }
 
 // SubmitTransaction Submits an already signed transaction to the blockchain
@@ -669,8 +663,8 @@ func (client *Client) AccountTransactions(address AccountAddress, start *uint64,
 //	rawTxn, _ := client.BuildTransaction(sender.AccountAddress(), txnPayload)
 //	signedTxn, _ := sender.SignTransaction(rawTxn)
 //	submitResponse, err := client.SubmitTransaction(signedTxn)
-func (client *Client) SubmitTransaction(signedTransaction *SignedTransaction) (data *api.SubmitTransactionResponse, err error) {
-	return client.nodeClient.SubmitTransaction(signedTransaction)
+func (client *Client) SubmitTransaction(ctx context.Context, signedTransaction *SignedTransaction) (data *api.SubmitTransactionResponse, err error) {
+	return client.nodeClient.SubmitTransaction(ctx, signedTransaction)
 }
 
 // BatchSubmitTransaction submits a collection of signed transactions to the network in a single request
@@ -696,8 +690,8 @@ func (client *Client) SubmitTransaction(signedTransaction *SignedTransaction) (d
 //	rawTxn, _ := client.BuildTransaction(sender.AccountAddress(), txnPayload)
 //	signedTxn, _ := sender.SignTransaction(rawTxn)
 //	submitResponse, err := client.BatchSubmitTransaction([]*SignedTransaction{signedTxn})
-func (client *Client) BatchSubmitTransaction(signedTxns []*SignedTransaction) (response *api.BatchSubmitTransactionResponse, err error) {
-	return client.nodeClient.BatchSubmitTransaction(signedTxns)
+func (client *Client) BatchSubmitTransaction(ctx context.Context, signedTxns []*SignedTransaction) (response *api.BatchSubmitTransactionResponse, err error) {
+	return client.nodeClient.BatchSubmitTransaction(ctx, signedTxns)
 }
 
 // SimulateTransaction Simulates a raw transaction without sending it to the blockchain
@@ -719,19 +713,19 @@ func (client *Client) BatchSubmitTransaction(signedTxns []*SignedTransaction) (r
 //	}
 //	rawTxn, _ := client.BuildTransaction(sender.AccountAddress(), txnPayload)
 //	simResponse, err := client.SimulateTransaction(rawTxn, sender)
-func (client *Client) SimulateTransaction(rawTxn *RawTransaction, sender TransactionSigner, options ...any) (data []*api.UserTransaction, err error) {
-	return client.nodeClient.SimulateTransaction(rawTxn, sender, options...)
+func (client *Client) SimulateTransaction(ctx context.Context, rawTxn *RawTransaction, sender TransactionSigner, options ...any) (data []*api.UserTransaction, err error) {
+	return client.nodeClient.SimulateTransaction(ctx, rawTxn, sender, options...)
 }
 
 // GetChainId Retrieves the ChainId of the network
 // Note this will be cached forever, or taken directly from the config
-func (client *Client) GetChainId() (chainId uint8, err error) {
-	return client.nodeClient.GetChainId()
+func (client *Client) GetChainId(ctx context.Context) (chainId uint8, err error) {
+	return client.nodeClient.GetChainId(ctx)
 }
 
 // Fund Uses the faucet to fund an address, only applies to non-production networks
-func (client *Client) Fund(address AccountAddress, amount uint64) error {
-	return client.faucetClient.Fund(address, amount)
+func (client *Client) Fund(ctx context.Context, address AccountAddress, amount uint64) error {
+	return client.faucetClient.Fund(ctx, address, amount)
 }
 
 // BuildTransaction Builds a raw transaction from the payload and fetches any necessary information from on-chain
@@ -752,8 +746,8 @@ func (client *Client) Fund(address AccountAddress, amount uint64) error {
 //		}
 //	}
 //	rawTxn, err := client.BuildTransaction(sender.AccountAddress(), txnPayload)
-func (client *Client) BuildTransaction(sender AccountAddress, payload TransactionPayload, options ...any) (rawTxn *RawTransaction, err error) {
-	return client.nodeClient.BuildTransaction(sender, payload, options...)
+func (client *Client) BuildTransaction(ctx context.Context, sender AccountAddress, payload TransactionPayload, options ...any) (rawTxn *RawTransaction, err error) {
+	return client.nodeClient.BuildTransaction(ctx, sender, payload, options...)
 }
 
 // BuildTransactionMultiAgent Builds a raw transaction for MultiAgent or FeePayer from the payload and fetches any necessary information from on-chain
@@ -774,8 +768,8 @@ func (client *Client) BuildTransaction(sender AccountAddress, payload Transactio
 //		}
 //	}
 //	rawTxn, err := client.BuildTransactionMultiAgent(sender.AccountAddress(), txnPayload, FeePayer(AccountZero))
-func (client *Client) BuildTransactionMultiAgent(sender AccountAddress, payload TransactionPayload, options ...any) (rawTxn *RawTransactionWithData, err error) {
-	return client.nodeClient.BuildTransactionMultiAgent(sender, payload, options...)
+func (client *Client) BuildTransactionMultiAgent(ctx context.Context, sender AccountAddress, payload TransactionPayload, options ...any) (rawTxn *RawTransactionWithData, err error) {
+	return client.nodeClient.BuildTransactionMultiAgent(ctx, sender, payload, options...)
 }
 
 // BuildSignAndSubmitTransaction Convenience function to do all three in one
@@ -797,8 +791,8 @@ func (client *Client) BuildTransactionMultiAgent(sender AccountAddress, payload 
 //		}
 //	}
 //	submitResponse, err := client.BuildSignAndSubmitTransaction(sender, txnPayload)
-func (client *Client) BuildSignAndSubmitTransaction(sender TransactionSigner, payload TransactionPayload, options ...any) (data *api.SubmitTransactionResponse, err error) {
-	return client.nodeClient.BuildSignAndSubmitTransaction(sender, payload, options...)
+func (client *Client) BuildSignAndSubmitTransaction(ctx context.Context, sender TransactionSigner, payload TransactionPayload, options ...any) (data *api.SubmitTransactionResponse, err error) {
+	return client.nodeClient.BuildSignAndSubmitTransaction(ctx, sender, payload, options...)
 }
 
 // View Runs a view function on chain returning a list of return values.
@@ -815,18 +809,18 @@ func (client *Client) BuildSignAndSubmitTransaction(sender TransactionSigner, pa
 //		}
 //		vals, err := client.aptosClient.View(payload)
 //		balance := StrToU64(vals.(any[])[0].(string))
-func (client *Client) View(payload *ViewPayload, ledgerVersion ...uint64) (vals []any, err error) {
-	return client.nodeClient.View(payload, ledgerVersion...)
+func (client *Client) View(ctx context.Context, payload *ViewPayload, ledgerVersion ...uint64) (vals []any, err error) {
+	return client.nodeClient.View(ctx, payload, ledgerVersion...)
 }
 
 // EstimateGasPrice Retrieves the gas estimate from the network.
-func (client *Client) EstimateGasPrice() (info EstimateGasInfo, err error) {
-	return client.nodeClient.EstimateGasPrice()
+func (client *Client) EstimateGasPrice(ctx context.Context) (info EstimateGasInfo, err error) {
+	return client.nodeClient.EstimateGasPrice(ctx)
 }
 
 // AccountAPTBalance retrieves the APT balance in the account
-func (client *Client) AccountAPTBalance(address AccountAddress, ledgerVersion ...uint64) (uint64, error) {
-	return client.nodeClient.AccountAPTBalance(address, ledgerVersion...)
+func (client *Client) AccountAPTBalance(ctx context.Context, address AccountAddress, ledgerVersion ...uint64) (uint64, error) {
+	return client.nodeClient.AccountAPTBalance(ctx, address, ledgerVersion...)
 }
 
 // QueryIndexer queries the indexer using GraphQL to fill the `query` struct with data.  See examples in the indexer client on how to make queries
@@ -855,21 +849,21 @@ func (client *Client) AccountAPTBalance(address AccountAddress, ledgerVersion ..
 //	}
 //
 //	return out, nil
-func (client *Client) QueryIndexer(query any, variables map[string]any, options ...graphql.Option) error {
-	return client.indexerClient.Query(query, variables, options...)
+func (client *Client) QueryIndexer(ctx context.Context, query any, variables map[string]any, options ...graphql.Option) error {
+	return client.indexerClient.Query(ctx, query, variables, options...)
 }
 
 // GetProcessorStatus returns the ledger version up to which the processor has processed
-func (client *Client) GetProcessorStatus(processorName string) (uint64, error) {
-	return client.indexerClient.GetProcessorStatus(processorName)
+func (client *Client) GetProcessorStatus(ctx context.Context, processorName string) (uint64, error) {
+	return client.indexerClient.GetProcessorStatus(ctx, processorName)
 }
 
 // GetCoinBalances gets the balances of all coins associated with a given address
-func (client *Client) GetCoinBalances(address AccountAddress) ([]CoinBalance, error) {
-	return client.indexerClient.GetCoinBalances(address)
+func (client *Client) GetCoinBalances(ctx context.Context, address AccountAddress) ([]CoinBalance, error) {
+	return client.indexerClient.GetCoinBalances(ctx, address)
 }
 
 // NodeAPIHealthCheck checks if the node is within durationSecs of the current time, if not provided the node default is used
-func (client *Client) NodeAPIHealthCheck(durationSecs ...uint64) (api.HealthCheckResponse, error) {
-	return client.nodeClient.NodeAPIHealthCheck(durationSecs...)
+func (client *Client) NodeAPIHealthCheck(ctx context.Context, durationSecs ...uint64) (api.HealthCheckResponse, error) {
+	return client.nodeClient.NodeAPIHealthCheck(ctx, durationSecs...)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package aptos
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"testing"
@@ -100,7 +101,7 @@ func setupIntegrationTest(t *testing.T, createAccount CreateSigner) (*Client, Tr
 	assert.NoError(t, err)
 
 	// Verify chain id retrieval works
-	chainId, err := client.GetChainId()
+	chainId, err := client.GetChainId(context.Background())
 	assert.NoError(t, err)
 	if testConfig == DevnetConfig {
 		assert.Greater(t, chainId, LocalnetConfig.ChainId)
@@ -109,7 +110,7 @@ func setupIntegrationTest(t *testing.T, createAccount CreateSigner) (*Client, Tr
 	}
 
 	// Verify gas estimation works
-	_, err = client.EstimateGasPrice()
+	_, err = client.EstimateGasPrice(context.Background())
 	assert.NoError(t, err)
 
 	// Create an account
@@ -117,7 +118,7 @@ func setupIntegrationTest(t *testing.T, createAccount CreateSigner) (*Client, Tr
 	assert.NoError(t, err)
 
 	// Fund the account with 1 APT
-	err = client.Fund(account.AccountAddress(), fundAmount)
+	err = client.Fund(context.Background(), account.AccountAddress(), fundAmount)
 	assert.NoError(t, err)
 
 	return client, account
@@ -135,17 +136,17 @@ func testTransaction(t *testing.T, createAccount CreateSigner, buildTransaction 
 	assert.NoError(t, err)
 
 	// Send transaction
-	result, err := client.SubmitTransaction(signedTxn)
+	result, err := client.SubmitTransaction(context.Background(), signedTxn)
 	assert.NoError(t, err)
 
 	hash := result.Hash
 
 	// Wait for the transaction
-	_, err = client.WaitForTransaction(hash)
+	_, err = client.WaitForTransaction(context.Background(), hash)
 	assert.NoError(t, err)
 
 	// Read transaction by hash
-	txn, err := client.TransactionByHash(hash)
+	txn, err := client.TransactionByHash(context.Background(), hash)
 	assert.NoError(t, err)
 
 	// Read transaction by version
@@ -153,7 +154,7 @@ func testTransaction(t *testing.T, createAccount CreateSigner, buildTransaction 
 	version := userTxn.Version
 
 	// Load the transaction again
-	txnByVersion, err := client.TransactionByVersion(version)
+	txnByVersion, err := client.TransactionByVersion(context.Background(), version)
 	assert.NoError(t, err)
 
 	// Assert that both are the same
@@ -170,7 +171,7 @@ func testTransactionSimulation(t *testing.T, createAccount CreateSigner, buildTr
 	// Simulate transaction (no options)
 	rawTxn, err := buildTransaction(client, account)
 	assert.NoError(t, err)
-	simulatedTxn, err := client.SimulateTransaction(rawTxn, account)
+	simulatedTxn, err := client.SimulateTransaction(context.Background(), rawTxn, account)
 	switch account.(type) {
 	case *MultiKeyTestSigner:
 		// multikey simulation currently not supported
@@ -187,7 +188,7 @@ func testTransactionSimulation(t *testing.T, createAccount CreateSigner, buildTr
 	// simulate transaction (estimate gas unit price)
 	rawTxnZeroGasUnitPrice, err := buildTransaction(client, account, GasUnitPrice(0))
 	assert.NoError(t, err)
-	simulatedTxn, err = client.SimulateTransaction(rawTxnZeroGasUnitPrice, account, EstimateGasUnitPrice(true))
+	simulatedTxn, err = client.SimulateTransaction(context.Background(), rawTxnZeroGasUnitPrice, account, EstimateGasUnitPrice(true))
 	assert.NoError(t, err)
 	assert.Equal(t, true, simulatedTxn[0].Success)
 	assert.Equal(t, vmStatusSuccess, simulatedTxn[0].VmStatus)
@@ -197,7 +198,7 @@ func testTransactionSimulation(t *testing.T, createAccount CreateSigner, buildTr
 	// simulate transaction (estimate max gas amount)
 	rawTxnZeroMaxGasAmount, err := buildTransaction(client, account, MaxGasAmount(0))
 	assert.NoError(t, err)
-	simulatedTxn, err = client.SimulateTransaction(rawTxnZeroMaxGasAmount, account, EstimateMaxGasAmount(true))
+	simulatedTxn, err = client.SimulateTransaction(context.Background(), rawTxnZeroMaxGasAmount, account, EstimateMaxGasAmount(true))
 	assert.NoError(t, err)
 	assert.Equal(t, true, simulatedTxn[0].Success)
 	assert.Equal(t, vmStatusSuccess, simulatedTxn[0].VmStatus)
@@ -206,7 +207,7 @@ func testTransactionSimulation(t *testing.T, createAccount CreateSigner, buildTr
 	// simulate transaction (estimate prioritized gas unit price and max gas amount)
 	rawTxnZeroGasConfig, err := buildTransaction(client, account, GasUnitPrice(0), MaxGasAmount(0))
 	assert.NoError(t, err)
-	simulatedTxn, err = client.SimulateTransaction(rawTxnZeroGasConfig, account, EstimatePrioritizedGasUnitPrice(true), EstimateMaxGasAmount(true))
+	simulatedTxn, err = client.SimulateTransaction(context.Background(), rawTxnZeroGasConfig, account, EstimatePrioritizedGasUnitPrice(true), EstimateMaxGasAmount(true))
 	assert.NoError(t, err)
 	assert.Equal(t, true, simulatedTxn[0].Success)
 	assert.Equal(t, vmStatusSuccess, simulatedTxn[0].VmStatus)
@@ -223,12 +224,12 @@ func TestAPTTransferTransaction(t *testing.T) {
 
 	client, err := createTestClient()
 	assert.NoError(t, err)
-	signedTxn, err := APTTransferTransaction(client, sender, dest.Address, 1337, MaxGasAmount(123123), GasUnitPrice(111), ExpirationSeconds(42), ChainIdOption(71), SequenceNumber(31337))
+	signedTxn, err := APTTransferTransaction(context.Background(), client, sender, dest.Address, 1337, MaxGasAmount(123123), GasUnitPrice(111), ExpirationSeconds(42), ChainIdOption(71), SequenceNumber(31337))
 	assert.NoError(t, err)
 	assert.NotNil(t, signedTxn)
 
 	// use defaults for: max gas amount, gas unit price
-	signedTxn, err = APTTransferTransaction(client, sender, dest.Address, 1337, ExpirationSeconds(42), ChainIdOption(71), SequenceNumber(31337))
+	signedTxn, err = APTTransferTransaction(context.Background(), client, sender, dest.Address, 1337, ExpirationSeconds(42), ChainIdOption(71), SequenceNumber(31337))
 	assert.NoError(t, err)
 	assert.NotNil(t, signedTxn)
 }
@@ -241,14 +242,14 @@ func Test_Indexer(t *testing.T) {
 	account, err := NewEd25519Account()
 	assert.NoError(t, err)
 
-	err = client.Fund(account.AccountAddress(), 10)
+	err = client.Fund(context.Background(), account.AccountAddress(), 10)
 	assert.NoError(t, err)
 
-	balance, err := client.AccountAPTBalance(account.AccountAddress())
+	balance, err := client.AccountAPTBalance(context.Background(), account.AccountAddress())
 	assert.NoError(t, err)
 
 	// TODO: May need to wait on indexer for this one
-	coins, err := client.GetCoinBalances(account.AccountAddress())
+	coins, err := client.GetCoinBalances(context.Background(), account.AccountAddress())
 	assert.NoError(t, err)
 	switch len(coins) {
 	case 0:
@@ -265,7 +266,7 @@ func Test_Indexer(t *testing.T) {
 	}
 
 	// Get current version
-	status, err := client.GetProcessorStatus("default_processor")
+	status, err := client.GetProcessorStatus(context.Background(), "default_processor")
 	assert.NoError(t, err)
 	// TODO: When we have waiting on indexer, we can add this check to be more accurate
 	assert.GreaterOrEqual(t, status, uint64(0))
@@ -275,7 +276,7 @@ func Test_Genesis(t *testing.T) {
 	client, err := createTestClient()
 	assert.NoError(t, err)
 
-	genesis, err := client.BlockByHeight(0, true)
+	genesis, err := client.BlockByHeight(context.Background(), 0, true)
 	assert.NoError(t, err)
 
 	txn, err := genesis.Transactions[0].GenesisTransaction()
@@ -287,7 +288,7 @@ func Test_Genesis(t *testing.T) {
 func Test_Block(t *testing.T) {
 	client, err := createTestClient()
 	assert.NoError(t, err)
-	info, err := client.Info()
+	info, err := client.Info(context.Background())
 	assert.NoError(t, err)
 
 	// TODO: I need to add hardcoded testing sets for these conversions
@@ -300,7 +301,7 @@ func Test_Block(t *testing.T) {
 	for i := uint64(0); i < numToCheck; i++ {
 		go func() {
 			blockNumber := blockHeight - i
-			blockByHeight, err := client.BlockByHeight(blockNumber, true)
+			blockByHeight, err := client.BlockByHeight(context.Background(), blockNumber, true)
 			assert.NoError(t, err)
 
 			assert.Equal(t, blockNumber, blockByHeight.BlockHeight)
@@ -309,7 +310,7 @@ func Test_Block(t *testing.T) {
 			assert.Equal(t, 1+blockByHeight.LastVersion-blockByHeight.FirstVersion, uint64(len(blockByHeight.Transactions)))
 
 			// Version should be the same
-			blockByVersion, err := client.BlockByVersion(blockByHeight.FirstVersion, true)
+			blockByVersion, err := client.BlockByVersion(context.Background(), blockByHeight.FirstVersion, true)
 			assert.NoError(t, err)
 
 			assert.Equal(t, blockByHeight, blockByVersion)
@@ -323,7 +324,7 @@ func Test_Block(t *testing.T) {
 func Test_Account(t *testing.T) {
 	client, err := createTestClient()
 	assert.NoError(t, err)
-	account, err := client.Account(AccountOne)
+	account, err := client.Account(context.Background(), AccountOne)
 	assert.NoError(t, err)
 	sequenceNumber, err := account.SequenceNumber()
 	assert.NoError(t, err)
@@ -340,22 +341,22 @@ func Test_Transactions(t *testing.T) {
 	start := uint64(1)
 	count := uint64(2)
 	// Specific 2 should only give 2
-	transactions, err := client.Transactions(&start, &count)
+	transactions, err := client.Transactions(context.Background(), &start, &count)
 	assert.NoError(t, err)
 	assert.Len(t, transactions, 2)
 
 	// This will give the latest 2
-	transactions, err = client.Transactions(nil, &count)
+	transactions, err = client.Transactions(context.Background(), nil, &count)
 	assert.NoError(t, err)
 	assert.Len(t, transactions, 2)
 
 	// This will give the 25 from 2
-	transactions, err = client.Transactions(&start, nil)
+	transactions, err = client.Transactions(context.Background(), &start, nil)
 	assert.NoError(t, err)
 	assert.Len(t, transactions, 25)
 
 	// This will give the latest 25
-	transactions, err = client.Transactions(nil, nil)
+	transactions, err = client.Transactions(context.Background(), nil, nil)
 	assert.NoError(t, err)
 	assert.Len(t, transactions, 25)
 }
@@ -363,13 +364,13 @@ func Test_Transactions(t *testing.T) {
 func submitAccountTransaction(t *testing.T, client *Client, account *Account, seqNo uint64) {
 	payload, err := CoinTransferPayload(nil, AccountOne, 1)
 	assert.NoError(t, err)
-	rawTxn, err := client.BuildTransaction(account.AccountAddress(), TransactionPayload{Payload: payload}, SequenceNumber(seqNo))
+	rawTxn, err := client.BuildTransaction(context.Background(), account.AccountAddress(), TransactionPayload{Payload: payload}, SequenceNumber(seqNo))
 	assert.NoError(t, err)
 	signedTxn, err := rawTxn.SignedTransaction(account)
 	assert.NoError(t, err)
-	txn, err := client.SubmitTransaction(signedTxn)
+	txn, err := client.SubmitTransaction(context.Background(), signedTxn)
 	assert.NoError(t, err)
-	_, err = client.WaitForTransaction(txn.Hash)
+	_, err = client.WaitForTransaction(context.Background(), txn.Hash)
 	assert.NoError(t, err)
 }
 
@@ -381,7 +382,7 @@ func Test_AccountTransactions(t *testing.T) {
 	// Create a bunch of transactions so we can test the pagination
 	account, err := NewEd25519Account()
 	assert.NoError(t, err)
-	err = client.Fund(account.AccountAddress(), 100_000_000)
+	err = client.Fund(context.Background(), account.AccountAddress(), 100_000_000)
 	assert.NoError(t, err)
 
 	// Build and submit 100 transactions
@@ -400,7 +401,7 @@ func Test_AccountTransactions(t *testing.T) {
 	submitAccountTransaction(t, client, account, 100)
 
 	// Fetch default
-	transactions, err := client.AccountTransactions(account.AccountAddress(), nil, nil)
+	transactions, err := client.AccountTransactions(context.Background(), account.AccountAddress(), nil, nil)
 	assert.NoError(t, err)
 	assert.Len(t, transactions, 25)
 
@@ -410,69 +411,69 @@ func Test_AccountTransactions(t *testing.T) {
 	ten := uint64(10)
 	hundredOne := uint64(101)
 
-	transactions, err = client.AccountTransactions(account.AccountAddress(), nil, &hundredOne)
+	transactions, err = client.AccountTransactions(context.Background(), account.AccountAddress(), nil, &hundredOne)
 	assert.NoError(t, err)
 	assert.Len(t, transactions, 101)
 
 	// Fetch 101 with start
-	transactions, err = client.AccountTransactions(account.AccountAddress(), &zero, &hundredOne)
+	transactions, err = client.AccountTransactions(context.Background(), account.AccountAddress(), &zero, &hundredOne)
 	assert.NoError(t, err)
 	assert.Len(t, transactions, 101)
 
 	// Fetch 100 from 1
-	transactions, err = client.AccountTransactions(account.AccountAddress(), &one, &hundredOne)
+	transactions, err = client.AccountTransactions(context.Background(), account.AccountAddress(), &one, &hundredOne)
 	assert.NoError(t, err)
 	assert.Len(t, transactions, 100)
 
 	// Fetch default from 0
-	transactions, err = client.AccountTransactions(account.AccountAddress(), &zero, nil)
+	transactions, err = client.AccountTransactions(context.Background(), account.AccountAddress(), &zero, nil)
 	assert.NoError(t, err)
 	assert.Len(t, transactions, 25)
 
 	// Check global transactions API
 
 	t.Run("Default transaction size, no start", func(t *testing.T) {
-		transactions, err = client.Transactions(nil, nil)
+		transactions, err = client.Transactions(context.Background(), nil, nil)
 		assert.NoError(t, err)
 		assert.Len(t, transactions, 25)
 	})
 	t.Run("Default transaction size, start from zero", func(t *testing.T) {
-		transactions, err = client.Transactions(&zero, nil)
+		transactions, err = client.Transactions(context.Background(), &zero, nil)
 		assert.NoError(t, err)
 		assert.Len(t, transactions, 25)
 	})
 	t.Run("Default transaction size, start from one", func(t *testing.T) {
-		transactions, err = client.Transactions(&one, nil)
+		transactions, err = client.Transactions(context.Background(), &one, nil)
 		assert.NoError(t, err)
 		assert.Len(t, transactions, 25)
 	})
 
 	t.Run("101 transactions, no start", func(t *testing.T) {
-		transactions, err = client.Transactions(nil, &hundredOne)
+		transactions, err = client.Transactions(context.Background(), nil, &hundredOne)
 		assert.NoError(t, err)
 		assert.Len(t, transactions, 101)
 	})
 
 	t.Run("101 transactions, start zero", func(t *testing.T) {
-		transactions, err = client.Transactions(&zero, &hundredOne)
+		transactions, err = client.Transactions(context.Background(), &zero, &hundredOne)
 		assert.NoError(t, err)
 		assert.Len(t, transactions, 101)
 	})
 
 	t.Run("101 transactions, start one", func(t *testing.T) {
-		transactions, err = client.Transactions(&one, &hundredOne)
+		transactions, err = client.Transactions(context.Background(), &one, &hundredOne)
 		assert.NoError(t, err)
 		assert.Len(t, transactions, 101)
 	})
 
 	t.Run("10 transactions, no start", func(t *testing.T) {
-		transactions, err = client.Transactions(nil, &ten)
+		transactions, err = client.Transactions(context.Background(), nil, &ten)
 		assert.NoError(t, err)
 		assert.Len(t, transactions, 10)
 	})
 
 	t.Run("10 transactions, start one", func(t *testing.T) {
-		transactions, err = client.Transactions(&one, &ten)
+		transactions, err = client.Transactions(context.Background(), &one, &ten)
 		assert.NoError(t, err)
 		assert.Len(t, transactions, 10)
 	})
@@ -482,7 +483,7 @@ func Test_Info(t *testing.T) {
 	client, err := createTestClient()
 	assert.NoError(t, err)
 
-	info, err := client.Info()
+	info, err := client.Info(context.Background())
 	assert.NoError(t, err)
 	assert.Greater(t, info.BlockHeight(), uint64(0))
 }
@@ -491,11 +492,11 @@ func Test_AccountResources(t *testing.T) {
 	client, err := createTestClient()
 	assert.NoError(t, err)
 
-	resources, err := client.AccountResources(AccountOne)
+	resources, err := client.AccountResources(context.Background(), AccountOne)
 	assert.NoError(t, err)
 	assert.Greater(t, len(resources), 0)
 
-	resourcesBcs, err := client.AccountResourcesBCS(AccountOne)
+	resourcesBcs, err := client.AccountResourcesBCS(context.Background(), AccountOne)
 	assert.NoError(t, err)
 	assert.Greater(t, len(resourcesBcs), 0)
 }
@@ -516,7 +517,7 @@ func concurrentTxnWaiter(
 		responseCount++
 		assert.NoError(t, response.Err)
 
-		waitResponse, err := client.WaitForTransaction(response.Response.Hash, PollTimeout(21*time.Second))
+		waitResponse, err := client.WaitForTransaction(context.Background(), response.Response.Hash, PollTimeout(21*time.Second))
 		if err != nil {
 			t.Logf("%s err %s", response.Response.Hash, err)
 		} else if waitResponse == nil {
@@ -544,15 +545,15 @@ func Test_Concurrent_Submission(t *testing.T) {
 	account2, err := NewEd25519Account()
 	assert.NoError(t, err)
 
-	err = client.Fund(account1.AccountAddress(), 100_000_000)
+	err = client.Fund(context.Background(), account1.AccountAddress(), 100_000_000)
 	assert.NoError(t, err)
-	err = client.Fund(account2.AccountAddress(), 0)
+	err = client.Fund(context.Background(), account2.AccountAddress(), 0)
 	assert.NoError(t, err)
 
 	// start submission goroutine
 	payloads := make(chan TransactionBuildPayload, 50)
 	results := make(chan TransactionSubmissionResponse, 50)
-	go client.BuildSignAndSubmitTransactions(account1, payloads, results, ExpirationSeconds(20))
+	go client.BuildSignAndSubmitTransactions(context.Background(), account1, payloads, results, ExpirationSeconds(20))
 
 	transferPayload, err := CoinTransferPayload(nil, AccountOne, 100)
 	assert.NoError(t, err)
@@ -638,7 +639,7 @@ func TestClient_View(t *testing.T) {
 		ArgTypes: []TypeTag{AptosCoinTypeTag},
 		Args:     [][]byte{AccountOne[:]},
 	}
-	vals, err := client.View(payload)
+	vals, err := client.View(context.Background(), payload)
 	assert.NoError(t, err)
 	assert.Len(t, vals, 1)
 	_, err = StrToUint64(vals[0].(string))
@@ -649,7 +650,7 @@ func TestClient_BlockByHeight(t *testing.T) {
 	client, err := createTestClient()
 	assert.NoError(t, err)
 
-	_, err = client.BlockByHeight(1, true)
+	_, err = client.BlockByHeight(context.Background(), 1, true)
 	assert.NoError(t, err)
 }
 
@@ -659,7 +660,7 @@ func TestClient_NodeAPIHealthCheck(t *testing.T) {
 
 	t.Run("Node API health check default", func(t *testing.T) {
 		t.Parallel()
-		response, err := client.NodeAPIHealthCheck()
+		response, err := client.NodeAPIHealthCheck(context.Background())
 		assert.NoError(t, err)
 		assert.True(t, strings.Contains(response.Message, "ok"), "Node API health check failed"+response.Message)
 	})
@@ -667,7 +668,7 @@ func TestClient_NodeAPIHealthCheck(t *testing.T) {
 	// Now, check node API health check with a future time that should never fail
 	t.Run("Node API health check far future", func(t *testing.T) {
 		t.Parallel()
-		response, err := client.NodeAPIHealthCheck(10000)
+		response, err := client.NodeAPIHealthCheck(context.Background(), 10000)
 		assert.NoError(t, err)
 		assert.True(t, strings.Contains(response.Message, "ok"), "Node API health check failed"+response.Message)
 	})
@@ -676,13 +677,13 @@ func TestClient_NodeAPIHealthCheck(t *testing.T) {
 	t.Run("Node API health check fail", func(t *testing.T) {
 		t.Parallel()
 		// Now, check node API health check with a time that should probably fail
-		_, err := client.NodeAPIHealthCheck(0)
+		_, err := client.NodeAPIHealthCheck(context.Background(), 0)
 		assert.Error(t, err)
 	})
 }
 
 func buildSingleSignerEntryFunction(client *Client, sender TransactionSigner, options ...any) (*RawTransaction, error) {
-	return APTTransferTransaction(client, sender, AccountOne, 100, options...)
+	return APTTransferTransaction(context.Background(), client, sender, AccountOne, 100, options...)
 }
 
 func buildSingleSignerScript(client *Client, sender TransactionSigner, options ...any) (*RawTransaction, error) {
@@ -694,7 +695,7 @@ func buildSingleSignerScript(client *Client, sender TransactionSigner, options .
 	amount := uint64(1)
 	dest := AccountOne
 
-	rawTxn, err := client.BuildTransaction(sender.AccountAddress(),
+	rawTxn, err := client.BuildTransaction(context.Background(), sender.AccountAddress(),
 		TransactionPayload{Payload: &Script{
 			Code:     scriptBytes,
 			ArgTypes: []TypeTag{},

--- a/client_util.go
+++ b/client_util.go
@@ -1,6 +1,7 @@
 package aptos
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"runtime/debug"
@@ -53,13 +54,13 @@ func init() {
 //
 // options may be: MaxGasAmount, GasUnitPrice, ExpirationSeconds, ValidUntil, SequenceNumber, ChainIdOption
 // deprecated, please use the EntryFunction APIs
-func APTTransferTransaction(client *Client, sender TransactionSigner, dest AccountAddress, amount uint64, options ...any) (rawTxn *RawTransaction, err error) {
+func APTTransferTransaction(ctx context.Context, client *Client, sender TransactionSigner, dest AccountAddress, amount uint64, options ...any) (rawTxn *RawTransaction, err error) {
 	entryFunction, err := CoinTransferPayload(nil, dest, amount)
 	if err != nil {
 		return nil, err
 	}
 
-	rawTxn, err = client.BuildTransaction(sender.AccountAddress(),
+	rawTxn, err = client.BuildTransaction(ctx, sender.AccountAddress(),
 		TransactionPayload{Payload: entryFunction}, options...)
 	return
 }

--- a/examples/alternative_signing/main.go
+++ b/examples/alternative_signing/main.go
@@ -2,7 +2,9 @@
 package main
 
 import (
+	"context"
 	"fmt"
+
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/aptos-labs/aptos-go-sdk/crypto"
 	"golang.org/x/crypto/ed25519"
@@ -90,7 +92,7 @@ func example(network aptos.NetworkConfig) {
 	}
 
 	// Fund the sender with the faucet to create it on-chain
-	err = client.Fund(sender.Address, 100_000_000)
+	err = client.Fund(context.Background(), sender.Address, 100_000_000)
 	fmt.Printf("We fund the signer account %s with the faucet\n", sender.Address.String())
 
 	// Prep arguments
@@ -102,7 +104,7 @@ func example(network aptos.NetworkConfig) {
 	amount := uint64(100)
 
 	// Build transaction
-	rawTxn, err := aptos.APTTransferTransaction(client, sender, receiver, amount)
+	rawTxn, err := aptos.APTTransferTransaction(context.Background(), client, sender, receiver, amount)
 	if err != nil {
 		panic("Failed to build transaction:" + err.Error())
 	}
@@ -115,7 +117,7 @@ func example(network aptos.NetworkConfig) {
 	fmt.Printf("Submit a coin transfer to address %s\n", receiver.String())
 
 	// Submit and wait for it to complete
-	submitResult, err := client.SubmitTransaction(signedTxn)
+	submitResult, err := client.SubmitTransaction(context.Background(), signedTxn)
 	if err != nil {
 		panic("Failed to submit transaction:" + err.Error())
 	}
@@ -123,7 +125,7 @@ func example(network aptos.NetworkConfig) {
 
 	// Wait for the transaction
 	fmt.Printf("And we wait for the transaction %s to complete...\n", txnHash)
-	userTxn, err := client.WaitForTransaction(txnHash)
+	userTxn, err := client.WaitForTransaction(context.Background(), txnHash)
 	if err != nil {
 		panic("Failed to wait for transaction:" + err.Error())
 	}

--- a/examples/external_signing/main.go
+++ b/examples/external_signing/main.go
@@ -2,7 +2,9 @@
 package main
 
 import (
+	"context"
 	"fmt"
+
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/aptos-labs/aptos-go-sdk/crypto"
 	"golang.org/x/crypto/ed25519"
@@ -91,7 +93,7 @@ func example(networkConfig aptos.NetworkConfig) {
 	}
 
 	// Fund the sender with the faucet to create it on-chain
-	err = client.Fund(sender.Address, 100_000_000)
+	err = client.Fund(context.Background(), sender.Address, 100_000_000)
 	fmt.Printf("We fund the signer account %s with the faucet\n", sender.Address.String())
 
 	// Prep arguments
@@ -108,7 +110,7 @@ func example(networkConfig aptos.NetworkConfig) {
 
 	// Sign transaction
 	fmt.Printf("Submit a coin transfer to address %s\n", receiver.String())
-	rawTxn, err := client.BuildTransaction(sender.Address,
+	rawTxn, err := client.BuildTransaction(context.Background(), sender.Address,
 		aptos.TransactionPayload{Payload: payload},
 	)
 	if err != nil {
@@ -139,7 +141,7 @@ func example(networkConfig aptos.NetworkConfig) {
 	// TODO: Show how to send over a wire with an encoding
 
 	// Submit and wait for it to complete
-	submitResult, err := client.SubmitTransaction(signedTxn)
+	submitResult, err := client.SubmitTransaction(context.Background(), signedTxn)
 	if err != nil {
 		panic("Failed to submit transaction:" + err.Error())
 	}
@@ -147,7 +149,7 @@ func example(networkConfig aptos.NetworkConfig) {
 
 	// Wait for the transaction
 	fmt.Printf("And we wait for the transaction %s to complete...\n", txnHash)
-	userTxn, err := client.WaitForTransaction(txnHash)
+	userTxn, err := client.WaitForTransaction(context.Background(), txnHash)
 	if err != nil {
 		panic("Failed to wait for transaction:" + err.Error())
 	}

--- a/examples/fungible_asset/main.go
+++ b/examples/fungible_asset/main.go
@@ -2,8 +2,10 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/aptos-labs/aptos-go-sdk/bcs"
 	"github.com/aptos-labs/aptos-go-sdk/crypto"
@@ -38,7 +40,7 @@ func example(networkConfig aptos.NetworkConfig) {
 
 	// Fund the sender with the faucet to create it on-chain
 	println("SENDER: ", sender.Address.String())
-	err = client.Fund(sender.Address, FundAmount)
+	err = client.Fund(context.Background(), sender.Address, FundAmount)
 	if err != nil {
 		panic("Failed to fund sender:" + err.Error())
 	}
@@ -50,11 +52,11 @@ func example(networkConfig aptos.NetworkConfig) {
 	if err != nil {
 		panic("Failed to create publish payload:" + err.Error())
 	}
-	response, err := client.BuildSignAndSubmitTransaction(sender, *payload)
+	response, err := client.BuildSignAndSubmitTransaction(context.Background(), sender, *payload)
 	if err != nil {
 		panic("Failed to build sign and submit publish transaction:" + err.Error())
 	}
-	waitResponse, err := client.WaitForTransaction(response.Hash)
+	waitResponse, err := client.WaitForTransaction(context.Background(), response.Hash)
 	if err != nil {
 		panic("Failed to wait for publish transaction:" + err.Error())
 	}
@@ -66,7 +68,7 @@ func example(networkConfig aptos.NetworkConfig) {
 	// Get the fungible asset address by view function
 	rupeeModule := aptos.ModuleId{Address: sender.Address, Name: "rupee"}
 	var noTypeTags []aptos.TypeTag
-	viewResponse, err := client.View(&aptos.ViewPayload{
+	viewResponse, err := client.View(context.Background(), &aptos.ViewPayload{
 		Module:   rupeeModule,
 		Function: "fa_address",
 		ArgTypes: noTypeTags,
@@ -85,7 +87,7 @@ func example(networkConfig aptos.NetworkConfig) {
 		panic("Failed to create fungible asset client:" + err.Error())
 	}
 
-	beforeBalance, err := faClient.PrimaryBalance(&sender.Address)
+	beforeBalance, err := faClient.PrimaryBalance(context.Background(), &sender.Address)
 	if err != nil {
 		panic("Failed to get balance:" + err.Error())
 	}
@@ -96,7 +98,7 @@ func example(networkConfig aptos.NetworkConfig) {
 		panic("Failed to serialize amount:" + err.Error())
 	}
 	serializedSenderAddress, _ := bcs.Serialize(&sender.Address) // This can't fail
-	response, err = client.BuildSignAndSubmitTransaction(sender, aptos.TransactionPayload{
+	response, err = client.BuildSignAndSubmitTransaction(context.Background(), sender, aptos.TransactionPayload{
 		Payload: &aptos.EntryFunction{
 			Module:   rupeeModule,
 			Function: "mint",
@@ -108,12 +110,12 @@ func example(networkConfig aptos.NetworkConfig) {
 		panic("Failed to build sign and submit mint transaction:" + err.Error())
 	}
 	fmt.Printf("Submitted mint as: %s\n", response.Hash)
-	_, err = client.WaitForTransaction(response.Hash)
+	_, err = client.WaitForTransaction(context.Background(), response.Hash)
 	if err != nil {
 		panic("Failed to wait for publish transaction:" + err.Error())
 	}
 
-	afterBalance, err := faClient.PrimaryBalance(&sender.Address)
+	afterBalance, err := faClient.PrimaryBalance(context.Background(), &sender.Address)
 	if err != nil {
 		panic("Failed to get balance:" + err.Error())
 	}
@@ -127,24 +129,24 @@ func example(networkConfig aptos.NetworkConfig) {
 	}
 
 	// Transfer some to 0xCAFE
-	receiverBeforeBalance, err := faClient.PrimaryBalance(receiver)
+	receiverBeforeBalance, err := faClient.PrimaryBalance(context.Background(), receiver)
 	if err != nil {
 		panic("Failed to get balance:" + err.Error())
 	}
-	transferTxn, err := faClient.TransferPrimaryStore(sender, *receiver, TransferAmount)
+	transferTxn, err := faClient.TransferPrimaryStore(context.Background(), sender, *receiver, TransferAmount)
 	if err != nil {
 		panic("Failed to create primary store transfer transaction:" + err.Error())
 	}
-	response, err = client.SubmitTransaction(transferTxn)
+	response, err = client.SubmitTransaction(context.Background(), transferTxn)
 	if err != nil {
 		panic("Failed to submit transaction:" + err.Error())
 	}
 	fmt.Printf("Submitted transfer as: %s\n", response.Hash)
-	err = client.PollForTransactions([]string{response.Hash})
+	err = client.PollForTransactions(context.Background(), []string{response.Hash})
 	if err != nil {
 		panic("Failed to wait for transaction:" + err.Error())
 	}
-	receiverAfterBalance, err := faClient.PrimaryBalance(receiver)
+	receiverAfterBalance, err := faClient.PrimaryBalance(context.Background(), receiver)
 	if err != nil {
 		panic("Failed to get store balance:" + err.Error())
 	}
@@ -155,7 +157,7 @@ func example(networkConfig aptos.NetworkConfig) {
 	fmt.Printf("\n== Now running script version ==\n")
 	runScript(client, sender, receiver, faMetadataAddress)
 
-	receiverAfterAfterBalance, err := faClient.PrimaryBalance(receiver)
+	receiverAfterAfterBalance, err := faClient.PrimaryBalance(context.Background(), receiver)
 	if err != nil {
 		panic("Failed to get store balance:" + err.Error())
 	}
@@ -171,7 +173,7 @@ func runScript(client *aptos.Client, alice *aptos.Account, bob *aptos.AccountAdd
 	}
 
 	// 1. Build transaction
-	rawTxn, err := client.BuildTransaction(alice.AccountAddress(), aptos.TransactionPayload{
+	rawTxn, err := client.BuildTransaction(context.Background(), alice.AccountAddress(), aptos.TransactionPayload{
 		Payload: &aptos.Script{
 			Code:     scriptBytes,
 			ArgTypes: []aptos.TypeTag{},
@@ -191,7 +193,7 @@ func runScript(client *aptos.Client, alice *aptos.Account, bob *aptos.AccountAdd
 	// This is useful for understanding how much the transaction will cost
 	// and to ensure that the transaction is valid before sending it to the network
 	// This is optional, but recommended
-	simulationResult, err := client.SimulateTransaction(rawTxn, alice)
+	simulationResult, err := client.SimulateTransaction(context.Background(), rawTxn, alice)
 	if err != nil {
 		panic("Failed to simulate transaction:" + err.Error())
 	}
@@ -208,14 +210,14 @@ func runScript(client *aptos.Client, alice *aptos.Account, bob *aptos.AccountAdd
 	}
 
 	// 4. Submit transaction
-	submitResult, err := client.SubmitTransaction(signedTxn)
+	submitResult, err := client.SubmitTransaction(context.Background(), signedTxn)
 	if err != nil {
 		panic("Failed to submit transaction:" + err.Error())
 	}
 	txnHash := submitResult.Hash
 
 	// 5. Wait for the transaction to complete
-	_, err = client.WaitForTransaction(txnHash)
+	_, err = client.WaitForTransaction(context.Background(), txnHash)
 	if err != nil {
 		panic("Failed to wait for transaction:" + err.Error())
 	}

--- a/examples/multi_agent/main.go
+++ b/examples/multi_agent/main.go
@@ -2,7 +2,9 @@
 package main
 
 import (
+	"context"
 	"fmt"
+
 	"github.com/aptos-labs/aptos-go-sdk/crypto"
 	"github.com/aptos-labs/aptos-go-sdk/internal/util"
 
@@ -37,19 +39,19 @@ func example(networkConfig aptos.NetworkConfig) {
 	fmt.Printf("Bob:%s\n", bob.Address.String())
 
 	// Fund the sender with the faucet to create it on-chain
-	err = client.Fund(alice.Address, FundAmount)
+	err = client.Fund(context.Background(), alice.Address, FundAmount)
 	if err != nil {
 		panic("Failed to fund alice:" + err.Error())
 	}
-	err = client.Fund(bob.Address, FundAmount)
+	err = client.Fund(context.Background(), bob.Address, FundAmount)
 	if err != nil {
 		panic("Failed to fund bob:" + err.Error())
 	}
-	aliceBalance, err := client.AccountAPTBalance(alice.Address)
+	aliceBalance, err := client.AccountAPTBalance(context.Background(), alice.Address)
 	if err != nil {
 		panic("Failed to retrieve alice balance:" + err.Error())
 	}
-	bobBalance, err := client.AccountAPTBalance(bob.Address)
+	bobBalance, err := client.AccountAPTBalance(context.Background(), bob.Address)
 	if err != nil {
 		panic("Failed to retrieve bob balance:" + err.Error())
 	}
@@ -62,7 +64,7 @@ func example(networkConfig aptos.NetworkConfig) {
 	if err != nil {
 		panic("Failed to deserialize script:" + err.Error())
 	}
-	rawTxn, err := client.BuildTransactionMultiAgent(alice.AccountAddress(), aptos.TransactionPayload{
+	rawTxn, err := client.BuildTransactionMultiAgent(context.Background(), alice.AccountAddress(), aptos.TransactionPayload{
 		Payload: &aptos.Script{
 			Code:     script,
 			ArgTypes: []aptos.TypeTag{aptos.AptosCoinTypeTag, aptos.AptosCoinTypeTag},
@@ -113,24 +115,24 @@ func example(networkConfig aptos.NetworkConfig) {
 	}
 
 	// 4. Submit transaction
-	submitResult, err := client.SubmitTransaction(signedTxn)
+	submitResult, err := client.SubmitTransaction(context.Background(), signedTxn)
 	if err != nil {
 		panic("Failed to submit transaction:" + err.Error())
 	}
 	txnHash := submitResult.Hash
 
 	// 5. Wait for the transaction to complete
-	_, err = client.WaitForTransaction(txnHash)
+	_, err = client.WaitForTransaction(context.Background(), txnHash)
 	if err != nil {
 		panic("Failed to wait for transaction:" + err.Error())
 	}
 
 	// Check balances
-	aliceBalance, err = client.AccountAPTBalance(alice.Address)
+	aliceBalance, err = client.AccountAPTBalance(context.Background(), alice.Address)
 	if err != nil {
 		panic("Failed to retrieve alice balance:" + err.Error())
 	}
-	bobBalance, err = client.AccountAPTBalance(bob.Address)
+	bobBalance, err = client.AccountAPTBalance(context.Background(), bob.Address)
 	if err != nil {
 		panic("Failed to retrieve bob balance:" + err.Error())
 	}

--- a/examples/offchain_multisig/main.go
+++ b/examples/offchain_multisig/main.go
@@ -2,7 +2,9 @@
 package main
 
 import (
+	"context"
 	"fmt"
+
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/aptos-labs/aptos-go-sdk/bcs"
 	"github.com/aptos-labs/aptos-go-sdk/crypto"
@@ -183,20 +185,20 @@ func example(networkConfig aptos.NetworkConfig) {
 	}
 
 	// Fund the sender with the faucet to create it on-chain
-	err = client.Fund(alice.AccountAddress(), TransferAmount)
+	err = client.Fund(context.Background(), alice.AccountAddress(), TransferAmount)
 	if err != nil {
 		panic("Failed to fund alice:" + err.Error())
 	}
-	err = client.Fund(multikeySigner.AccountAddress(), FundAmount)
+	err = client.Fund(context.Background(), multikeySigner.AccountAddress(), FundAmount)
 	if err != nil {
 		panic("Failed to fund multikey:" + err.Error())
 	}
 
-	aliceBalance, err := client.AccountAPTBalance(alice.Address)
+	aliceBalance, err := client.AccountAPTBalance(context.Background(), alice.Address)
 	if err != nil {
 		panic("Failed to retrieve alice balance:" + err.Error())
 	}
-	multikeyBalance, err := client.AccountAPTBalance(multikeySigner.AccountAddress())
+	multikeyBalance, err := client.AccountAPTBalance(context.Background(), multikeySigner.AccountAddress())
 	if err != nil {
 		panic("Failed to retrieve multikey balance:" + err.Error())
 	}
@@ -215,7 +217,7 @@ func example(networkConfig aptos.NetworkConfig) {
 	if err != nil {
 		panic("Failed to serialize transfer amount:" + err.Error())
 	}
-	rawTxn, err := client.BuildTransaction(multikeyAddress, aptos.TransactionPayload{
+	rawTxn, err := client.BuildTransaction(context.Background(), multikeyAddress, aptos.TransactionPayload{
 		Payload: &aptos.EntryFunction{
 			Module: aptos.ModuleId{
 				Address: aptos.AccountOne,
@@ -257,24 +259,24 @@ func example(networkConfig aptos.NetworkConfig) {
 	}
 
 	// 4. Submit transaction
-	submitResult, err := client.SubmitTransaction(signedTxn)
+	submitResult, err := client.SubmitTransaction(context.Background(), signedTxn)
 	if err != nil {
 		panic("Failed to submit transaction:" + err.Error())
 	}
 	txnHash := submitResult.Hash
 
 	// 5. Wait for the transaction to complete
-	_, err = client.WaitForTransaction(txnHash)
+	_, err = client.WaitForTransaction(context.Background(), txnHash)
 	if err != nil {
 		panic("Failed to wait for transaction:" + err.Error())
 	}
 
 	// Check balances
-	aliceBalance, err = client.AccountAPTBalance(alice.Address)
+	aliceBalance, err = client.AccountAPTBalance(context.Background(), alice.Address)
 	if err != nil {
 		panic("Failed to retrieve alice balance:" + err.Error())
 	}
-	multikeyBalance, err = client.AccountAPTBalance(multikeyAddress)
+	multikeyBalance, err = client.AccountAPTBalance(context.Background(), multikeyAddress)
 	if err != nil {
 		panic("Failed to retrieve bob balance:" + err.Error())
 	}

--- a/examples/onchain_multisig/main.go
+++ b/examples/onchain_multisig/main.go
@@ -2,12 +2,14 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/aptos-labs/aptos-go-sdk/api"
 	"github.com/aptos-labs/aptos-go-sdk/bcs"
-	"time"
 )
 
 const TransferAmount = uint64(1_000_000)
@@ -112,7 +114,7 @@ func example(networkConfig aptos.NetworkConfig) {
 }
 
 func assertBalance(client *aptos.Client, address aptos.AccountAddress, expectedBalance uint64) {
-	amount, err := client.AccountAPTBalance(address)
+	amount, err := client.AccountAPTBalance(context.Background(), address)
 	if err != nil {
 		panic("failed to get balance: " + err.Error())
 	}
@@ -135,7 +137,7 @@ func generateOwnerAccounts() []*aptos.Account {
 
 func fundAccounts(client *aptos.Client, accounts []*aptos.AccountAddress) {
 	for _, account := range accounts {
-		err := client.Fund(*account, 100_000_000)
+		err := client.Fund(context.Background(), *account, 100_000_000)
 		if err != nil {
 			panic("Failed to fund account " + err.Error())
 		}
@@ -149,7 +151,7 @@ func setUpMultisig(client *aptos.Client, accounts []*aptos.Account) *aptos.Accou
 	// ===========================================================================================
 	// Get the next multisig account address. This will be the same as the account address of the multisig account we'll
 	// be creating.
-	multisigAddress, err := client.FetchNextMultisigAddress(accounts[0].Address)
+	multisigAddress, err := client.FetchNextMultisigAddress(context.Background(), accounts[0].Address)
 	if err != nil {
 		panic("Failed to fetch next multisig address: " + err.Error())
 	}
@@ -193,7 +195,7 @@ func createMultisig(client *aptos.Client, account *aptos.Account, additionalAddr
 
 // TODO: This should be a view function
 func multisigResource(client *aptos.Client, multisigAddress *aptos.AccountAddress) (uint64, []any) {
-	resource, err := client.AccountResource(*multisigAddress, "0x1::multisig_account::MultisigAccount")
+	resource, err := client.AccountResource(context.Background(), *multisigAddress, "0x1::multisig_account::MultisigAccount")
 	if err != nil {
 		panic("Failed to get resource for multisig account: " + err.Error())
 	}
@@ -300,12 +302,12 @@ func executeTransaction(client *aptos.Client, multisigAddress aptos.AccountAddre
 }
 
 func submitAndWait(client *aptos.Client, sender *aptos.Account, payload aptos.TransactionPayloadImpl) *api.UserTransaction {
-	submitResponse, err := client.BuildSignAndSubmitTransaction(sender, aptos.TransactionPayload{Payload: payload})
+	submitResponse, err := client.BuildSignAndSubmitTransaction(context.Background(), sender, aptos.TransactionPayload{Payload: payload})
 	if err != nil {
 		panic("Failed to submit transaction: " + err.Error())
 	}
 
-	txn, err := client.WaitForTransaction(submitResponse.Hash)
+	txn, err := client.WaitForTransaction(context.Background(), submitResponse.Hash)
 	if err != nil {
 		panic("Failed to wait for transaction: " + err.Error())
 	}

--- a/examples/performance_transaction/main.go
+++ b/examples/performance_transaction/main.go
@@ -2,9 +2,11 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
-	"github.com/aptos-labs/aptos-go-sdk"
 	"time"
+
+	"github.com/aptos-labs/aptos-go-sdk"
 )
 
 // example This example shows you how to improve performance of the transaction submission
@@ -31,7 +33,7 @@ func example(networkConfig aptos.NetworkConfig) {
 	before = time.Now()
 
 	// Fund the sender with the faucet to create it on-chain
-	err = client.Fund(sender.Address, 100_000_000)
+	err = client.Fund(context.Background(), sender.Address, 100_000_000)
 
 	println("Fund sender:", time.Since(before).Milliseconds(), "ms")
 
@@ -51,7 +53,7 @@ func example(networkConfig aptos.NetworkConfig) {
 		panic("Failed to serialize arguments:" + err.Error())
 	}
 
-	rawTxn, err := client.BuildTransaction(sender.Address,
+	rawTxn, err := client.BuildTransaction(context.Background(), sender.Address,
 		aptos.TransactionPayload{Payload: payload}, aptos.SequenceNumber(0)) // Use the sequence number to skip fetching it
 	if err != nil {
 		panic("Failed to build transaction:" + err.Error())
@@ -70,7 +72,7 @@ func example(networkConfig aptos.NetworkConfig) {
 	println("Sign transaction:", time.Since(before).Milliseconds(), "ms")
 
 	before = time.Now()
-	submitResult, err := client.SubmitTransaction(signedTxn)
+	submitResult, err := client.SubmitTransaction(context.Background(), signedTxn)
 	if err != nil {
 		panic("Failed to submit transaction:" + err.Error())
 	}
@@ -79,7 +81,7 @@ func example(networkConfig aptos.NetworkConfig) {
 
 	// Wait for the transaction
 	before = time.Now()
-	txn, err := client.WaitForTransaction(txnHash)
+	txn, err := client.WaitForTransaction(context.Background(), txnHash)
 	if err != nil {
 		panic("Failed to wait for transaction:" + err.Error())
 	}

--- a/examples/sponsored_transaction/main.go
+++ b/examples/sponsored_transaction/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aptos-labs/aptos-go-sdk"
@@ -39,26 +40,26 @@ func example(networkConfig aptos.NetworkConfig) {
 	fmt.Printf("Sponsor:%s\n", sponsor.Address.String())
 
 	// Fund the alice with the faucet to create it on-chain
-	err = client.Fund(alice.Address, FundAmount)
+	err = client.Fund(context.Background(), alice.Address, FundAmount)
 	if err != nil {
 		panic("Failed to fund alice:" + err.Error())
 	}
 
 	// And the sponsor
-	err = client.Fund(sponsor.Address, FundAmount)
+	err = client.Fund(context.Background(), sponsor.Address, FundAmount)
 	if err != nil {
 		panic("Failed to fund sponsor:" + err.Error())
 	}
 
-	aliceBalance, err := client.AccountAPTBalance(alice.Address)
+	aliceBalance, err := client.AccountAPTBalance(context.Background(), alice.Address)
 	if err != nil {
 		panic("Failed to retrieve alice balance:" + err.Error())
 	}
-	bobBalance, err := client.AccountAPTBalance(bob.Address)
+	bobBalance, err := client.AccountAPTBalance(context.Background(), bob.Address)
 	if err != nil {
 		panic("Failed to retrieve bob balance:" + err.Error())
 	}
-	sponsorBalance, err := client.AccountAPTBalance(sponsor.Address)
+	sponsorBalance, err := client.AccountAPTBalance(context.Background(), sponsor.Address)
 	if err != nil {
 		panic("Failed to retrieve sponsor balance:" + err.Error())
 	}
@@ -73,6 +74,7 @@ func example(networkConfig aptos.NetworkConfig) {
 		panic("Failed to build transfer payload:" + err.Error())
 	}
 	rawTxn, err := client.BuildTransactionMultiAgent(
+		context.Background(),
 		alice.Address,
 		aptos.TransactionPayload{
 			Payload: transferPayload,
@@ -103,7 +105,7 @@ func example(networkConfig aptos.NetworkConfig) {
 	}
 
 	// Submit and wait for it to complete
-	submitResult, err := client.SubmitTransaction(signedFeePayerTxn)
+	submitResult, err := client.SubmitTransaction(context.Background(), signedFeePayerTxn)
 	if err != nil {
 		panic("Failed to submit transaction:" + err.Error())
 	}
@@ -111,19 +113,19 @@ func example(networkConfig aptos.NetworkConfig) {
 	println("Submitted transaction hash:", txnHash)
 
 	// Wait for the transaction
-	_, err = client.WaitForTransaction(txnHash)
+	_, err = client.WaitForTransaction(context.Background(), txnHash)
 	if err != nil {
 		panic("Failed to wait for transaction:" + err.Error())
 	}
-	aliceBalance, err = client.AccountAPTBalance(alice.Address)
+	aliceBalance, err = client.AccountAPTBalance(context.Background(), alice.Address)
 	if err != nil {
 		panic("Failed to retrieve alice balance:" + err.Error())
 	}
-	bobBalance, err = client.AccountAPTBalance(bob.Address)
+	bobBalance, err = client.AccountAPTBalance(context.Background(), bob.Address)
 	if err != nil {
 		panic("Failed to retrieve bob balance:" + err.Error())
 	}
-	sponsorBalance, err = client.AccountAPTBalance(sponsor.Address)
+	sponsorBalance, err = client.AccountAPTBalance(context.Background(), sponsor.Address)
 	if err != nil {
 		panic("Failed to retrieve sponsor balance:" + err.Error())
 	}
@@ -135,6 +137,7 @@ func example(networkConfig aptos.NetworkConfig) {
 	fmt.Printf("\n=== Now do it without knowing the signer ahead of time ===\n")
 
 	rawTxn, err = client.BuildTransactionMultiAgent(
+		context.Background(),
 		alice.Address,
 		aptos.TransactionPayload{
 			Payload: transferPayload,
@@ -173,7 +176,7 @@ func example(networkConfig aptos.NetworkConfig) {
 	}
 
 	// Submit and wait for it to complete
-	submitResult, err = client.SubmitTransaction(signedFeePayerTxn)
+	submitResult, err = client.SubmitTransaction(context.Background(), signedFeePayerTxn)
 	if err != nil {
 		panic("Failed to submit transaction:" + err.Error())
 	}
@@ -181,19 +184,19 @@ func example(networkConfig aptos.NetworkConfig) {
 	println("Submitted transaction hash:", txnHash)
 
 	// Wait for the transaction
-	_, err = client.WaitForTransaction(txnHash)
+	_, err = client.WaitForTransaction(context.Background(), txnHash)
 	if err != nil {
 		panic("Failed to wait for transaction:" + err.Error())
 	}
-	aliceBalance, err = client.AccountAPTBalance(alice.Address)
+	aliceBalance, err = client.AccountAPTBalance(context.Background(), alice.Address)
 	if err != nil {
 		panic("Failed to retrieve alice balance:" + err.Error())
 	}
-	bobBalance, err = client.AccountAPTBalance(bob.Address)
+	bobBalance, err = client.AccountAPTBalance(context.Background(), bob.Address)
 	if err != nil {
 		panic("Failed to retrieve bob balance:" + err.Error())
 	}
-	sponsorBalance, err = client.AccountAPTBalance(sponsor.Address)
+	sponsorBalance, err = client.AccountAPTBalance(context.Background(), sponsor.Address)
 	if err != nil {
 		panic("Failed to retrieve sponsor balance:" + err.Error())
 	}

--- a/examples/transfer_coin/main.go
+++ b/examples/transfer_coin/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aptos-labs/aptos-go-sdk"
@@ -34,16 +35,16 @@ func example(networkConfig aptos.NetworkConfig) {
 	fmt.Printf("Bob:%s\n", bob.Address.String())
 
 	// Fund the sender with the faucet to create it on-chain
-	err = client.Fund(alice.Address, FundAmount)
+	err = client.Fund(context.Background(), alice.Address, FundAmount)
 	if err != nil {
 		panic("Failed to fund alice:" + err.Error())
 	}
 
-	aliceBalance, err := client.AccountAPTBalance(alice.Address)
+	aliceBalance, err := client.AccountAPTBalance(context.Background(), alice.Address)
 	if err != nil {
 		panic("Failed to retrieve alice balance:" + err.Error())
 	}
-	bobBalance, err := client.AccountAPTBalance(bob.Address)
+	bobBalance, err := client.AccountAPTBalance(context.Background(), bob.Address)
 	if err != nil {
 		panic("Failed to retrieve bob balance:" + err.Error())
 	}
@@ -61,7 +62,7 @@ func example(networkConfig aptos.NetworkConfig) {
 	if err != nil {
 		panic("Failed to serialize transfer amount:" + err.Error())
 	}
-	rawTxn, err := client.BuildTransaction(alice.AccountAddress(), aptos.TransactionPayload{
+	rawTxn, err := client.BuildTransaction(context.Background(), alice.AccountAddress(), aptos.TransactionPayload{
 		Payload: &aptos.EntryFunction{
 			Module: aptos.ModuleId{
 				Address: aptos.AccountOne,
@@ -84,7 +85,7 @@ func example(networkConfig aptos.NetworkConfig) {
 	// This is useful for understanding how much the transaction will cost
 	// and to ensure that the transaction is valid before sending it to the network
 	// This is optional, but recommended
-	simulationResult, err := client.SimulateTransaction(rawTxn, alice)
+	simulationResult, err := client.SimulateTransaction(context.Background(), rawTxn, alice)
 	if err != nil {
 		panic("Failed to simulate transaction:" + err.Error())
 	}
@@ -101,24 +102,24 @@ func example(networkConfig aptos.NetworkConfig) {
 	}
 
 	// 4. Submit transaction
-	submitResult, err := client.SubmitTransaction(signedTxn)
+	submitResult, err := client.SubmitTransaction(context.Background(), signedTxn)
 	if err != nil {
 		panic("Failed to submit transaction:" + err.Error())
 	}
 	txnHash := submitResult.Hash
 
 	// 5. Wait for the transaction to complete
-	_, err = client.WaitForTransaction(txnHash)
+	_, err = client.WaitForTransaction(context.Background(), txnHash)
 	if err != nil {
 		panic("Failed to wait for transaction:" + err.Error())
 	}
 
 	// Check balances
-	aliceBalance, err = client.AccountAPTBalance(alice.Address)
+	aliceBalance, err = client.AccountAPTBalance(context.Background(), alice.Address)
 	if err != nil {
 		panic("Failed to retrieve alice balance:" + err.Error())
 	}
-	bobBalance, err = client.AccountAPTBalance(bob.Address)
+	bobBalance, err = client.AccountAPTBalance(context.Background(), bob.Address)
 	if err != nil {
 		panic("Failed to retrieve bob balance:" + err.Error())
 	}
@@ -127,7 +128,7 @@ func example(networkConfig aptos.NetworkConfig) {
 	fmt.Printf("Bob:%d\n", bobBalance)
 
 	// Now do it again, but with a different method
-	resp, err := client.BuildSignAndSubmitTransaction(alice, aptos.TransactionPayload{
+	resp, err := client.BuildSignAndSubmitTransaction(context.Background(), alice, aptos.TransactionPayload{
 		Payload: &aptos.EntryFunction{
 			Module: aptos.ModuleId{
 				Address: aptos.AccountOne,
@@ -145,16 +146,16 @@ func example(networkConfig aptos.NetworkConfig) {
 		panic("Failed to sign transaction:" + err.Error())
 	}
 
-	_, err = client.WaitForTransaction(resp.Hash)
+	_, err = client.WaitForTransaction(context.Background(), resp.Hash)
 	if err != nil {
 		panic("Failed to wait for transaction:" + err.Error())
 	}
 
-	aliceBalance, err = client.AccountAPTBalance(alice.Address)
+	aliceBalance, err = client.AccountAPTBalance(context.Background(), alice.Address)
 	if err != nil {
 		panic("Failed to retrieve alice balance:" + err.Error())
 	}
-	bobBalance, err = client.AccountAPTBalance(bob.Address)
+	bobBalance, err = client.AccountAPTBalance(context.Background(), bob.Address)
 	if err != nil {
 		panic("Failed to retrieve bob balance:" + err.Error())
 	}

--- a/multisig.go
+++ b/multisig.go
@@ -1,10 +1,14 @@
 package aptos
 
-import "github.com/aptos-labs/aptos-go-sdk/bcs"
+import (
+	"context"
+
+	"github.com/aptos-labs/aptos-go-sdk/bcs"
+)
 
 // FetchNextMultisigAddress retrieves the next multisig address to be created from the given account
-func (client *Client) FetchNextMultisigAddress(address AccountAddress) (*AccountAddress, error) {
-	viewResponse, err := client.View(&ViewPayload{
+func (client *Client) FetchNextMultisigAddress(ctx context.Context, address AccountAddress) (*AccountAddress, error) {
+	viewResponse, err := client.View(ctx, &ViewPayload{
 		Module: ModuleId{
 			Address: AccountOne,
 			Name:    "multisig_account",

--- a/nodeClient_test.go
+++ b/nodeClient_test.go
@@ -1,9 +1,11 @@
 package aptos
 
 import (
-	"github.com/stretchr/testify/assert"
+	"context"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPollForTransaction(t *testing.T) {
@@ -13,7 +15,7 @@ func TestPollForTransaction(t *testing.T) {
 	assert.NoError(t, err)
 
 	start := time.Now()
-	err = client.PollForTransactions([]string{"alice", "bob"}, PollTimeout(10*time.Millisecond), PollPeriod(2*time.Millisecond))
+	err = client.PollForTransactions(context.Background(), []string{"alice", "bob"}, PollTimeout(10*time.Millisecond), PollPeriod(2*time.Millisecond))
 	dt := time.Now().Sub(start)
 
 	assert.GreaterOrEqual(t, dt, 9*time.Millisecond)


### PR DESCRIPTION
### Description
This PR exposes the `context.Context` parameter, allowing users to have more granular control over request duration management. The changes are minimal and strictly limited to exposing the context.Context without modifying existing logic.

### Test Plan
- Invoke the method with a `context.Context` that has a timeout.
- Verify that the request is canceled after the timeout expires.

### Related Links
#95 