### PR TITLE
[type conversion] Add ability to take in plain types and convert them…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 
 # Unreleased
 
+- [`Feature`] Add the ability for ABI simple type conversion of entry function arguments with both remote and local ABI
 - [`Fix`] Ensure proper cleanup of response body on read error to prevent potential memory leak.
 
 # v1.5.0 (2/10/2024)

--- a/bcs/serializer.go
+++ b/bcs/serializer.go
@@ -293,6 +293,13 @@ func SerializeU256(input big.Int) ([]byte, error) {
 	})
 }
 
+// SerializeUleb128 Serializes a single uleb128
+func SerializeUleb128(input uint32) ([]byte, error) {
+	return SerializeSingle(func(ser *Serializer) {
+		ser.Uleb128(input)
+	})
+}
+
 // SerializeBytes Serializes a single byte array
 //
 //	input := []byte{0x1, 0x2}

--- a/client.go
+++ b/client.go
@@ -899,3 +899,11 @@ func (client *Client) GetCoinBalances(address AccountAddress) ([]CoinBalance, er
 func (client *Client) NodeAPIHealthCheck(durationSecs ...uint64) (api.HealthCheckResponse, error) {
 	return client.nodeClient.NodeAPIHealthCheck(durationSecs...)
 }
+
+func (client *Client) AccountModule(address AccountAddress, moduleName string, ledgerVersion ...uint64) (data *api.MoveBytecode, err error) {
+	return client.nodeClient.AccountModule(address, moduleName, ledgerVersion...)
+}
+
+func (client *Client) EntryFunctionWithArgs(address AccountAddress, moduleName string, functionName string, typeArgs []any, args []any) (entry *EntryFunction, err error) {
+	return client.nodeClient.EntryFunctionWithArgs(address, moduleName, functionName, typeArgs, args)
+}

--- a/examples/local_abi/.gitignore
+++ b/examples/local_abi/.gitignore
@@ -1,0 +1,1 @@
+local_abi

--- a/examples/local_abi/main.go
+++ b/examples/local_abi/main.go
@@ -1,0 +1,165 @@
+// transfer_coin is an example of how to make a coin transfer transaction in the simplest possible way
+package main
+
+import (
+	"fmt"
+	"github.com/aptos-labs/aptos-go-sdk/api"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+)
+
+const FundAmount = 100_000_000
+const TransferAmount = 1_000
+
+// example This example shows you how to make an APT transfer transaction in the simplest possible way
+func example(networkConfig aptos.NetworkConfig) {
+	// Create a client for Aptos
+	client, err := aptos.NewClient(networkConfig)
+	if err != nil {
+		panic("Failed to create client:" + err.Error())
+	}
+
+	// Create accounts locally for alice and bob
+	alice, err := aptos.NewEd25519Account()
+	if err != nil {
+		panic("Failed to create alice:" + err.Error())
+	}
+	bob, err := aptos.NewEd25519Account()
+	if err != nil {
+		panic("Failed to create bob:" + err.Error())
+	}
+
+	fmt.Printf("\n=== Addresses ===\n")
+	fmt.Printf("Alice: %s\n", alice.Address.String())
+	fmt.Printf("Bob:%s\n", bob.Address.String())
+
+	// Fund the sender with the faucet to create it on-chain
+	err = client.Fund(alice.Address, FundAmount)
+	if err != nil {
+		panic("Failed to fund alice:" + err.Error())
+	}
+
+	aliceBalance, err := client.AccountAPTBalance(alice.Address)
+	if err != nil {
+		panic("Failed to retrieve alice balance:" + err.Error())
+	}
+	bobBalance, err := client.AccountAPTBalance(bob.Address)
+	if err != nil {
+		panic("Failed to retrieve bob balance:" + err.Error())
+	}
+	fmt.Printf("\n=== Initial Balances ===\n")
+	fmt.Printf("Alice: %d\n", aliceBalance)
+	fmt.Printf("Bob:%d\n", bobBalance)
+
+	// 1. Build transaction, with a single move function ABI
+	transferCoinsFunctionAbi := &api.MoveFunction{
+		Name:              "transfer_coins",
+		Visibility:        "public",
+		IsEntry:           true,
+		IsView:            false,
+		GenericTypeParams: []*api.GenericTypeParam{{Constraints: []api.MoveAbility{}}},
+		Params:            []string{"&signer", "address", "u64"},
+		Return:            []string{},
+	}
+
+	payload, err := aptos.EntryFunctionFromAbi(transferCoinsFunctionAbi, aptos.AccountOne, "aptos_account", "transfer_coins", []any{"0x1::aptos_coin::AptosCoin"}, []any{bob.Address, TransferAmount})
+	if err != nil {
+		panic("Failed to call EntryFunctionWithArgs:" + err.Error())
+	}
+	rawTxn, err := client.BuildTransaction(alice.AccountAddress(), aptos.TransactionPayload{
+		Payload: payload,
+	})
+
+	if err != nil {
+		panic("Failed to build transaction:" + err.Error())
+	}
+
+	// 2. Simulate transaction (optional)
+	// This is useful for understanding how much the transaction will cost
+	// and to ensure that the transaction is valid before sending it to the network
+	// This is optional, but recommended
+	simulationResult, err := client.SimulateTransaction(rawTxn, alice)
+	if err != nil {
+		panic("Failed to simulate transaction:" + err.Error())
+	}
+	fmt.Printf("\n=== Simulation ===\n")
+	fmt.Printf("Gas unit price: %d\n", simulationResult[0].GasUnitPrice)
+	fmt.Printf("Gas used: %d\n", simulationResult[0].GasUsed)
+	fmt.Printf("Total gas fee: %d\n", simulationResult[0].GasUsed*simulationResult[0].GasUnitPrice)
+	fmt.Printf("Status: %s\n", simulationResult[0].VmStatus)
+
+	// 3. Sign transaction
+	signedTxn, err := rawTxn.SignedTransaction(alice)
+	if err != nil {
+		panic("Failed to sign transaction:" + err.Error())
+	}
+
+	// 4. Submit transaction
+	submitResult, err := client.SubmitTransaction(signedTxn)
+	if err != nil {
+		panic("Failed to submit transaction:" + err.Error())
+	}
+	txnHash := submitResult.Hash
+
+	// 5. Wait for the transaction to complete
+	_, err = client.WaitForTransaction(txnHash)
+	if err != nil {
+		panic("Failed to wait for transaction:" + err.Error())
+	}
+
+	// Check balances
+	aliceBalance, err = client.AccountAPTBalance(alice.Address)
+	if err != nil {
+		panic("Failed to retrieve alice balance:" + err.Error())
+	}
+	bobBalance, err = client.AccountAPTBalance(bob.Address)
+	if err != nil {
+		panic("Failed to retrieve bob balance:" + err.Error())
+	}
+	fmt.Printf("\n=== Intermediate Balances ===\n")
+	fmt.Printf("Alice: %d\n", aliceBalance)
+	fmt.Printf("Bob:%d\n", bobBalance)
+
+	// Now do it again, but with a different function, with types
+
+	moduleAbi := &api.MoveModule{
+		Address:          &aptos.AccountOne,
+		Name:             "aptos_account",
+		Friends:          []string{},
+		ExposedFunctions: []*api.MoveFunction{transferCoinsFunctionAbi},
+		Structs:          []*api.MoveStruct{},
+	}
+
+	payload2, err := aptos.EntryFunctionFromAbi(moduleAbi, aptos.AccountOne, "aptos_account", "transfer_coins", []any{aptos.AptosCoinTypeTag}, []any{bob.Address.String(), "1000"})
+	if err != nil {
+		panic("Failed to call EntryFunctionWithArgs:" + err.Error())
+	}
+	resp, err := client.BuildSignAndSubmitTransaction(alice, aptos.TransactionPayload{
+		Payload: payload2,
+	})
+
+	if err != nil {
+		panic("Failed to sign transaction:" + err.Error())
+	}
+
+	_, err = client.WaitForTransaction(resp.Hash)
+	if err != nil {
+		panic("Failed to wait for transaction:" + err.Error())
+	}
+
+	aliceBalance, err = client.AccountAPTBalance(alice.Address)
+	if err != nil {
+		panic("Failed to retrieve alice balance:" + err.Error())
+	}
+	bobBalance, err = client.AccountAPTBalance(bob.Address)
+	if err != nil {
+		panic("Failed to retrieve bob balance:" + err.Error())
+	}
+	fmt.Printf("\n=== Final Balances ===\n")
+	fmt.Printf("Alice: %d\n", aliceBalance)
+	fmt.Printf("Bob:%d\n", bobBalance)
+}
+
+func main() {
+	example(aptos.DevnetConfig)
+}

--- a/examples/local_abi/main_test.go
+++ b/examples/local_abi/main_test.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/aptos-labs/aptos-go-sdk"
+	"testing"
+)
+
+func Test_Main(t *testing.T) {
+	t.Parallel()
+	example(aptos.LocalnetConfig)
+}

