### PR TITLE
[account address] use value receiver where possible

### DIFF
--- a/internal/types/accountAddress.go
+++ b/internal/types/accountAddress.go
@@ -40,7 +40,7 @@ var AccountFour = AccountAddress{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 // the addresses in the range from `0x0` to `0xf` (inclusive) are special.
 // For more details see the v1 address standard defined as part of AIP-40:
 // https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md
-func (aa *AccountAddress) IsSpecial() bool {
+func (aa AccountAddress) IsSpecial() bool {
 	for _, b := range aa[:31] {
 		if b != 0 {
 			return false
@@ -52,7 +52,7 @@ func (aa *AccountAddress) IsSpecial() bool {
 // String Returns the canonical string representation of the [AccountAddress]
 //
 // Please use [AccountAddress.StringLong] for all indexer queries.
-func (aa *AccountAddress) String() string {
+func (aa AccountAddress) String() string {
 	if aa.IsSpecial() {
 		return fmt.Sprintf("0x%x", aa[31])
 	} else {
@@ -66,7 +66,7 @@ func (aa *AccountAddress) FromAuthKey(authKey *crypto.AuthenticationKey) {
 }
 
 // AuthKey converts [AccountAddress] to [crypto.AuthenticationKey]
-func (aa *AccountAddress) AuthKey() *crypto.AuthenticationKey {
+func (aa AccountAddress) AuthKey() *crypto.AuthenticationKey {
 	authKey := &crypto.AuthenticationKey{}
 	copy(authKey[:], aa[:])
 	return authKey
@@ -75,12 +75,12 @@ func (aa *AccountAddress) AuthKey() *crypto.AuthenticationKey {
 // StringLong Returns the long string representation of the AccountAddress
 //
 // This is most commonly used for all indexer queries.
-func (aa *AccountAddress) StringLong() string {
+func (aa AccountAddress) StringLong() string {
 	return util.BytesToHex(aa[:])
 }
 
 // MarshalBCS Converts the AccountAddress to BCS encoded bytes
-func (aa *AccountAddress) MarshalBCS(ser *bcs.Serializer) {
+func (aa AccountAddress) MarshalBCS(ser *bcs.Serializer) {
 	ser.FixedBytes(aa[:])
 }
 
@@ -90,7 +90,7 @@ func (aa *AccountAddress) UnmarshalBCS(des *bcs.Deserializer) {
 }
 
 // MarshalJSON converts the AccountAddress to JSON
-func (aa *AccountAddress) MarshalJSON() ([]byte, error) {
+func (aa AccountAddress) MarshalJSON() ([]byte, error) {
 	return json.Marshal(aa.String())
 }
 
@@ -109,22 +109,22 @@ func (aa *AccountAddress) UnmarshalJSON(b []byte) error {
 }
 
 // NamedObjectAddress derives a named object address based on the input address as the creator
-func (aa *AccountAddress) NamedObjectAddress(seed []byte) (accountAddress AccountAddress) {
+func (aa AccountAddress) NamedObjectAddress(seed []byte) (accountAddress AccountAddress) {
 	return aa.DerivedAddress(seed, crypto.NamedObjectScheme)
 }
 
 // ObjectAddressFromObject derives an object address based on the input address as the creator object
-func (aa *AccountAddress) ObjectAddressFromObject(objectAddress *AccountAddress) (accountAddress AccountAddress) {
+func (aa AccountAddress) ObjectAddressFromObject(objectAddress *AccountAddress) (accountAddress AccountAddress) {
 	return aa.DerivedAddress(objectAddress[:], crypto.DeriveObjectScheme)
 }
 
 // ResourceAccount derives an object address based on the input address as the creator
-func (aa *AccountAddress) ResourceAccount(seed []byte) (accountAddress AccountAddress) {
+func (aa AccountAddress) ResourceAccount(seed []byte) (accountAddress AccountAddress) {
 	return aa.DerivedAddress(seed, crypto.ResourceAccountScheme)
 }
 
 // DerivedAddress addresses are derived by the address, the seed, then the type byte
-func (aa *AccountAddress) DerivedAddress(seed []byte, typeByte uint8) (accountAddress AccountAddress) {
+func (aa AccountAddress) DerivedAddress(seed []byte, typeByte uint8) (accountAddress AccountAddress) {
 	authKey := aa.AuthKey()
 	authKey.FromBytesAndScheme(append(authKey[:], seed[:]...), typeByte)
 	copy(accountAddress[:], authKey[:])


### PR DESCRIPTION
### Description

`AccountAddress` is used by value in most of the use cases. The most frequent use case is retrieving it from `Account`:

```go
func (account *Account) AccountAddress() AccountAddress
```

Currently, all the `AccountAddress` methods are implemented using pointer receiver making the following constructions impossible:

```go
_ = account.AccountAddress().String()
_ = account.AccountAddress().StringLong()
...
```

the only way to make it work is to do a copy and create a reference to it:

```go
address := account.AccountAddress()
_ = address.String()
```

I suggest using value receiver where possible to make the UX better.