### PR TITLE
Add Configurable Worker Pool for Transaction Processing

### DIFF
--- a/integration_test/transactionSubmission/multi_sender_test.go
+++ b/integration_test/transactionSubmission/multi_sender_test.go
@@ -1,0 +1,97 @@
+package integration_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/internal/testutil"
+)
+
+func TestBuildSignAndSubmitTransactionsWithSignFnAndWorkerPoolWithMultipleSenders(t *testing.T) {
+	const (
+		numSenders      = 3
+		txPerSender     = 5
+		initialFunding  = uint64(100_000_000)
+		transfer_amount = uint64(100)
+	)
+
+	clients := testutil.SetupTestClients(t)
+
+	// Create and fund senders
+	senders := make([]testutil.TestAccount, numSenders)
+	for i := 0; i < numSenders; i++ {
+		senders[i] = testutil.SetupTestAccount(t, clients.Client, initialFunding)
+	}
+
+	receiver := testutil.SetupTestAccount(t, clients.Client, 0)
+
+	startTime := time.Now()
+
+	// Process transactions for each sender
+	doneCh := make(chan struct{})
+
+	for senderIdx := 0; senderIdx < numSenders; senderIdx++ {
+		go func(senderIdx int) {
+			defer func() {
+				doneCh <- struct{}{}
+			}()
+
+			sender := senders[senderIdx]
+			payloads := make(chan aptos.TransactionBuildPayload, txPerSender)
+			responses := make(chan aptos.TransactionSubmissionResponse, txPerSender)
+
+			go clients.NodeClient.BuildSignAndSubmitTransactionsWithSignFnAndWorkerPool(
+				sender.Account.Address,
+				payloads,
+				responses,
+				func(rawTxn aptos.RawTransactionImpl) (*aptos.SignedTransaction, error) {
+					switch txn := rawTxn.(type) {
+					case *aptos.RawTransaction:
+						return txn.SignedTransaction(sender.Account)
+					default:
+						return nil, fmt.Errorf("unsupported transaction type")
+					}
+				},
+				aptos.WorkerPoolConfig{NumWorkers: 3},
+			)
+
+			workerStartTime := time.Now()
+			for txNum := 0; txNum < txPerSender; txNum++ {
+				payload := testutil.CreateTransferPayload(t, receiver.Account.Address, transfer_amount)
+				payloads <- aptos.TransactionBuildPayload{
+					Id:    uint64(txNum),
+					Inner: payload,
+					Type:  aptos.TransactionSubmissionTypeSingle,
+				}
+			}
+			close(payloads)
+
+			for i := 0; i < txPerSender; i++ {
+				resp := <-responses
+				if resp.Err != nil {
+					t.Errorf("Transaction failed: %v", resp.Err)
+					continue
+				}
+				fmt.Printf("[%s] Worker %d → hash: %s\n",
+					time.Now().Format("15:04:05.000"),
+					senderIdx,
+					resp.Response.Hash)
+			}
+
+			fmt.Printf("[%s] Worker %d completed all transactions (t+%v)\n",
+				time.Now().Format("15:04:05.000"),
+				senderIdx,
+				time.Since(workerStartTime).Round(time.Millisecond))
+		}(senderIdx)
+	}
+
+	// Wait for all senders to complete
+	for i := 0; i < numSenders; i++ {
+		<-doneCh
+	}
+
+	duration := time.Since(startTime)
+	fmt.Printf("\nTotal Duration: %v\n", duration)
+}