--- a/examples/remote_abi/.gitignore
+++ b/examples/remote_abi/.gitignore
@@ -1,1 +1,1 @@
-transfer_coin
+remote_abi

--- a/examples/remote_abi/.gitignore
+++ b/examples/remote_abi/.gitignore
@@ -1,0 +1,1 @@
+transfer_coin

--- a/examples/remote_abi/main.go
+++ b/examples/remote_abi/main.go
@@ -1,0 +1,145 @@
+// transfer_coin is an example of how to make a coin transfer transaction in the simplest possible way
+package main
+
+import (
+	"fmt"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+)
+
+const FundAmount = 100_000_000
+const TransferAmount = 1_000
+
+// example This example shows you how to make an APT transfer transaction in the simplest possible way
+func example(networkConfig aptos.NetworkConfig) {
+	// Create a client for Aptos
+	client, err := aptos.NewClient(networkConfig)
+	if err != nil {
+		panic("Failed to create client:" + err.Error())
+	}
+
+	// Create accounts locally for alice and bob
+	alice, err := aptos.NewEd25519Account()
+	if err != nil {
+		panic("Failed to create alice:" + err.Error())
+	}
+	bob, err := aptos.NewEd25519Account()
+	if err != nil {
+		panic("Failed to create bob:" + err.Error())
+	}
+
+	fmt.Printf("\n=== Addresses ===\n")
+	fmt.Printf("Alice: %s\n", alice.Address.String())
+	fmt.Printf("Bob:%s\n", bob.Address.String())
+
+	// Fund the sender with the faucet to create it on-chain
+	err = client.Fund(alice.Address, FundAmount)
+	if err != nil {
+		panic("Failed to fund alice:" + err.Error())
+	}
+
+	aliceBalance, err := client.AccountAPTBalance(alice.Address)
+	if err != nil {
+		panic("Failed to retrieve alice balance:" + err.Error())
+	}
+	bobBalance, err := client.AccountAPTBalance(bob.Address)
+	if err != nil {
+		panic("Failed to retrieve bob balance:" + err.Error())
+	}
+	fmt.Printf("\n=== Initial Balances ===\n")
+	fmt.Printf("Alice: %d\n", aliceBalance)
+	fmt.Printf("Bob:%d\n", bobBalance)
+
+	// 1. Build transaction, with easy mode, no BCS serialization necessary
+	payload, err := client.EntryFunctionWithArgs(aptos.AccountOne, "aptos_account", "transfer_coins", []any{"0x1::aptos_coin::AptosCoin"}, []any{bob.Address, TransferAmount})
+	if err != nil {
+		panic("Failed to call EntryFunctionWithArgs:" + err.Error())
+	}
+	rawTxn, err := client.BuildTransaction(alice.AccountAddress(), aptos.TransactionPayload{
+		Payload: payload,
+	})
+
+	if err != nil {
+		panic("Failed to build transaction:" + err.Error())
+	}
+
+	// 2. Simulate transaction (optional)
+	// This is useful for understanding how much the transaction will cost
+	// and to ensure that the transaction is valid before sending it to the network
+	// This is optional, but recommended
+	simulationResult, err := client.SimulateTransaction(rawTxn, alice)
+	if err != nil {
+		panic("Failed to simulate transaction:" + err.Error())
+	}
+	fmt.Printf("\n=== Simulation ===\n")
+	fmt.Printf("Gas unit price: %d\n", simulationResult[0].GasUnitPrice)
+	fmt.Printf("Gas used: %d\n", simulationResult[0].GasUsed)
+	fmt.Printf("Total gas fee: %d\n", simulationResult[0].GasUsed*simulationResult[0].GasUnitPrice)
+	fmt.Printf("Status: %s\n", simulationResult[0].VmStatus)
+
+	// 3. Sign transaction
+	signedTxn, err := rawTxn.SignedTransaction(alice)
+	if err != nil {
+		panic("Failed to sign transaction:" + err.Error())
+	}
+
+	// 4. Submit transaction
+	submitResult, err := client.SubmitTransaction(signedTxn)
+	if err != nil {
+		panic("Failed to submit transaction:" + err.Error())
+	}
+	txnHash := submitResult.Hash
+
+	// 5. Wait for the transaction to complete
+	_, err = client.WaitForTransaction(txnHash)
+	if err != nil {
+		panic("Failed to wait for transaction:" + err.Error())
+	}
+
+	// Check balances
+	aliceBalance, err = client.AccountAPTBalance(alice.Address)
+	if err != nil {
+		panic("Failed to retrieve alice balance:" + err.Error())
+	}
+	bobBalance, err = client.AccountAPTBalance(bob.Address)
+	if err != nil {
+		panic("Failed to retrieve bob balance:" + err.Error())
+	}
+	fmt.Printf("\n=== Intermediate Balances ===\n")
+	fmt.Printf("Alice: %d\n", aliceBalance)
+	fmt.Printf("Bob:%d\n", bobBalance)
+
+	// Now do it again, but with a different function, with types
+	payload2, err := client.EntryFunctionWithArgs(aptos.AccountOne, "aptos_account", "transfer_coins", []any{aptos.AptosCoinTypeTag}, []any{bob.Address.String(), "1000"})
+	if err != nil {
+		panic("Failed to call EntryFunctionWithArgs:" + err.Error())
+	}
+	resp, err := client.BuildSignAndSubmitTransaction(alice, aptos.TransactionPayload{
+		Payload: payload2,
+	})
+
+	if err != nil {
+		panic("Failed to sign transaction:" + err.Error())
+	}
+
+	_, err = client.WaitForTransaction(resp.Hash)
+	if err != nil {
+		panic("Failed to wait for transaction:" + err.Error())
+	}
+
+	aliceBalance, err = client.AccountAPTBalance(alice.Address)
+	if err != nil {
+		panic("Failed to retrieve alice balance:" + err.Error())
+	}
+	bobBalance, err = client.AccountAPTBalance(bob.Address)
+	if err != nil {
+		panic("Failed to retrieve bob balance:" + err.Error())
+	}
+	fmt.Printf("\n=== Final Balances ===\n")
+	fmt.Printf("Alice: %d\n", aliceBalance)
+	fmt.Printf("Bob:%d\n", bobBalance)
+}
+
+func main() {
+	example(aptos.DevnetConfig)
+}

