### PR TITLE
chore: update txn build opt for compatible with older aptos node

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aptos-labs/aptos-go-sdk/api"
+	"github.com/aptos-labs/aptos-go-sdk/crypto"
 	"github.com/hasura/go-graphql-client"
 )
 
@@ -104,6 +105,9 @@ type ExpirationSeconds uint64
 
 // FeePayer will set the fee payer for a transaction
 type FeePayer *AccountAddress
+
+// (Deprecated) FeePayerPublicKey will construct authenticator from public key.
+type FeePayerPublicKey crypto.PublicKey
 
 // AdditionalSigners will set the additional signers for a transaction
 type AdditionalSigners []AccountAddress

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -10,9 +10,6 @@ type Signer interface {
 	// SignMessage signs a message and returns the raw [Signature] without a [PublicKey] for verification
 	SignMessage(msg []byte) (signature Signature, err error)
 
-	// SimulationAuthenticator creates a new [AccountAuthenticator] for simulation purposes
-	SimulationAuthenticator() *AccountAuthenticator
-
 	// AuthKey gives the [AuthenticationKey] associated with the [Signer]
 	AuthKey() *AuthenticationKey
 
@@ -43,6 +40,9 @@ type PublicKey interface {
 
 	// Scheme The [DeriveScheme] used for address derivation
 	Scheme() DeriveScheme
+
+	// SimulationAuthenticator creates a new [AccountAuthenticator] for simulation purposes
+	SimulationAuthenticator() *AccountAuthenticator
 }
 
 // VerifyingKey a generic interface for a public key associated with the private key, but it cannot necessarily stand on

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -75,24 +75,6 @@ func (key *Ed25519PrivateKey) Sign(msg []byte) (*AccountAuthenticator, error) {
 	}, nil
 }
 
-// SimulationAuthenticator creates a new [AccountAuthenticator] for simulation purposes
-//
-// Implements:
-//   - [Signer]
-func (key *Ed25519PrivateKey) SimulationAuthenticator() *AccountAuthenticator {
-	pubkey, ok := key.PubKey().(*Ed25519PublicKey)
-	if !ok {
-		return nil
-	}
-	return &AccountAuthenticator{
-		Variant: AccountAuthenticatorEd25519,
-		Auth: &Ed25519Authenticator{
-			PubKey: pubkey,
-			Sig:    &Ed25519Signature{},
-		},
-	}
-}
-
 // PubKey returns the [Ed25519PublicKey] associated with the [Ed25519PrivateKey]
 //
 // Implements:
