### PR TITLE
Refactor: Simplify building transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 
 # Unreleased
 
+- [`Refactor`] Remove unnecessary atomic swap in submit transactions
+
 # v1.6.0 (3/24/2025)
 
 - [`Feature`] Add the ability for ABI simple type conversion of entry function arguments with both remote and local ABI


### PR DESCRIPTION
### Description
- The use of atomic operations is unnecessary in this context.
- Since all return paths ensure the channel is closed, the closure can be simply defered.

### Test Plan

### Related Links
