### PR TITLE
Optimize WaitForTransaction

### DIFF
--- a/nodeClient.go
+++ b/nodeClient.go
@@ -328,17 +328,8 @@ func getTransactionPollOptions(defaultPeriod, defaultTimeout time.Duration, opti
 // Accepts options PollPeriod and PollTimeout which should wrap time.Duration values.
 // Not just a degenerate case of PollForTransactions, it may return additional information for the single transaction polled.
 func (rc *NodeClient) PollForTransaction(hash string, options ...any) (*api.UserTransaction, error) {
-	// Check if the transaction is already done
-	txn, err := rc.TransactionByHash(hash)
-	if err != nil {
-		return nil, err
-	}
-	if txn.Type == api.TransactionVariantUser {
-		return txn.UserTransaction()
-	}
-
 	// Wait for the transaction to be done
-	txn, err = rc.WaitTransactionByHash(hash)
+	txn, err := rc.WaitTransactionByHash(hash)
 	if err != nil {
 		return nil, err
 	}

--- a/nodeClient.go
+++ b/nodeClient.go
@@ -330,10 +330,7 @@ func getTransactionPollOptions(defaultPeriod, defaultTimeout time.Duration, opti
 func (rc *NodeClient) PollForTransaction(hash string, options ...any) (*api.UserTransaction, error) {
 	// Wait for the transaction to be done
 	txn, err := rc.WaitTransactionByHash(hash)
-	if err != nil {
-		return nil, err
-	}
-	if txn.Type == api.TransactionVariantUser {
+	if err == nil && txn.Type == api.TransactionVariantUser {
 		return txn.UserTransaction()
 	}
 


### PR DESCRIPTION
### Description
- Optimize WaitForTransaction.

Adopt the WaitForTransaction polling method implemented via [wait_by_hash api](https://aptos.dev/en/build/apis/fullnode-rest-api-reference#tag/transactions/GET/transactions/wait_by_hash/{txn_hash}) in the Typescript SDK.

However, there is a concern that this might conflict with the PR using Golang context for HTTP requests. 
In that case, a ctx should be accepted and used for polling.

### Test Plan
- Verify that WaitTransactionByHash operates correctly.
- Confirm that PollForTransaction produces the same results as before.

### Related Links
-  https://aptos.dev/en/build/apis/fullnode-rest-api-reference#tag/transactions/GET/transactions/wait_by_hash/{txn_hash}
-  https://github.com/aptos-labs/aptos-go-sdk/pull/128