--- a/integration_test/transactionSubmission/single_sender_test.go
+++ b/integration_test/transactionSubmission/single_sender_test.go
@@ -1,0 +1,72 @@
+package integration_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/internal/testutil"
+)
+
+func TestBuildSignAndSubmitTransactionsWithSignFnAndWorkerPoolWithOneSender(t *testing.T) {
+	const (
+		numTransactions = 5
+		transferAmount  = uint64(100)
+		numWorkers      = 3
+		initialFunding  = uint64(100_000_000)
+	)
+
+	clients := testutil.SetupTestClients(t)
+	sender := testutil.SetupTestAccount(t, clients.Client, initialFunding)
+	receiver := testutil.SetupTestAccount(t, clients.Client, 0)
+
+	payloads := make(chan aptos.TransactionBuildPayload, numTransactions)
+	responses := make(chan aptos.TransactionSubmissionResponse, numTransactions)
+	workerPoolConfig := aptos.WorkerPoolConfig{
+		NumWorkers:          numWorkers,
+		BuildResponseBuffer: numTransactions,
+		SubmissionBuffer:    numTransactions,
+	}
+
+	startTime := time.Now()
+
+	go clients.NodeClient.BuildSignAndSubmitTransactionsWithSignFnAndWorkerPool(
+		sender.Account.Address,
+		payloads,
+		responses,
+		func(rawTxn aptos.RawTransactionImpl) (*aptos.SignedTransaction, error) {
+			switch txn := rawTxn.(type) {
+			case *aptos.RawTransaction:
+				return txn.SignedTransaction(sender.Account)
+			default:
+				return nil, fmt.Errorf("unsupported transaction type")
+			}
+		},
+		workerPoolConfig,
+	)
+
+	for txNum := 0; txNum < numTransactions; txNum++ {
+		payload := testutil.CreateTransferPayload(t, receiver.Account.Address, transferAmount)
+		payloads <- aptos.TransactionBuildPayload{
+			Id:    uint64(txNum),
+			Inner: payload,
+			Type:  aptos.TransactionSubmissionTypeSingle,
+		}
+	}
+	close(payloads)
+
+	for i := 0; i < numTransactions; i++ {
+		resp := <-responses
+		if resp.Err != nil {
+			t.Errorf("Transaction failed: %v", resp.Err)
+			continue
+		}
+		fmt.Printf("[%s] hash: %s\n",
+			time.Now().Format("15:04:05.000"),
+			resp.Response.Hash)
+	}
+
+	duration := time.Since(startTime)
+	fmt.Printf("\nTotal Duration: %v\n", duration)
+}

--- a/internal/testutil/test_helpers.go
+++ b/internal/testutil/test_helpers.go
@@ -1,0 +1,74 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+)
+
+// TestClients holds the clients needed for testing
+type TestClients struct {
+	NodeClient *aptos.NodeClient
+	Client     *aptos.Client
+}
+
+func CreateTestClient() (*aptos.Client, error) {
+	return aptos.NewClient(aptos.DevnetConfig)
+}
+
+func CreateTestNodeClient() (*aptos.NodeClient, error) {
+	return aptos.NewNodeClient(aptos.DevnetConfig.NodeUrl, aptos.DevnetConfig.ChainId)
+}
+
+func SetupTestClients(t *testing.T) *TestClients {
+	nodeClient, err := CreateTestNodeClient()
+	if err != nil {
+		t.Fatalf("Failed to create NodeClient: %v", err)
+	}
+
+	client, err := CreateTestClient()
+	if err != nil {
+		t.Fatalf("Failed to create Client: %v", err)
+	}
+
+	return &TestClients{
+		NodeClient: nodeClient,
+		Client:     client,
+	}
+}
+
+func CreateTransferPayload(t *testing.T, receiver aptos.AccountAddress, amount uint64) aptos.TransactionPayload {
+	p, err := aptos.CoinTransferPayload(nil, receiver, amount)
+	if err != nil {
+		t.Fatalf("Failed to create transfer payload: %v", err)
+	}
+	return aptos.TransactionPayload{Payload: p}
+}
+
+// TestAccount represents a funded account for testing
+type TestAccount struct {
+	Account        *aptos.Account
+	InitialBalance uint64
+}
+
+func SetupTestAccount(t *testing.T, client *aptos.Client, funding uint64) TestAccount {
+	account, err := aptos.NewEd25519Account()
+	if err != nil {
+		t.Fatalf("Failed to create account: %v", err)
+	}
+
+	err = client.Fund(account.Address, funding)
+	if err != nil {
+		t.Fatalf("Failed to fund account: %v", err)
+	}
+
+	balance, err := client.AccountAPTBalance(account.Address)
+	if err != nil {
+		t.Fatalf("Failed to get initial balance: %v", err)
+	}
+
+	return TestAccount{
+		Account:        account,
+		InitialBalance: balance,
+	}
+}


### PR DESCRIPTION
## Description
PR addresses the TODO comment in `BuildSignAndSubmitTransactionsWithSignFunction` regarding configurable buffer sizes. 
- This provides more predictable resource control and memory usage.

### Test Plan

- Ran integration tests against Devnet

1. **Integration Tests**
   - Added two comprehensive integration tests in `integration_test/transactionSubmission/`
     - `TestBuildSignAndSubmitTransactionsWithSignFnAndWorkerPoolWithOneSender`
       - Tests single sender submitting multiple transactions
     - `TestBuildSignAndSubmitTransactionsWithSignFnAndWorkerPoolWithMultipleSenders`
       - Tests multiple concurrent senders

<img width="803" alt="Screenshot 2025-02-16 at 16 31 43" src="https://github.com/user-attachments/assets/85f56c2d-31e5-4df5-95ff-dc0fc6ddecc6" />
<img width="819" alt="Screenshot 2025-02-16 at 16 32 02" src="https://github.com/user-attachments/assets/fbd212cc-4c49-4b73-97a8-4e937e6c1f21" />