--- a/examples/remote_abi/main_test.go
+++ b/examples/remote_abi/main_test.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/aptos-labs/aptos-go-sdk"
+	"testing"
+)
+
+func Test_Main(t *testing.T) {
+	t.Parallel()
+	example(aptos.LocalnetConfig)
+}

--- a/nodeClient.go
+++ b/nodeClient.go
@@ -192,100 +192,14 @@ func (rc *NodeClient) AccountModule(address AccountAddress, moduleName string, l
 	return data, nil
 }
 
-func (rc *NodeClient) EntryFunctionWithArgs(address AccountAddress, moduleName string, functionName string, typeArgs []any, args []any) (entry *EntryFunction, err error) {
+func (rc *NodeClient) EntryFunctionWithArgs(moduleAddress AccountAddress, moduleName string, functionName string, typeArgs []any, args []any) (entry *EntryFunction, err error) {
 	// TODO: This should be cached / we should be able to take in an ABI
-	module, err := rc.AccountModule(address, moduleName)
+	module, err := rc.AccountModule(moduleAddress, moduleName)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: everything below should be moved out of the client
-	// Find function
-	var function *api.MoveFunction
-	for _, fun := range module.Abi.ExposedFunctions {
-		if fun.Name == functionName {
-			if fun.IsEntry == false {
-				return nil, fmt.Errorf("function %s is not a entry function in module %s", functionName, moduleName)
-			}
-
-			function = fun
-			break
-		}
-	}
-
-	if function == nil {
-		return nil, fmt.Errorf("entry function %s not found in module %s", functionName, moduleName)
-	}
-
-	// Check type args length matches
-	if len(typeArgs) != len(function.GenericTypeParams) {
-		return nil, fmt.Errorf("entry function %s does not have the correct number of type arguments for function %s", functionName, functionName)
-	}
-
-	// Convert TypeTag, *TypeTag, and string to TypeTag
-	// TODO: Check properties of generic type?
-	convertedTypeArgs := make([]TypeTag, len(typeArgs))
-	for i, typeArg := range typeArgs {
-		tag, err := ConvertTypeTag(typeArg)
-		if err != nil {
-			return nil, err
-		}
-		convertedTypeArgs[i] = *tag
-	}
-
-	// Convert string types to actual types
-	argTypes := make([]TypeTag, 0)
-	for _, typeStr := range function.Params {
-		typeArg, err := ParseTypeTag(typeStr)
-		if err != nil {
-			return nil, err
-		}
-
-		// If it's `signer` or `&signer` need to skip
-		// TODO: only skip at the beginning
-		switch typeArg.Value.(type) {
-		case *SignerTag:
-			// Skip
-			continue
-		case *ReferenceTag:
-			innerArg := typeArg.Value.(*ReferenceTag)
-			switch innerArg.TypeParam.Value.(type) {
-			case *SignerTag:
-				// Skip
-				continue
-			default:
-				argTypes = append(argTypes, *typeArg)
-			}
-		default:
-			argTypes = append(argTypes, *typeArg)
-		}
-	}
-
-	// Check args length matches
-	if len(args) != len(argTypes) {
-		return nil, fmt.Errorf("entry function %s does not have the correct number of arguments for function %s", functionName, functionName)
-	}
-
-	convertedArgs := make([][]byte, len(args))
-	for i, arg := range args {
-		b, err := ConvertArg(argTypes[i], arg, argTypes)
-		if err != nil {
-			return nil, err
-		}
-		convertedArgs[i] = b
-	}
-
-	entry = &EntryFunction{
-		Module: ModuleId{
-			Address: address,
-			Name:    moduleName,
-		},
-		Function: functionName,
-		ArgTypes: convertedTypeArgs,
-		Args:     convertedArgs,
-	}
-
-	return entry, err
+	return EntryFunctionFromAbi(module.Abi, moduleAddress, moduleName, functionName, typeArgs, args)
 }
 
 // TransactionByHash gets info on a transaction

--- a/typeConversion.go
+++ b/typeConversion.go
@@ -1,0 +1,656 @@
+package aptos
+
+import (
+	"fmt"
+	"math/big"
+	"strconv"
+
+	"github.com/aptos-labs/aptos-go-sdk/bcs"
+	"github.com/aptos-labs/aptos-go-sdk/internal/util"
+)
+
+func ConvertTypeTag(typeArg any) (*TypeTag, error) {
+	switch typeArg.(type) {
+	case TypeTag:
+		tag := typeArg.(TypeTag)
+		return &tag, nil
+	case *TypeTag:
+		tag := typeArg.(*TypeTag)
+		if tag == nil {
+			return nil, fmt.Errorf("invalid type tag %s, cannot be nil", typeArg)
+		}
+		return tag, nil
+	case string:
+		strTypeTag := typeArg.(string)
+		return ParseTypeTag(strTypeTag)
+	default:
+		return nil, fmt.Errorf("invalid type tag type")
+	}
+}
+
+func ConvertToU8(arg any) (*uint8, error) {
+	var num uint8
+	switch arg.(type) {
+	case int:
+		num = uint8(arg.(int))
+	case uint:
+		num = uint8(arg.(uint))
+	case uint8:
+		num = arg.(uint8)
+	case big.Int:
+		b := arg.(big.Int)
+		num = uint8(b.Uint64())
+	case *big.Int:
+		b := arg.(*big.Int)
+		if b == nil {
+			return nil, fmt.Errorf("cannot convert to uint8, input is nil")
+		}
+		num = uint8(b.Uint64())
+	case string:
+		// Convert the number
+		u64, err := strconv.ParseUint(arg.(string), 10, 8)
+		if err != nil {
+			return nil, err
+		}
+		num = uint8(u64)
+	default:
+		return nil, fmt.Errorf("invalid input type for uint8")
+	}
+
+	return &num, nil
+}
+
+func ConvertToU16(arg any) (*uint16, error) {
+	var num uint16
+	switch arg.(type) {
+	case int:
+		num = uint16(arg.(int))
+	case uint:
+		num = uint16(arg.(uint))
+	case uint16:
+		num = arg.(uint16)
+	case big.Int:
+		b := arg.(big.Int)
+		num = uint16(b.Uint64())
+	case *big.Int:
+		b := arg.(*big.Int)
+		if b == nil {
+			return nil, fmt.Errorf("cannot convert to uint16, input is nil")
+		}
+		num = uint16(b.Uint64())
+	case string:
+		// Convert the number
+		u64, err := strconv.ParseUint(arg.(string), 10, 16)
+		if err != nil {
+			return nil, err
+		}
+		num = uint16(u64)
+	default:
+		return nil, fmt.Errorf("invalid input type for uint16")
+	}
+
+	return &num, nil
+}
+
+func ConvertToU32(arg any) (*uint32, error) {
+	var num uint32
+	switch arg.(type) {
+	case int:
+		num = uint32(arg.(int))
+	case uint:
+		num = uint32(arg.(uint))
+	case uint32:
+		num = arg.(uint32)
+	case big.Int:
+		b := arg.(big.Int)
+		num = uint32(b.Uint64())
+	case *big.Int:
+		b := arg.(*big.Int)
+		if b == nil {
+			return nil, fmt.Errorf("cannot convert to uint32, input is nil")
+		}
+		num = uint32(b.Uint64())
+	case string:
+		// Convert the number
+		u64, err := strconv.ParseUint(arg.(string), 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		num = uint32(u64)
+	default:
+		return nil, fmt.Errorf("invalid input type for uint32")
+	}
+
+	return &num, nil
+}
+
+func ConvertToU64(arg any) (*uint64, error) {
+	var num uint64
+	switch arg.(type) {
+	case int:
+		num = uint64(arg.(int))
+	case uint:
+		num = uint64(arg.(uint))
+	case uint64:
+		num = arg.(uint64)
+	case big.Int:
+		b := arg.(big.Int)
+		num = b.Uint64()
+	case *big.Int:
+		b := arg.(*big.Int)
+		if b == nil {
+			return nil, fmt.Errorf("cannot convert to uint64, input is nil")
+		}
+		num = b.Uint64()
+	case string:
+		// Convert the number
+		u64, err := strconv.ParseUint(arg.(string), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		num = u64
+	default:
+		return nil, fmt.Errorf("invalid input type for uint64")
+	}
+
+	return &num, nil
+}
+
+func ConvertToU128(arg any) (num *big.Int, err error) {
+	switch arg.(type) {
+	case int:
+		num = big.NewInt(int64(arg.(int)))
+	case uint:
+		num = big.NewInt(int64(arg.(uint)))
+	case big.Int:
+		b := arg.(big.Int)
+		num = &b
+	case *big.Int:
+		num = arg.(*big.Int)
+		if num == nil {
+			return nil, fmt.Errorf("cannot convert to uint128, input is nil")
+		}
+	case string:
+		// Convert the number
+		num, err = util.StrToBigInt(arg.(string))
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("invalid input type for uint128")
+	}
+
+	return num, nil
+}
+
+func ConvertToU256(arg any) (num *big.Int, err error) {
+	switch arg.(type) {
+	case int:
+		num = big.NewInt(int64(arg.(int)))
+	case uint:
+		num = big.NewInt(int64(arg.(uint)))
+	case big.Int:
+		b := arg.(big.Int)
+		num = &b
+	case *big.Int:
+		num = arg.(*big.Int)
+		if num == nil {
+			return nil, fmt.Errorf("cannot convert to uint256, input is nil")
+		}
+	case string:
+		// Convert the number
+		num, err = util.StrToBigInt(arg.(string))
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("invalid input type for uint256")
+	}
+
+	return num, nil
+}
+
+func ConvertToBool(arg any) (b bool, err error) {
+	switch arg.(type) {
+	case bool:
+		b = arg.(bool)
+	case string:
+		switch arg.(string) {
+		case "true":
+			b = true
+		case "false":
+			b = false
+		default:
+			err = fmt.Errorf("invalid boolean input for bool")
+		}
+	default:
+		err = fmt.Errorf("invalid input type for bool")
+	}
+	return b, err
+}
+
+func ConvertToAddress(arg any) (a *AccountAddress, err error) {
+	switch arg.(type) {
+	case AccountAddress:
+		addr := arg.(AccountAddress)
+		return &addr, nil
+	case *AccountAddress:
+		a = arg.(*AccountAddress)
+		if a == nil {
+			err = fmt.Errorf("invalid account address, nil")
+		}
+	case string:
+		addr := AccountAddress{}
+		err = addr.ParseStringRelaxed(arg.(string))
+		if err != nil {
+			return nil, err
+		}
+		a = &addr
+	default:
+		err = fmt.Errorf("invalid input type for address")
+	}
+	return a, err
+}
+
+// ConvertToVectorU8 returns the BCS encoded version of the bytes
+func ConvertToVectorU8(arg any) (b []byte, err error) {
+	// Special case, handle hex string
+	switch arg.(type) {
+	case string:
+		bytes, err := util.ParseHex(arg.(string))
+		if err != nil {
+			return nil, err
+		}
+		// Serialize the bytes
+		return bcs.SerializeBytes(bytes)
+	case []byte:
+		convertedArg := arg.([]byte)
+		if convertedArg == nil {
+			return nil, fmt.Errorf("cannot convert nil to bytes")
+		}
+		return bcs.SerializeBytes(convertedArg)
+	default:
+		return nil, fmt.Errorf("invalid input type for vector<u8>")
+	}
+}
+
+// ConvertToVectorU16 returns the BCS encoded version of the bytes
+func ConvertToVectorU16(arg any) (b []byte, err error) {
+	// Special case, handle hex string
+	switch arg.(type) {
+	case []uint16:
+		convertedArg := arg.([]uint16)
+		if convertedArg == nil {
+			return nil, fmt.Errorf("cannot convert nil to bytes")
+		}
+		return bcs.SerializeSingle(func(ser *bcs.Serializer) {
+			bcs.SerializeSequenceWithFunction(convertedArg, ser, func(serializer *bcs.Serializer, item uint16) {
+				ser.U16(item)
+			})
+		})
+	default:
+		return nil, fmt.Errorf("invalid input type for vector<u16>")
+	}
+}
+
+// ConvertToVectorU32 returns the BCS encoded version of the bytes
+func ConvertToVectorU32(arg any) (b []byte, err error) {
+	// Special case, handle hex string
+	switch arg.(type) {
+	case []uint32:
+		convertedArg := arg.([]uint32)
+		if convertedArg == nil {
+			return nil, fmt.Errorf("cannot convert nil to bytes")
+		}
+		return bcs.SerializeSingle(func(ser *bcs.Serializer) {
+			bcs.SerializeSequenceWithFunction(convertedArg, ser, func(serializer *bcs.Serializer, item uint32) {
+				ser.U32(item)
+			})
+		})
+	default:
+		return nil, fmt.Errorf("invalid input type for vector<u32>")
+	}
+}
+
+// ConvertToVectorU64 returns the BCS encoded version of the bytes
+func ConvertToVectorU64(arg any) (b []byte, err error) {
+	// Special case, handle hex string
+	switch arg.(type) {
+	case []uint64:
+		convertedArg := arg.([]uint64)
+		if convertedArg == nil {
+			return nil, fmt.Errorf("cannot convert nil to bytes")
+		}
+		return bcs.SerializeSingle(func(ser *bcs.Serializer) {
+			bcs.SerializeSequenceWithFunction(convertedArg, ser, func(serializer *bcs.Serializer, item uint64) {
+				ser.U64(item)
+			})
+		})
+	default:
+		return nil, fmt.Errorf("invalid input type for vector<u64>")
+	}
+}
+
+// ConvertToVectorU128 returns the BCS encoded version of the bytes
+func ConvertToVectorU128(arg any) (b []byte, err error) {
+	// Special case, handle hex string
+	switch arg.(type) {
+	case []big.Int:
+		convertedArg := arg.([]big.Int)
+		if convertedArg == nil {
+			return nil, fmt.Errorf("cannot convert nil to bytes")
+		}
+		return bcs.SerializeSingle(func(ser *bcs.Serializer) {
+			bcs.SerializeSequenceWithFunction(convertedArg, ser, func(serializer *bcs.Serializer, item big.Int) {
+				ser.U128(item)
+			})
+		})
+	default:
+		return nil, fmt.Errorf("invalid input type for vector<u128>")
+	}
+}
+
+// ConvertToVectorU256 returns the BCS encoded version of the bytes
+func ConvertToVectorU256(arg any) (b []byte, err error) {
+	// Special case, handle hex string
+	switch arg.(type) {
+	case []big.Int:
+		convertedArg := arg.([]big.Int)
+		if convertedArg == nil {
+			return nil, fmt.Errorf("cannot convert nil to bytes")
+		}
+		return bcs.SerializeSingle(func(ser *bcs.Serializer) {
+			bcs.SerializeSequenceWithFunction(convertedArg, ser, func(serializer *bcs.Serializer, item big.Int) {
+				ser.U256(item)
+			})
+		})
+	default:
+		return nil, fmt.Errorf("invalid input type for vector<u256>")
+	}
+}
+
+// ConvertToVectorBool returns the BCS encoded version of the boolean vector
+func ConvertToVectorBool(arg any) (b []byte, err error) {
+	switch arg.(type) {
+	case []bool:
+		convertedArg := arg.([]bool)
+		if convertedArg == nil {
+			return nil, fmt.Errorf("cannot convert nil to bool vector")
+		}
+		return bcs.SerializeSingle(func(ser *bcs.Serializer) {
+			bcs.SerializeSequenceWithFunction(convertedArg, ser, func(serializer *bcs.Serializer, item bool) {
+				ser.Bool(item)
+			})
+		})
+	default:
+		return nil, fmt.Errorf("invalid input type for vector<bool>")
+	}
+}
+
+// ConvertToVectorAddress returns the BCS encoded version of the address vector
+func ConvertToVectorAddress(arg any) (b []byte, err error) {
+	switch arg.(type) {
+	case []AccountAddress:
+		convertedArg := arg.([]AccountAddress)
+		if convertedArg == nil {
+			return nil, fmt.Errorf("cannot convert nil to address vector")
+		}
+		return bcs.SerializeSequenceOnly(convertedArg)
+	case []*AccountAddress:
+		convertedArg := arg.([]*AccountAddress)
+		if convertedArg == nil {
+			return nil, fmt.Errorf("cannot convert nil to address vector")
+		}
+		// Convert []*AccountAddress to []AccountAddress
+		addresses := make([]AccountAddress, len(convertedArg))
+		for i, addr := range convertedArg {
+			if addr == nil {
+				return nil, fmt.Errorf("cannot convert nil address in vector")
+			}
+			addresses[i] = *addr
+		}
+		return bcs.SerializeSequenceOnly(addresses)
+	default:
+		return nil, fmt.Errorf("invalid input type for vector<address>")
+	}
+}
+
+// ConvertToVectorGeneric returns the BCS encoded version of the generic vector
+func ConvertToVectorGeneric(typeArg TypeTag, arg any, generics []TypeTag) (b []byte, err error) {
+	genericTag, ok := typeArg.Value.(*GenericTag)
+	if !ok {
+		return nil, fmt.Errorf("invalid type tag for generic vector")
+	}
+
+	if genericTag.Num >= uint64(len(generics)) {
+		return nil, fmt.Errorf("generic number out of bounds")
+	}
+
+	innerType := generics[genericTag.Num]
+
+	switch arg.(type) {
+	case []any:
+		convertedArg := arg.([]any)
+		if convertedArg == nil {
+			return nil, fmt.Errorf("cannot convert nil to generic vector")
+		}
+
+		// Serialize length
+		lengthBytes, err := bcs.SerializeUleb128(uint32(len(convertedArg)))
+		if err != nil {
+			return nil, err
+		}
+		b = lengthBytes
+
+		// Serialize each element
+		for _, item := range convertedArg {
+			val, err := ConvertArg(innerType, item, generics)
+			if err != nil {
+				return nil, err
+			}
+			b = append(b, val...)
+		}
+		return b, nil
+	default:
+		return nil, fmt.Errorf("invalid input type for generic vector")
+	}
+}
+
+// ConvertToVectorReference returns the BCS encoded version of the reference vector
+func ConvertToVectorReference(typeArg TypeTag, arg any, generics []TypeTag) (b []byte, err error) {
+	refTag, ok := typeArg.Value.(*ReferenceTag)
+	if !ok {
+		return nil, fmt.Errorf("invalid type tag for reference vector")
+	}
+
+	innerType := refTag.TypeParam
+
+	switch arg.(type) {
+	case []any:
+		convertedArg := arg.([]any)
+		if convertedArg == nil {
+			return nil, fmt.Errorf("cannot convert nil to reference vector")
+		}
+
+		// Serialize length
+		lengthBytes, err := bcs.SerializeUleb128(uint32(len(convertedArg)))
+		if err != nil {
+			return nil, err
+		}
+		b = lengthBytes
+
+		// Serialize each element
+		for _, item := range convertedArg {
+			val, err := ConvertArg(innerType, item, generics)
+			if err != nil {
+				return nil, err
+			}
+			b = append(b, val...)
+		}
+		return b, nil
+	default:
+		return nil, fmt.Errorf("invalid input type for reference vector")
+	}
+}
+
+func ConvertToVector(typeArg TypeTag, arg any, generics []TypeTag) (out []byte, err error) {
+	// We have to switch based on type, thanks Golang
+	switch typeArg.Value.(type) {
+	case *U8Tag:
+		return ConvertToVectorU8(arg)
+	case *U16Tag:
+		return ConvertToVectorU16(arg)
+	case *U32Tag:
+		return ConvertToVectorU32(arg)
+	case *U64Tag:
+		return ConvertToVectorU64(arg)
+	case *U128Tag:
+		return ConvertToVectorU128(arg)
+	case *U256Tag:
+		return ConvertToVectorU256(arg)
+	case *BoolTag:
+		return ConvertToVectorBool(arg)
+	case *AddressTag:
+		return ConvertToVectorAddress(arg)
+	case *SignerTag:
+		return ConvertToVectorAddress(arg)
+	case *GenericTag:
+		return ConvertToVectorGeneric(typeArg, arg, generics)
+	case *ReferenceTag:
+		return ConvertToVectorReference(typeArg, arg, generics)
+	// TODO: Handle structs
+	default:
+		return nil, fmt.Errorf("%s is currently not supported as an input type", typeArg.String())
+	}
+}
+
+func ConvertArg(typeArg TypeTag, arg any, generics []TypeTag) (b []byte, err error) {
+	switch typeArg.Value.(type) {
+	case *U8Tag:
+		num, err := ConvertToU8(arg)
+		if err != nil {
+			return nil, err
+		}
+		return bcs.SerializeU8(*num)
+	case *U16Tag:
+		num, err := ConvertToU16(arg)
+		if err != nil {
+			return nil, err
+		}
+		return bcs.SerializeU16(*num)
+	case *U32Tag:
+		num, err := ConvertToU32(arg)
+		if err != nil {
+			return nil, err
+		}
+		return bcs.SerializeU32(*num)
+	case *U64Tag:
+		num, err := ConvertToU64(arg)
+		if err != nil {
+			return nil, err
+		}
+		return bcs.SerializeU64(*num)
+	case *U128Tag:
+		num, err := ConvertToU128(arg)
+		if err != nil {
+			return nil, err
+		}
+		return bcs.SerializeU128(*num)
+	case *U256Tag:
+		num, err := ConvertToU256(arg)
+		if err != nil {
+			return nil, err
+		}
+		return bcs.SerializeU256(*num)
+	case *BoolTag:
+		bo, err := ConvertToBool(arg)
+		if err != nil {
+			return nil, err
+		}
+		return bcs.SerializeBool(bo)
+	case *AddressTag:
+		a, err := ConvertToAddress(arg)
+		if err != nil {
+			return nil, err
+		}
+		return bcs.Serialize(a)
+	case *GenericTag:
+		// Convert based on number
+		genericTag := typeArg.Value.(*GenericTag)
+		genericNum := genericTag.Num
+		if genericNum >= uint64(len(generics)) {
+			return nil, fmt.Errorf("generic number out of bounds")
+		}
+
+		tag := generics[genericTag.Num]
+		return ConvertArg(tag, arg, generics)
+	case *ReferenceTag:
+		// Convert based on inner type
+		refTag := typeArg.Value.(*ReferenceTag)
+		return ConvertArg(refTag.TypeParam, arg, generics)
+	case *VectorTag:
+		// This has two paths:
+		// 1. Hex strings are allowed for vector<u8>
+		// 2. Otherwise, everything is just parsed as an array of the inner type
+		vecTag := typeArg.Value.(*VectorTag)
+		switch vecTag.TypeParam.Value.(type) {
+		case *U8Tag:
+			return ConvertToVectorU8(arg)
+		default:
+			return ConvertToVector(vecTag.TypeParam, arg, generics)
+		}
+	case *StructTag:
+		structTag := typeArg.Value.(*StructTag)
+		// TODO: We should be able to support custom structs, but for now only support known
+		switch structTag.Address {
+		case AccountOne:
+			switch structTag.Module {
+			case "object":
+				switch structTag.Name {
+				case "Object":
+					// TODO: Move to function
+					// Handle as address, inner type doesn't matter
+					// TODO: Improve error message
+					return ConvertArg(TypeTag{&AddressTag{}}, arg, generics)
+				}
+			case "string":
+				switch structTag.Name {
+				case "String":
+					// Handle as string, we won't let bytes as an input for now here
+					switch arg.(type) {
+					case string:
+						return bcs.SerializeBytes([]byte(arg.(string)))
+					default:
+						return nil, fmt.Errorf("invalid input type for 0x1::string::String")
+					}
+				}
+			case "option":
+				switch structTag.Name {
+				case "Option":
+					// Check it has the proper inner type
+					if 1 != len(structTag.TypeParams) {
+						return nil, fmt.Errorf("invalid input type for option, must have exactly one type arg")
+					}
+					// Get inner type
+					typeParam := structTag.TypeParams[0]
+
+					// Handle special case of "none", it's a single 0 byte
+					if arg == nil {
+						return bcs.SerializeU8(0)
+					}
+
+					// Otherwise, it's a single byte 1, and the encoded arg
+					b, err = ConvertArg(typeParam, arg, generics)
+					if err != nil {
+						return nil, err
+					}
+					return append([]byte{1}, b...), nil
+				}
+			}
+		}
+	default:
+		return nil, fmt.Errorf("unknown type argument")
+	}
+
+	return nil, fmt.Errorf("failed to convert type argument")
+}

--- a/typeConversion_test.go
+++ b/typeConversion_test.go
@@ -1,0 +1,683 @@
+package aptos
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ... existing code ...
+
+func TestConvertTypeTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		wantErr  bool
+		validate func(*testing.T, *TypeTag)
+	}{
+		{
+			name:    "TypeTag value",
+			input:   TypeTag{Value: &U8Tag{}},
+			wantErr: false,
+			validate: func(t *testing.T, tag *TypeTag) {
+				if _, ok := tag.Value.(*U8Tag); !ok {
+					t.Error("Expected U8Tag")
+				}
+			},
+		},
+		{
+			name:    "TypeTag pointer",
+			input:   &TypeTag{Value: &U8Tag{}},
+			wantErr: false,
+			validate: func(t *testing.T, tag *TypeTag) {
+				if _, ok := tag.Value.(*U8Tag); !ok {
+					t.Error("Expected U8Tag")
+				}
+			},
+		},
+		{
+			name:    "nil TypeTag pointer",
+			input:   (*TypeTag)(nil),
+			wantErr: true,
+		},
+		{
+			name:    "string type tag",
+			input:   "u8",
+			wantErr: false,
+			validate: func(t *testing.T, tag *TypeTag) {
+				if _, ok := tag.Value.(*U8Tag); !ok {
+					t.Error("Expected U8Tag")
+				}
+			},
+		},
+		{
+			name:    "vector type tag string",
+			input:   "vector<u8>",
+			wantErr: false,
+			validate: func(t *testing.T, tag *TypeTag) {
+				vecTag, ok := tag.Value.(*VectorTag)
+				if !ok {
+					t.Error("Expected VectorTag")
+				}
+				if _, ok := vecTag.TypeParam.Value.(*U8Tag); !ok {
+					t.Error("Expected U8Tag in VectorTag")
+				}
+			},
+		},
+		{
+			name:    "reference type tag string",
+			input:   "&u8",
+			wantErr: false,
+			validate: func(t *testing.T, tag *TypeTag) {
+				refTag, ok := tag.Value.(*ReferenceTag)
+				if !ok {
+					t.Error("Expected ReferenceTag")
+				}
+				if _, ok := refTag.TypeParam.Value.(*U8Tag); !ok {
+					t.Error("Expected U8Tag in ReferenceTag")
+				}
+			},
+		},
+		{
+			name:    "generic type tag string",
+			input:   "T0",
+			wantErr: false,
+			validate: func(t *testing.T, tag *TypeTag) {
+				genTag, ok := tag.Value.(*GenericTag)
+				if !ok {
+					t.Error("Expected GenericTag")
+				}
+				if genTag.Num != 0 {
+					t.Error("Expected generic number 0")
+				}
+			},
+		},
+		{
+			name:    "struct type tag string",
+			input:   "0x1::string::String",
+			wantErr: false,
+			validate: func(t *testing.T, tag *TypeTag) {
+				structTag, ok := tag.Value.(*StructTag)
+				if !ok {
+					t.Error("Expected StructTag")
+				}
+				if structTag.Address != AccountOne {
+					t.Error("Expected AccountOne address")
+				}
+				if structTag.Module != "string" {
+					t.Error("Expected string module")
+				}
+				if structTag.Name != "String" {
+					t.Error("Expected String name")
+				}
+			},
+		},
+		{
+			name:    "invalid type",
+			input:   123,
+			wantErr: true,
+		},
+		{
+			name:    "invalid string type tag",
+			input:   "invalid_type",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertTypeTag(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertTypeTag() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.validate != nil {
+				tt.validate(t, got)
+			}
+		})
+	}
+}
+
+// ... existing code ...
+
+func TestConvertArg(t *testing.T) {
+	tests := []struct {
+		name     string
+		typeArg  TypeTag
+		arg      any
+		generics []TypeTag
+		expected []byte
+		wantErr  bool
+	}{
+		{
+			name:     "u8",
+			typeArg:  TypeTag{Value: &U8Tag{}},
+			arg:      uint8(42),
+			expected: []byte{42},
+			wantErr:  false,
+		},
+		{
+			name:     "u16",
+			typeArg:  TypeTag{Value: &U16Tag{}},
+			arg:      uint16(42),
+			expected: []byte{42, 0},
+			wantErr:  false,
+		},
+		{
+			name:     "u32",
+			typeArg:  TypeTag{Value: &U32Tag{}},
+			arg:      uint32(42),
+			expected: []byte{42, 0, 0, 0},
+			wantErr:  false,
+		},
+		{
+			name:     "u64",
+			typeArg:  TypeTag{Value: &U64Tag{}},
+			arg:      uint64(42),
+			expected: []byte{42, 0, 0, 0, 0, 0, 0, 0},
+			wantErr:  false,
+		},
+		{
+			name:     "u128",
+			typeArg:  TypeTag{Value: &U128Tag{}},
+			arg:      big.NewInt(42),
+			expected: []byte{42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			wantErr:  false,
+		},
+		{
+			name:     "u256",
+			typeArg:  TypeTag{Value: &U256Tag{}},
+			arg:      big.NewInt(42),
+			expected: []byte{42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			wantErr:  false,
+		},
+		{
+			name:     "bool",
+			typeArg:  TypeTag{Value: &BoolTag{}},
+			arg:      true,
+			expected: []byte{0x01},
+			wantErr:  false,
+		},
+		{
+			name:     "address",
+			typeArg:  TypeTag{Value: &AddressTag{}},
+			arg:      AccountOne,
+			expected: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01},
+			wantErr:  false,
+		},
+		{
+			name:     "vector<u8> from hex",
+			typeArg:  TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &U8Tag{}}}},
+			arg:      "0x42",
+			expected: []byte{0x1, 0x42},
+			wantErr:  false,
+		},
+		{
+			name:     "vector<u8> from bytes",
+			typeArg:  TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &U8Tag{}}}},
+			arg:      []byte{0x42},
+			expected: []byte{0x1, 0x42},
+			wantErr:  false,
+		},
+		{
+			name:     "option",
+			typeArg:  TypeTag{Value: &StructTag{Address: AccountOne, Module: "option", Name: "Option", TypeParams: []TypeTag{{Value: &U8Tag{}}}}},
+			arg:      uint8(0x42),
+			expected: []byte{0x1, 0x42},
+			wantErr:  false,
+		},
+		{
+			name:     "option none",
+			typeArg:  TypeTag{Value: &StructTag{Address: AccountOne, Module: "option", Name: "Option", TypeParams: []TypeTag{{Value: &U8Tag{}}}}},
+			arg:      nil,
+			expected: []byte{0x0},
+			wantErr:  false,
+		},
+		{
+			name:     "string",
+			typeArg:  TypeTag{Value: &StructTag{Address: AccountOne, Module: "string", Name: "String"}},
+			arg:      "hello",
+			expected: []byte{5, byte('h'), byte('e'), byte('l'), byte('l'), byte('o')},
+			wantErr:  false,
+		},
+		{
+			name:     "reference",
+			typeArg:  TypeTag{Value: &ReferenceTag{TypeParam: TypeTag{Value: &U8Tag{}}}},
+			arg:      uint8(0x42),
+			expected: []byte{0x42},
+			wantErr:  false,
+		},
+		{
+			name:     "generic",
+			typeArg:  TypeTag{Value: &GenericTag{Num: 0}},
+			arg:      uint8(0x42),
+			expected: []byte{0x42},
+			generics: []TypeTag{
+				{Value: &U8Tag{}},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "generic out of bounds",
+			typeArg: TypeTag{Value: &GenericTag{Num: 1}},
+			arg:     uint8(42),
+			generics: []TypeTag{
+				{Value: &U8Tag{}},
+			},
+			wantErr: true,
+		},
+		{
+			name:     "object",
+			typeArg:  TypeTag{Value: &StructTag{Address: AccountOne, Module: "object", Name: "Object"}},
+			arg:      AccountOne,
+			expected: AccountOne[:],
+			wantErr:  false,
+		},
+		{
+			name:    "invalid type",
+			typeArg: TypeTag{Value: &U8Tag{}},
+			arg:     "invalid",
+			wantErr: true,
+		},
+		{
+			name:    "invalid vector type",
+			typeArg: TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &U8Tag{}}}},
+			arg:     "invalid",
+			wantErr: true,
+		},
+		{
+			name:    "invalid option type",
+			typeArg: TypeTag{Value: &StructTag{Address: AccountOne, Module: "option", Name: "Option", TypeParams: []TypeTag{{Value: &U8Tag{}}}}},
+			arg:     "invalid",
+			wantErr: true,
+		},
+		{
+			name:    "invalid string type",
+			typeArg: TypeTag{Value: &StructTag{Address: AccountOne, Module: "string", Name: "String"}},
+			arg:     42,
+			wantErr: true,
+		},
+		{
+			name:    "invalid reference type",
+			typeArg: TypeTag{Value: &ReferenceTag{TypeParam: TypeTag{Value: &U8Tag{}}}},
+			arg:     "invalid",
+			wantErr: true,
+		},
+		{
+			name:    "invalid generic type",
+			typeArg: TypeTag{Value: &GenericTag{Num: 0}},
+			arg:     "invalid",
+			generics: []TypeTag{
+				{Value: &U8Tag{}},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "invalid object type",
+			typeArg: TypeTag{Value: &StructTag{Address: AccountOne, Module: "object", Name: "Object"}},
+			arg:     "invalid",
+			wantErr: true,
+		},
+		{
+			name:     "vector<u64>",
+			typeArg:  TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &U64Tag{}}}},
+			arg:      []uint64{0, 1, 2},
+			expected: []byte{3, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0},
+			wantErr:  false,
+		},
+		{
+			name:     "vector<bool>",
+			typeArg:  TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &BoolTag{}}}},
+			arg:      []bool{true, false, true},
+			expected: []byte{3, 1, 0, 1},
+			wantErr:  false,
+		},
+		{
+			name:     "vector<address>",
+			typeArg:  TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &AddressTag{}}}},
+			arg:      []AccountAddress{AccountOne, AccountTwo},
+			expected: []byte{2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2},
+			wantErr:  false,
+		},
+		{
+			name:     "vector<address> with pointers",
+			typeArg:  TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &AddressTag{}}}},
+			arg:      []*AccountAddress{&AccountOne, &AccountTwo},
+			expected: []byte{2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2},
+			wantErr:  false,
+		},
+		{
+			name:     "vector<generic>",
+			typeArg:  TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &GenericTag{Num: 0}}}},
+			arg:      []any{uint8(42), uint8(43)},
+			generics: []TypeTag{{Value: &U8Tag{}}},
+			expected: []byte{2, 42, 43},
+			wantErr:  false,
+		},
+		{
+			name:     "vector<reference>",
+			typeArg:  TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &ReferenceTag{TypeParam: TypeTag{Value: &U8Tag{}}}}}},
+			arg:      []any{uint8(42), uint8(43)},
+			expected: []byte{2, 42, 43},
+			wantErr:  false,
+		},
+		{
+			name:    "nil vector<bool>",
+			typeArg: TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &BoolTag{}}}},
+			arg:     []bool(nil),
+			wantErr: true,
+		},
+		{
+			name:    "nil vector<address>",
+			typeArg: TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &AddressTag{}}}},
+			arg:     []AccountAddress(nil),
+			wantErr: true,
+		},
+		{
+			name:    "nil vector<address> with pointers",
+			typeArg: TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &AddressTag{}}}},
+			arg:     []*AccountAddress(nil),
+			wantErr: true,
+		},
+		{
+			name:     "nil vector<generic>",
+			typeArg:  TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &GenericTag{Num: 0}}}},
+			arg:      []any(nil),
+			generics: []TypeTag{{Value: &U8Tag{}}},
+			wantErr:  true,
+		},
+		{
+			name:    "nil vector<reference>",
+			typeArg: TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &ReferenceTag{TypeParam: TypeTag{Value: &U8Tag{}}}}}},
+			arg:     []any(nil),
+			wantErr: true,
+		},
+		{
+			name:    "invalid vector<bool> type",
+			typeArg: TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &BoolTag{}}}},
+			arg:     "invalid",
+			wantErr: true,
+		},
+		{
+			name:    "invalid vector<address> type",
+			typeArg: TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &AddressTag{}}}},
+			arg:     "invalid",
+			wantErr: true,
+		},
+		{
+			name:     "invalid vector<generic> type",
+			typeArg:  TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &GenericTag{Num: 0}}}},
+			arg:      "invalid",
+			generics: []TypeTag{{Value: &U8Tag{}}},
+			wantErr:  true,
+		},
+		{
+			name:    "invalid vector<reference> type",
+			typeArg: TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &ReferenceTag{TypeParam: TypeTag{Value: &U8Tag{}}}}}},
+			arg:     "invalid",
+			wantErr: true,
+		},
+		{
+			name:     "generic vector out of bounds",
+			typeArg:  TypeTag{Value: &VectorTag{TypeParam: TypeTag{Value: &GenericTag{Num: 1}}}},
+			arg:      []any{uint8(42)},
+			generics: []TypeTag{{Value: &U8Tag{}}},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := ConvertArg(tt.typeArg, tt.arg, tt.generics)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertArg() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equalf(t, tt.expected, val, "ConvertArg() failed to convert to correct bytes %v != %v", tt.expected, val)
+		})
+	}
+}
+
+func TestConvertToU8(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    uint8
+		wantErr bool
+	}{
+		{
+			name:    "int",
+			input:   42,
+			want:    42,
+			wantErr: false,
+		},
+		{
+			name:    "uint",
+			input:   uint(42),
+			want:    42,
+			wantErr: false,
+		},
+		{
+			name:    "uint8",
+			input:   uint8(42),
+			want:    42,
+			wantErr: false,
+		},
+		{
+			name:    "big.Int",
+			input:   big.NewInt(42),
+			want:    42,
+			wantErr: false,
+		},
+		{
+			name:    "nil big.Int",
+			input:   (*big.Int)(nil),
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "string",
+			input:   "42",
+			want:    42,
+			wantErr: false,
+		},
+		{
+			name:    "invalid string",
+			input:   "invalid",
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "invalid type",
+			input:   float64(42),
+			want:    0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertToU8(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertToU8() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && *got != tt.want {
+				t.Errorf("ConvertToU8() = %v, want %v", *got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertToBool(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "true bool",
+			input:   true,
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "false bool",
+			input:   false,
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "true string",
+			input:   "true",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "false string",
+			input:   "false",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "invalid string",
+			input:   "invalid",
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name:    "invalid type",
+			input:   42,
+			want:    false,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertToBool(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertToBool() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ConvertToBool() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertToAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    *AccountAddress
+		wantErr bool
+	}{
+		{
+			name:    "AccountAddress",
+			input:   AccountOne,
+			want:    &AccountOne,
+			wantErr: false,
+		},
+		{
+			name:    "AccountAddress pointer",
+			input:   &AccountOne,
+			want:    &AccountOne,
+			wantErr: false,
+		},
+		{
+			name:    "nil AccountAddress pointer",
+			input:   (*AccountAddress)(nil),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "valid string",
+			input:   "0x1",
+			want:    &AccountOne,
+			wantErr: false,
+		},
+		{
+			name:    "invalid string",
+			input:   "invalid",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid type",
+			input:   42,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertToAddress(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertToAddress() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got.String() != tt.want.String() {
+				t.Errorf("ConvertToAddress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertToVectorU8(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:    "hex string",
+			input:   "0x42",
+			want:    []byte{0x01, 0x42},
+			wantErr: false,
+		},
+		{
+			name:    "bytes",
+			input:   []byte{0x42},
+			want:    []byte{0x01, 0x42},
+			wantErr: false,
+		},
+		{
+			name:    "nil bytes",
+			input:   []byte(nil),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid hex string",
+			input:   "invalid",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid type",
+			input:   42,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertToVectorU8(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertToVectorU8() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && string(got) != string(tt.want) {
+				t.Errorf("ConvertToVectorU8() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ... existing code ...


### PR DESCRIPTION
… to entry function types

### Description
There are examples for remote and local ABIs.  Complex types atm are not supported past individual vectors.  Nested vectors are not supported, or vectors of options.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->
Resolves https://github.com/aptos-labs/aptos-go-sdk/issues/90