### PR TITLE
Pin GitHub Actions dependencies

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1,0 +1,8 @@
+# GitHub Actions pinning policy
+
+External GitHub Actions used by workflows or local composite actions are pinned to
+full commit SHAs. Keep the upstream version in a trailing comment so Dependabot,
+Renovate, or a manual audit can identify the intended release.
+
+When updating an action, resolve the release tag to its current commit and review
+the upstream changelog before replacing the pinned SHA.

--- a/.github/actions/run-go-tests/action.yaml
+++ b/.github/actions/run-go-tests/action.yaml
@@ -5,15 +5,13 @@ description: |
 runs:
   using: composite
   steps:
-    # Setup checkout of Git
-    - uses: actions/checkout@v6
     # Setup Go
-    - uses: actions/setup-go@v6
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: '>=1.24'
     # Run a local testnet in the background. After this action runs the local testnet
     # should be up and queryable. This also installs node and pnpm for us.
-    - uses: aptos-labs/actions/run-local-testnet@main
+    - uses: aptos-labs/actions/run-local-testnet@528ef7ad9427a8c0720ea3eea790a9190d6e377d # main
       with:
         PNPM_VERSION: 8.9.0
     # Run unit tests

--- a/.github/actions/run-gofumpt/action.yaml
+++ b/.github/actions/run-gofumpt/action.yaml
@@ -5,17 +5,15 @@ description: |
 runs:
   using: composite
   steps:
-    # Setup checkout of Git
-    - uses: actions/checkout@v6
     # Setup Go
-    - uses: actions/setup-go@v6
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: '>=1.24'
     # Run vet and formatter
     - shell: bash
       run: 'go vet ./...'
     - shell: bash
-      run: 'go install mvdan.cc/gofumpt@latest'
+      run: 'go install mvdan.cc/gofumpt@v0.9.2'
     - shell: bash
       run: "(test `gofumpt -l -e . | wc -l | sed 's/ //g'` = '0' && echo 'Formatting is good') || (echo 'Formatting is wrong please run gofumpt -l -w' && exit -1)"
 

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -10,16 +10,20 @@ on:
 env:
   GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     name: Generate Coverage Report
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ env.GIT_SHA }}
+          persist-credentials: false
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ">=1.24"
 
@@ -37,7 +41,7 @@ jobs:
 
       # Upload v2 coverage to Codecov
       - name: Upload v2 coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./v2/coverage.out
           flags: v2
@@ -49,7 +53,7 @@ jobs:
 
       # Upload v1 coverage to Codecov (if available)
       - name: Upload v1 coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         if: hashFiles('coverage-v1.out') != ''
         with:
           files: ./coverage-v1.out

--- a/.github/workflows/gofumpt-lint.yaml
+++ b/.github/workflows/gofumpt-lint.yaml
@@ -1,4 +1,7 @@
 name: gofumpt
+env:
+  GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
 on:
   push:
     branches:
@@ -16,11 +19,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version: stable
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ env.GIT_SHA }}
+          persist-credentials: false
       - uses: ./.github/actions/run-gofumpt

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -8,19 +8,19 @@ on:
 
 permissions:
   contents: read
-  # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  # pull-requests: read
 
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
-          version: latest
+          version: v2.11.4

--- a/.github/workflows/run-go-tests.yaml
+++ b/.github/workflows/run-go-tests.yaml
@@ -9,11 +9,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ env.GIT_SHA }}
+          persist-credentials: false
       - uses: ./.github/actions/run-go-tests


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Pin GitHub Actions workflow dependencies to immutable commit SHAs and reduce token exposure in CI.

Changes include:
- Pin external workflow and composite-action `uses:` references to full commit SHAs.
- Disable checkout credential persistence where workflows only need read-only access.
- Add missing top-level read-only `contents` permissions.
- Remove redundant checkouts from local composite actions so the calling workflow controls the checked-out ref.
- Pin mutable tool installs (`gofumpt`, `golangci-lint`) to concrete versions.
- Document the action pinning policy for future updates.

### Test Plan
- `git diff --check`
- Custom scan verifying all external `.github` `uses:` references are pinned to full 40-character commit SHAs
- `gofumpt -l -w .`
- `golangci-lint run`
- `go test -short ./...`
- `cd v2 && go test -short ./...`

### Related Links
<!-- Please link to any relevant issues or pull requests! -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-878a1008-70ce-4c90-b982-25a224009845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-878a1008-70ce-4c90-b982-25a224009845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

