### PR TITLE
[aip80] Default the string format for private keys to be AIP-80

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ cmd/goclient/goclient
 .idea/
 *.swp
 *.swo
+
+# MacOS
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 
 # Unreleased
 
+- [`Feature`] Added `String()` method to `Ed25519PrivateKey` and `Secp256k1PrivateKey` which exports the private key in the AIP-80 format
 - [`Fix`] Add missing `Version` field to Event struct
 
 # v1.6.2 (3/28/2025)
@@ -16,7 +17,7 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 
 - [`Refactor`] Remove unnecessary atomic swap in submit transactions
 - [`Fix`] Enable users to simulate gas fee payer and multi agent transactions
- 
+
 # v1.6.0 (3/24/2025)
 
 - [`Feature`] Add the ability for ABI simple type conversion of entry function arguments with both remote and local ABI

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 
 	"github.com/aptos-labs/aptos-go-sdk/bcs"
 	"github.com/aptos-labs/aptos-go-sdk/internal/util"
@@ -188,6 +189,19 @@ func (key *Ed25519PrivateKey) ToHex() string {
 // ToAIP80 formats the private key to AIP-80 compliant string
 func (key *Ed25519PrivateKey) ToAIP80() (string, error) {
 	return FormatPrivateKey(key.ToHex(), PrivateKeyVariantEd25519)
+}
+
+// String returns the string representation of the [Ed25519PrivateKey] in the AIP-80 format
+//
+// If an error occurs during formatting, it returns a placeholder string.
+func (key *Ed25519PrivateKey) String() string {
+	s, err := key.ToAIP80()
+	if err != nil {
+		// This should never happen
+		log.Printf("Error formatting Ed25519PrivateKey: %v", err)
+		return "<error formatting Ed25519PrivateKey>"
+	}
+	return s
 }
 
 // FromHex sets the [Ed25519PrivateKey] to the bytes represented by the hex string, with or without a leading 0x

--- a/crypto/ed25519_test.go
+++ b/crypto/ed25519_test.go
@@ -102,6 +102,14 @@ func TestEd25519Keys(t *testing.T) {
 	assert.Equal(t, authenticator, authenticator2)
 }
 
+func TestEd25519Key_String(t *testing.T) {
+	t.Parallel()
+	privateKey := &Ed25519PrivateKey{}
+	err := privateKey.FromHex(testEd25519PrivateKeyHex)
+	require.NoError(t, err)
+	assert.Equal(t, testEd25519PrivateKey, privateKey.String())
+}
+
 func TestEd25519PrivateKeyWrongLength(t *testing.T) {
 	t.Parallel()
 	privateKey := &Ed25519PrivateKey{}

--- a/crypto/secp256k1.go
+++ b/crypto/secp256k1.go
@@ -3,6 +3,7 @@ package crypto
 import (
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/aptos-labs/aptos-go-sdk/bcs"
 	"github.com/aptos-labs/aptos-go-sdk/internal/util"
@@ -114,6 +115,19 @@ func (key *Secp256k1PrivateKey) ToHex() string {
 // ToAIP80 formats the private key to AIP-80 compliant string
 func (key *Secp256k1PrivateKey) ToAIP80() (string, error) {
 	return FormatPrivateKey(key.ToHex(), PrivateKeyVariantSecp256k1)
+}
+
+// String returns the string representation of the [Secp256k1PrivateKey] in the AIP-80 format
+//
+// If an error occurs during formatting, it returns a placeholder string.
+func (key *Secp256k1PrivateKey) String() string {
+	s, err := key.ToAIP80()
+	if err != nil {
+		// This should never happen
+		log.Printf("Error formatting Secp256k1PrivateKey: %v", err)
+		return "<error formatting Secp256k1PrivateKey>"
+	}
+	return s
 }
 
 // endregion

--- a/crypto/secp256k1_test.go
+++ b/crypto/secp256k1_test.go
@@ -134,6 +134,14 @@ func TestGenerateSecp256k1Key(t *testing.T) {
 	assert.True(t, privateKey.VerifyingKey().Verify(msg, sig))
 }
 
+func TestSecp256k1Key_String(t *testing.T) {
+	t.Parallel()
+	privateKey := &Secp256k1PrivateKey{}
+	err := privateKey.FromHex(testSecp256k1PrivateKeyHex)
+	require.NoError(t, err)
+	assert.Equal(t, testSecp256k1PrivateKey, privateKey.String())
+}
+
 func TestSecp256k1Signature_RecoverPublicKey(t *testing.T) {
 	t.Parallel()
 	privateKey := &Secp256k1PrivateKey{}


### PR DESCRIPTION
### Description
Add default string export to use the AIP-80 format.

### Test Plan
- [x] Added `Secp256k1` and `Ed25519` formatting tests

### Related Links
https://github.com/aptos-labs/aptos-go-sdk/pull/107