### PR TITLE
Fix AccountTransactions pagination underflow at sequence 0 (v1); clarify v2

### DIFF
--- a/client.go
+++ b/client.go
@@ -263,7 +263,7 @@ type AptosRpcClient interface {
 	Transactions(start *uint64, limit *uint64) ([]*api.CommittedTransaction, error)
 
 	// AccountTransactions Get transactions associated with an account.
-	// Start is a version number. Nil for most recent transactions.
+	// Start is an account sequence number (REST query parameter `start`). Nil for most recent transactions.
 	// Limit is a number of transactions to return. 'about a hundred' by default.
 	//
 	//	client.AccountTransactions(AccountOne, 0, 2)   // Returns 2 transactions for 0x1
@@ -733,7 +733,7 @@ func (client *Client) Transactions(start *uint64, limit *uint64) ([]*api.Committ
 }
 
 // AccountTransactions Get transactions associated with an account.
-// Start is a version number. Nil for most recent transactions.
+// Start is an account sequence number (REST query parameter `start`). Nil for most recent transactions.
 // Limit is a number of transactions to return. 'about a hundred' by default.
 //
 //	client.AccountTransactions(AccountOne, 0, 2)   // Returns 2 transactions for 0x1

--- a/nodeClient.go
+++ b/nodeClient.go
@@ -440,9 +440,13 @@ func (rc *NodeClient) WaitForTransaction(txnHash string, options ...any) (*api.U
 //   - start is a version number. Nil for most recent transactions.
 //   - limit is a number of transactions to return. 'about a hundred' by default.
 func (rc *NodeClient) Transactions(start *uint64, limit *uint64) ([]*api.CommittedTransaction, error) {
-	return rc.handleTransactions(start, limit, func(txns *[]*api.CommittedTransaction) uint64 {
+	return rc.handleTransactions(start, limit, func(txns *[]*api.CommittedTransaction) (uint64, bool) {
 		txn := (*txns)[len(*txns)-1]
-		return txn.Version()
+		v := txn.Version()
+		if v == 0 {
+			return 0, false
+		}
+		return v - 1, true
 	}, func(start *uint64, limit *uint64) ([]*api.CommittedTransaction, error) {
 		return rc.transactionsInner(start, limit)
 	})
@@ -454,10 +458,16 @@ func (rc *NodeClient) Transactions(start *uint64, limit *uint64) ([]*api.Committ
 //   - start is a version number. Nil for most recent transactions.
 //   - limit is a number of transactions to return. 'about a hundred' by default.
 func (rc *NodeClient) AccountTransactions(account AccountAddress, start *uint64, limit *uint64) ([]*api.CommittedTransaction, error) {
-	return rc.handleTransactions(start, limit, func(txns *[]*api.CommittedTransaction) uint64 {
+	return rc.handleTransactions(start, limit, func(txns *[]*api.CommittedTransaction) (uint64, bool) {
+		if len(*txns) == 0 {
+			return 0, false
+		}
 		// It will always be a UserTransaction, no other type will come from the API
 		userTxn, _ := ((*txns)[0]).UserTransaction()
-		return userTxn.SequenceNumber - 1
+		if userTxn.SequenceNumber == 0 {
+			return 0, false
+		}
+		return userTxn.SequenceNumber - 1, true
 	}, func(start *uint64, limit *uint64) ([]*api.CommittedTransaction, error) {
 		return rc.accountTransactionsInner(account, start, limit)
 	})
@@ -654,7 +664,7 @@ func (rc *NodeClient) EventsByCreationNumber(
 func (rc *NodeClient) handleTransactions(
 	start *uint64,
 	limit *uint64,
-	getNext func(txns *[]*api.CommittedTransaction) uint64,
+	getNext func(txns *[]*api.CommittedTransaction) (nextStart uint64, ok bool),
 	getTxns func(start *uint64, limit *uint64) ([]*api.CommittedTransaction, error),
 ) ([]*api.CommittedTransaction, error) {
 	// Can only pull everything in parallel if a start and a limit is handled
@@ -675,7 +685,10 @@ func (rc *NodeClient) handleTransactions(
 			return txns, nil
 		}
 
-		newStart := getNext(&txns)
+		newStart, hasPrev := getNext(&txns)
+		if !hasPrev {
+			return txns, nil
+		}
 		newLength := actualLimit - numTxns
 		extra, err := rc.transactionsConcurrent(newStart, newLength, getTxns)
 		if err != nil {

--- a/nodeClient.go
+++ b/nodeClient.go
@@ -441,6 +441,9 @@ func (rc *NodeClient) WaitForTransaction(txnHash string, options ...any) (*api.U
 //   - limit is a number of transactions to return. 'about a hundred' by default.
 func (rc *NodeClient) Transactions(start *uint64, limit *uint64) ([]*api.CommittedTransaction, error) {
 	return rc.handleTransactions(start, limit, func(txns *[]*api.CommittedTransaction) (uint64, bool) {
+		if len(*txns) == 0 {
+			return 0, false
+		}
 		txn := (*txns)[len(*txns)-1]
 		v := txn.Version()
 		if v == 0 {
@@ -455,7 +458,7 @@ func (rc *NodeClient) Transactions(start *uint64, limit *uint64) ([]*api.Committ
 // AccountTransactions Get recent transactions for an account
 //
 // Arguments:
-//   - start is a version number. Nil for most recent transactions.
+//   - start is an account sequence number (REST query parameter `start`). Nil for most recent transactions.
 //   - limit is a number of transactions to return. 'about a hundred' by default.
 func (rc *NodeClient) AccountTransactions(account AccountAddress, start *uint64, limit *uint64) ([]*api.CommittedTransaction, error) {
 	return rc.handleTransactions(start, limit, func(txns *[]*api.CommittedTransaction) (uint64, bool) {

--- a/nodeClient_test.go
+++ b/nodeClient_test.go
@@ -280,6 +280,47 @@ func TestNodeClient_AccountTransactions(t *testing.T) {
 	assert.Len(t, txns, 1)
 }
 
+func TestNodeClient_AccountTransactions_LimitOnly_NoUnderflowAtSeqZero(t *testing.T) {
+	t.Parallel()
+	var requestCount int
+	client, server := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if start := r.URL.Query().Get("start"); start != "" {
+			assert.NotEqual(t, "18446744073709551615", start,
+				"previous-page cursor must not underflow sequence number 0")
+		}
+		assert.Contains(t, r.URL.Path, "/transactions")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"type":                      "user_transaction",
+				"hash":                      "0xaaa",
+				"version":                   "100",
+				"success":                   true,
+				"sender":                    "0x1",
+				"sequence_number":           "0",
+				"max_gas_amount":            "100000",
+				"gas_unit_price":            "100",
+				"expiration_timestamp_secs": "9999999999",
+				"gas_used":                  "42",
+				"vm_status":                 "Executed successfully",
+				"timestamp":                 "1000000",
+				"accumulator_root_hash":     "0x0",
+				"state_change_hash":         "0x0",
+				"event_root_hash":           "0x0",
+				"changes":                   []any{},
+				"events":                    []any{},
+			},
+		})
+	})
+	defer server.Close()
+
+	limit := uint64(9)
+	txns, err := client.AccountTransactions(AccountOne, nil, &limit)
+	require.NoError(t, err)
+	assert.Len(t, txns, 1)
+	assert.Equal(t, 1, requestCount, "must not request an earlier page when already at sequence 0")
+}
+
 func TestNodeClient_SubmitTransaction(t *testing.T) {
 	t.Parallel()
 	client, server := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/nodeClient_test.go
+++ b/nodeClient_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -282,9 +283,9 @@ func TestNodeClient_AccountTransactions(t *testing.T) {
 
 func TestNodeClient_AccountTransactions_LimitOnly_NoUnderflowAtSeqZero(t *testing.T) {
 	t.Parallel()
-	var requestCount int
+	var requestCount atomic.Int32
 	client, server := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+		requestCount.Add(1)
 		if start := r.URL.Query().Get("start"); start != "" {
 			assert.NotEqual(t, "18446744073709551615", start,
 				"previous-page cursor must not underflow sequence number 0")
@@ -318,14 +319,14 @@ func TestNodeClient_AccountTransactions_LimitOnly_NoUnderflowAtSeqZero(t *testin
 	txns, err := client.AccountTransactions(AccountOne, nil, &limit)
 	require.NoError(t, err)
 	assert.Len(t, txns, 1)
-	assert.Equal(t, 1, requestCount, "must not request an earlier page when already at sequence 0")
+	assert.Equal(t, int32(1), requestCount.Load(), "must not request an earlier page when already at sequence 0")
 }
 
 func TestNodeClient_Transactions_LimitOnly_NoUnderflowAtVersionZero(t *testing.T) {
 	t.Parallel()
-	var requestCount int
+	var requestCount atomic.Int32
 	client, server := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+		requestCount.Add(1)
 		if start := r.URL.Query().Get("start"); start != "" {
 			assert.NotEqual(t, "18446744073709551615", start,
 				"previous-page cursor must not underflow ledger version 0")
@@ -367,7 +368,24 @@ func TestNodeClient_Transactions_LimitOnly_NoUnderflowAtVersionZero(t *testing.T
 	txns, err := client.Transactions(nil, &limit)
 	require.NoError(t, err)
 	assert.Len(t, txns, 2)
-	assert.Equal(t, 1, requestCount, "must not request an earlier page when oldest version on page is 0")
+	assert.Equal(t, int32(1), requestCount.Load(), "must not request an earlier page when oldest version on page is 0")
+}
+
+func TestNodeClient_Transactions_LimitOnly_EmptyFirstPage(t *testing.T) {
+	t.Parallel()
+	var requestCount atomic.Int32
+	client, server := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		assert.Equal(t, "/transactions", r.URL.Path)
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
+	})
+	defer server.Close()
+
+	limit := uint64(9)
+	txns, err := client.Transactions(nil, &limit)
+	require.NoError(t, err)
+	assert.Empty(t, txns)
+	assert.Equal(t, int32(1), requestCount.Load())
 }
 
 func TestNodeClient_SubmitTransaction(t *testing.T) {

--- a/nodeClient_test.go
+++ b/nodeClient_test.go
@@ -321,6 +321,55 @@ func TestNodeClient_AccountTransactions_LimitOnly_NoUnderflowAtSeqZero(t *testin
 	assert.Equal(t, 1, requestCount, "must not request an earlier page when already at sequence 0")
 }
 
+func TestNodeClient_Transactions_LimitOnly_NoUnderflowAtVersionZero(t *testing.T) {
+	t.Parallel()
+	var requestCount int
+	client, server := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if start := r.URL.Query().Get("start"); start != "" {
+			assert.NotEqual(t, "18446744073709551615", start,
+				"previous-page cursor must not underflow ledger version 0")
+		}
+		assert.Equal(t, "/transactions", r.URL.Path)
+		// Newest-first page: oldest txn is last; version 0 means no earlier ledger page.
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"type":                  "state_checkpoint_transaction",
+				"hash":                  "0x2",
+				"version":               "1",
+				"success":               true,
+				"accumulator_root_hash": "0x0",
+				"state_change_hash":     "0x0",
+				"event_root_hash":       "0x0",
+				"changes":               []any{},
+				"events":                []any{},
+				"timestamp":             "1000000",
+				"state_checkpoint_hash": "0x0",
+			},
+			{
+				"type":                  "state_checkpoint_transaction",
+				"hash":                  "0x1",
+				"version":               "0",
+				"success":               true,
+				"accumulator_root_hash": "0x0",
+				"state_change_hash":     "0x0",
+				"event_root_hash":       "0x0",
+				"changes":               []any{},
+				"events":                []any{},
+				"timestamp":             "1000000",
+				"state_checkpoint_hash": "0x0",
+			},
+		})
+	})
+	defer server.Close()
+
+	limit := uint64(9)
+	txns, err := client.Transactions(nil, &limit)
+	require.NoError(t, err)
+	assert.Len(t, txns, 2)
+	assert.Equal(t, 1, requestCount, "must not request an earlier page when oldest version on page is 0")
+}
+
 func TestNodeClient_SubmitTransaction(t *testing.T) {
 	t.Parallel()
 	client, server := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/v2/node_client.go
+++ b/v2/node_client.go
@@ -578,7 +578,7 @@ func (c *nodeClient) AccountModule(ctx context.Context, address AccountAddress, 
 }
 
 // AccountTransactions returns transactions sent by an account in a single REST response.
-// Unlike [github.com/aptos-labs/aptos-go-sdk/v1].NodeClient.AccountTransactions, this does not
+// Unlike [github.com/aptos-labs/aptos-go-sdk.NodeClient.AccountTransactions], this does not
 // merge multiple pages when [limit] is larger than one response page; pass an explicit [start]
 // and/or issue additional calls if you need more than the node returns in one request.
 func (c *nodeClient) AccountTransactions(ctx context.Context, address AccountAddress, start *uint64, limit *uint64) ([]*Transaction, error) {

--- a/v2/node_client.go
+++ b/v2/node_client.go
@@ -577,7 +577,10 @@ func (c *nodeClient) AccountModule(ctx context.Context, address AccountAddress, 
 	return &module, nil
 }
 
-// AccountTransactions returns transactions sent by an account.
+// AccountTransactions returns transactions sent by an account in a single REST response.
+// Unlike [github.com/aptos-labs/aptos-go-sdk/v1].NodeClient.AccountTransactions, this does not
+// merge multiple pages when [limit] is larger than one response page; pass an explicit [start]
+// and/or issue additional calls if you need more than the node returns in one request.
 func (c *nodeClient) AccountTransactions(ctx context.Context, address AccountAddress, start *uint64, limit *uint64) ([]*Transaction, error) {
 	path := fmt.Sprintf("accounts/%s/transactions", address.String())
 	params := url.Values{}

--- a/v2/node_client_test.go
+++ b/v2/node_client_test.go
@@ -96,6 +96,36 @@ func TestNodeClient_AccountTransactions_WithParams(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestNodeClient_AccountTransactions_LimitOnly_SingleRequestNoUnderflowPath(t *testing.T) {
+	t.Parallel()
+	var requestCount int
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		assert.Contains(t, r.URL.Path, "/accounts/")
+		assert.Contains(t, r.URL.Path, "/transactions")
+		q := r.URL.Query()
+		assert.Empty(t, q.Get("start"), "nil start must not send a start query param")
+		assert.Equal(t, "9", q.Get("limit"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]*Transaction{
+			{
+				Type:           "user_transaction",
+				Hash:           "0xaaa",
+				Version:        100,
+				Success:        true,
+				SequenceNumber: 0,
+			},
+		})
+	}))
+
+	limit := uint64(9)
+	result, err := client.AccountTransactions(context.Background(), AccountOne, nil, &limit)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, uint64(0), result[0].SequenceNumber)
+	assert.Equal(t, 1, requestCount, "v2 performs one GET; no client-side back-pagination")
+}
+
 func TestNodeClient_EventsByCreationNumber(t *testing.T) {
 	t.Parallel()
 	events := []Event{{Type: "0x1::coin::DepositEvent", SequenceNumber: 0}}

--- a/v2/node_client_test.go
+++ b/v2/node_client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -98,13 +99,14 @@ func TestNodeClient_AccountTransactions_WithParams(t *testing.T) {
 
 func TestNodeClient_AccountTransactions_LimitOnly_SingleRequestNoUnderflowPath(t *testing.T) {
 	t.Parallel()
-	var requestCount int
+	var requestCount atomic.Int32
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+		requestCount.Add(1)
 		assert.Contains(t, r.URL.Path, "/accounts/")
 		assert.Contains(t, r.URL.Path, "/transactions")
 		q := r.URL.Query()
-		assert.Empty(t, q.Get("start"), "nil start must not send a start query param")
+		_, hasStart := q["start"]
+		assert.False(t, hasStart, "nil start must omit the start query parameter")
 		assert.Equal(t, "9", q.Get("limit"))
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode([]*Transaction{
@@ -123,7 +125,7 @@ func TestNodeClient_AccountTransactions_LimitOnly_SingleRequestNoUnderflowPath(t
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	assert.Equal(t, uint64(0), result[0].SequenceNumber)
-	assert.Equal(t, 1, requestCount, "v2 performs one GET; no client-side back-pagination")
+	assert.Equal(t, int32(1), requestCount.Load(), "v2 performs one GET; no client-side back-pagination")
 }
 
 func TestNodeClient_EventsByCreationNumber(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes v1 `NodeClient.AccountTransactions` when called with `start == nil` and a non-nil `limit`: the previous-page cursor was computed as `userTxn.SequenceNumber - 1`, which underflows for sequence `0` and produced `start=18446744073709551615` on the follow-up request.

`handleTransactions` now uses a `(nextStart, ok)` result from the pagination callback. When there is no earlier page (`ok == false`), the helper returns the transactions from the first response only.

Also guards `Transactions()` when the first page is empty or when subtracting for the next cursor would underflow at ledger version `0`.

v2 `nodeClient.AccountTransactions` only performs a single HTTP GET and does not implement v1’s multi-page merge. Godoc compares to `[github.com/aptos-labs/aptos-go-sdk.NodeClient.AccountTransactions]` and notes the behavioral difference.

### Test Plan

- `go test -short ./...` (v1)
- `cd v2 && go test -short ./...`
- `go test -race -short ./... -run 'TestNodeClient_(AccountTransactions_LimitOnly|Transactions_LimitOnly)'` and v2 equivalent
- `gofumpt -l -w .` and `golangci-lint run` (root)

Mock regressions:

- `TestNodeClient_AccountTransactions_LimitOnly_NoUnderflowAtSeqZero`
- `TestNodeClient_Transactions_LimitOnly_NoUnderflowAtVersionZero`
- `TestNodeClient_Transactions_LimitOnly_EmptyFirstPage`
- `TestNodeClient_AccountTransactions_LimitOnly_SingleRequestNoUnderflowPath` (v2)

### Related Links

- Follow-up on Copilot PR review (#214).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e666373c-5c06-4bb1-af11-32f02cb65028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e666373c-5c06-4bb1-af11-32f02cb65028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

