### PR TITLE
Fix memory leak on read error

### DIFF
--- a/nodeClient.go
+++ b/nodeClient.go
@@ -1051,11 +1051,11 @@ func Get[T any](rc *NodeClient, getUrl string) (out T, err error) {
 		err = NewHttpError(response)
 		return out, err
 	}
+	defer response.Body.Close()
 	blob, err := io.ReadAll(response.Body)
 	if err != nil {
 		return out, fmt.Errorf("error getting response data, %w", err)
 	}
-	_ = response.Body.Close()
 	err = json.Unmarshal(blob, &out)
 	if err != nil {
 		return out, err
@@ -1086,12 +1086,12 @@ func (rc *NodeClient) GetBCS(getUrl string) (out []byte, err error) {
 		err = NewHttpError(response)
 		return
 	}
+	defer response.Body.Close()
 	blob, err := io.ReadAll(response.Body)
 	if err != nil {
 		err = fmt.Errorf("error getting response data, %w", err)
 		return
 	}
-	_ = response.Body.Close()
 	return blob, nil
 }
 
@@ -1121,12 +1121,12 @@ func Post[T any](rc *NodeClient, postUrl string, contentType string, body io.Rea
 		err = NewHttpError(response)
 		return data, err
 	}
+	defer response.Body.Close()
 	blob, err := io.ReadAll(response.Body)
 	if err != nil {
 		err = fmt.Errorf("error getting response data, %w", err)
 		return data, err
 	}
-	_ = response.Body.Close()
 
 	err = json.Unmarshal(blob, &data)
 	return data, err


### PR DESCRIPTION
### Description
This PR fixes a potential memory leak that occurs when a read error happens while processing the response body.

According to the [net/http package documentation](https://pkg.go.dev/net/http):

The caller must close the response body when finished with it.

Failing to close the response body on read errors can lead to resource leaks. This change ensures proper cleanup in such cases.


### Test Plan
Testing this issue is not straightforward, as it depends on network failures. The read operation may return an error, as seen in the [Go source reference](https://github.com/golang/go/blob/11f7ea8ce045c27956fcbffcc98e8987f9fb9743/src/net/http/response.go#L72).

One way to simulate this in a controlled environment is by setting an invalid Content-Length in the response header on the server side, forcing a read error:
```
handler := func(w http.ResponseWriter, r *http.Request) {
    w.Header().Set("Content-Length", "1")
}
```
This should trigger an unexpected EOF error when reading the response body.
### Related Links
None.