@@ -274,6 +256,20 @@ func (key *Ed25519PublicKey) AuthKey() *AuthenticationKey {
 //   - [PublicKey]
 func (key *Ed25519PublicKey) Scheme() uint8 {
 	return Ed25519Scheme
+}
+
+// SimulationAuthenticator creates a new [AccountAuthenticator] for simulation purposes
+//
+// Implements:
+//   - [PublicKey]
+func (key *Ed25519PublicKey) SimulationAuthenticator() *AccountAuthenticator {
+	return &AccountAuthenticator{
+		Variant: AccountAuthenticatorEd25519,
+		Auth: &Ed25519Authenticator{
+			PubKey: key,
+			Sig:    &Ed25519Signature{},
+		},
+	}
 }
 
 // endregion

--- a/crypto/multiEd25519.go
+++ b/crypto/multiEd25519.go
@@ -74,6 +74,20 @@ func (key *MultiEd25519PublicKey) Scheme() uint8 {
 	return MultiEd25519Scheme
 }
 
+// SimulationAuthenticator creates a new [AccountAuthenticator] for simulation purposes
+//
+// Implements:
+//   - [PublicKey]
+func (key *MultiEd25519PublicKey) SimulationAuthenticator() *AccountAuthenticator {
+	return &AccountAuthenticator{
+		Variant: AccountAuthenticatorMultiEd25519,
+		Auth: &MultiEd25519Authenticator{
+			PubKey: key,
+			Sig:    &MultiEd25519Signature{},
+		},
+	}
+}
+
 // endregion
 
 // region MultiEd25519PublicKey CryptoMaterial implementation

--- a/crypto/multiKey.go
+++ b/crypto/multiKey.go
@@ -82,6 +82,20 @@ func (key *MultiKey) Scheme() uint8 {
 	return MultiKeyScheme
 }
 
+// SimulationAuthenticator creates a new [AccountAuthenticator] for simulation purposes
+//
+// Implements:
+//   - [PublicKey]
+func (key *MultiKey) SimulationAuthenticator() *AccountAuthenticator {
+	return &AccountAuthenticator{
+		Variant: AccountAuthenticatorMultiKey,
+		Auth: &MultiKeyAuthenticator{
+			PubKey: key,
+			Sig:    &MultiKeySignature{},
+		},
+	}
+}
+
 // endregion
 
 // region MultiKey CryptoMaterial implementation

--- a/crypto/singleKey.go
+++ b/crypto/singleKey.go
@@ -204,6 +204,20 @@ func (key *AnyPublicKey) Scheme() uint8 {
 	return SingleKeyScheme
 }
 
+// SimulationAuthenticator creates a new [AccountAuthenticator] for simulation purposes
+
+// Implements:
+//   - [PublicKey]
+func (key *AnyPublicKey) SimulationAuthenticator() *AccountAuthenticator {
+	return &AccountAuthenticator{
+		Variant: AccountAuthenticatorSingleSender,
+		Auth: &SingleKeyAuthenticator{
+			PubKey: key,
+			Sig:    &AnySignature{},
+		},
+	}
+}
+
 // endregion
 
 // region AnyPublicKey CryptoMaterial implementation

--- a/internal/types/account.go
+++ b/internal/types/account.go
@@ -108,7 +108,7 @@ func (account *Account) SignMessage(message []byte) (crypto.Signature, error) {
 
 // SimulationAuthenticator creates a new authenticator for simulation purposes
 func (account *Account) SimulationAuthenticator() *crypto.AccountAuthenticator {
-	return account.Signer.SimulationAuthenticator()
+	return account.Signer.PubKey().SimulationAuthenticator()
 }
 
 // PubKey retrieves the public key for signature verification

--- a/nodeClient.go
+++ b/nodeClient.go
@@ -834,7 +834,11 @@ func (rc *NodeClient) SimulateTransactionMultiAgent(rawTxn *RawTransactionWithDa
 		case FeePayer:
 			feePayerAuth = crypto.NoAccountAuthenticator()
 		case FeePayerPublicKey:
-			feePayerAuth = ovalue.(crypto.PublicKey).SimulationAuthenticator()
+			pubKey, ok := ovalue.(crypto.PublicKey)
+			if !ok {
+				return nil, errors.New("FeePayerPublicKey must be a crypto.PublicKey")
+			}
+			feePayerAuth = pubKey.SimulationAuthenticator()
 		case AdditionalSigners:
 			additionalSigners = ovalue
 		default:
@@ -1003,7 +1007,11 @@ func (rc *NodeClient) BuildTransactionMultiAgent(sender AccountAddress, payload 
 			feePayer = ovalue
 		case FeePayerPublicKey:
 			feePayer = new(AccountAddress)
-			copy(feePayer[:], ovalue.(crypto.PublicKey).AuthKey()[:])
+			pubKey, ok := ovalue.(crypto.PublicKey)
+			if !ok {
+				return nil, errors.New("FeePayerPublicKey must be a crypto.PublicKey")
+			}
+			copy(feePayer[:], pubKey.AuthKey()[:])
 		case AdditionalSigners:
 			additionalSigners = ovalue
 		default:

--- a/spec_ed25519_test.go
+++ b/spec_ed25519_test.go
@@ -248,7 +248,7 @@ func Test_Spec_Ed25519_Authenticator(t *testing.T) {
 	// It should be able to generate an empty signature AccountAuthenticator
 	emptySig := key1.EmptySignature()
 	assert.Equal(t, &crypto.Ed25519Signature{}, emptySig, "It should be able to generate an empty signature AccountAuthenticator")
-	emptyAuth := key1.SimulationAuthenticator()
+	emptyAuth := key1.PubKey().SimulationAuthenticator()
 	pubkey, ok := pubKey1.(*crypto.Ed25519PublicKey)
 	require.True(t, ok)
 	sig, ok := emptySig.(*crypto.Ed25519Signature)


### PR DESCRIPTION
### Description
Aptos now support NoAccountSignature in simulation for fee payer and multi agent transaction. But it's only supported on node version >= 1.19.1. I add an old way to simulate using public key of fee payer to construct authenticator with zero signature. It would support more wide range of aptos node versions.

### Related Links
- [Release node](https://github.com/aptos-labs/aptos-core/releases/tag/aptos-node-v1.19.1)
- [PR that support NoAccountSignature](https://github.com/aptos-labs/aptos-core/pull/13714)
- [Aptos TS SDK](https://github.com/aptos-labs/aptos-ts-sdk/blob/4b1296a2672a40519b96ccf3e490d9dc4591cbcf/src/transactions/transactionBuilder/transactionBuilder.ts#L666-L716) reference still use public key if provided.
