### PR TITLE
Fix CI gofumpt and golangci-lint failures; add mise.toml for consistent tooling

### DIFF
--- a/.github/actions/run-go-tests/action.yaml
+++ b/.github/actions/run-go-tests/action.yaml
@@ -1,22 +1,20 @@
 name: "Go Unit Tests"
 description: |
-  Run Go unit tests
+  Run Go unit tests. The Go version is pinned via mise.toml so the build
+  uses the same toolchain as the lint and format jobs.
 
 runs:
   using: composite
   steps:
-    # Setup checkout of Git
-    - uses: actions/checkout@v6
-    # Setup Go
-    - uses: actions/setup-go@v6
+    - uses: jdx/mise-action@v4
       with:
-        go-version: '>=1.24'
+        install_args: "go"
+        cache: true
     # Run a local testnet in the background. After this action runs the local testnet
     # should be up and queryable. This also installs node and pnpm for us.
     - uses: aptos-labs/actions/run-local-testnet@main
       with:
         PNPM_VERSION: 8.9.0
-    # Run unit tests
 
     - shell: bash
       run: |

--- a/.github/actions/run-gofumpt/action.yaml
+++ b/.github/actions/run-gofumpt/action.yaml
@@ -1,21 +1,15 @@
-name: "Go Unit Tests"
+name: "gofumpt formatting check"
 description: |
-  Run Go unit tests
+  Check Go source formatting with gofumpt at the version pinned in mise.toml.
 
 runs:
   using: composite
   steps:
-    # Setup checkout of Git
-    - uses: actions/checkout@v6
-    # Setup Go
-    - uses: actions/setup-go@v6
+    - uses: jdx/mise-action@v4
       with:
-        go-version: '>=1.24'
-    # Run vet and formatter
+        install_args: "go gofumpt"
+        cache: true
     - shell: bash
       run: 'go vet ./...'
     - shell: bash
-      run: 'go install mvdan.cc/gofumpt@latest'
-    - shell: bash
-      run: "(test `gofumpt -l -e . | wc -l | sed 's/ //g'` = '0' && echo 'Formatting is good') || (echo 'Formatting is wrong please run gofumpt -l -w' && exit -1)"
-
+      run: 'mise run fmt-check'

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -19,9 +19,10 @@ jobs:
         with:
           ref: ${{ env.GIT_SHA }}
 
-      - uses: actions/setup-go@v6
+      - uses: jdx/mise-action@v4
         with:
-          go-version: ">=1.24"
+          install_args: "go"
+          cache: true
 
       # Run v2 SDK tests with coverage
       - name: Run v2 SDK tests with coverage

--- a/.github/workflows/gofumpt-lint.yaml
+++ b/.github/workflows/gofumpt-lint.yaml
@@ -17,10 +17,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version: stable
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ env.GIT_SHA }}
       - uses: ./.github/actions/run-gofumpt

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,10 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: jdx/mise-action@v4
         with:
-          go-version: stable
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: latest
+          install_args: "go golangci-lint"
+          cache: true
+      - name: golangci-lint (v1)
+        run: mise run lint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,7 +24,7 @@ linters:
     - gocritic
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -431,7 +431,7 @@ func (o *UserTransaction) UnmarshalJSON(b []byte) error {
 	o.StateCheckpointHash = data.StateCheckpointHash
 
 	if data.ReplayProtectionNonce != nil {
-		replayNonce := (data.ReplayProtectionNonce).ToUint64()
+		replayNonce := data.ReplayProtectionNonce.ToUint64()
 		o.ReplayProtectionNonce = &replayNonce
 	}
 	return nil

--- a/client_test.go
+++ b/client_test.go
@@ -767,7 +767,8 @@ func buildSingleSignerScript(client *Client, sender TransactionSigner, options .
 	amount := uint64(1)
 	dest := AccountOne
 
-	rawTxn, err := client.BuildTransaction(sender.AccountAddress(),
+	rawTxn, err := client.BuildTransaction(
+		sender.AccountAddress(),
 		TransactionPayload{Payload: &Script{
 			Code:     scriptBytes,
 			ArgTypes: []TypeTag{},

--- a/examples/external_signing/main.go
+++ b/examples/external_signing/main.go
@@ -117,7 +117,8 @@ func example(networkConfig aptos.NetworkConfig) {
 
 	// Sign transaction
 	fmt.Printf("Submit a coin transfer to address %s\n", receiver.String())
-	rawTxn, err := client.BuildTransaction(sender.Address,
+	rawTxn, err := client.BuildTransaction(
+		sender.Address,
 		aptos.TransactionPayload{Payload: payload},
 	)
 	if err != nil {

--- a/examples/fungible_asset/main.go
+++ b/examples/fungible_asset/main.go
@@ -189,17 +189,18 @@ func runScript(client *aptos.Client, alice *aptos.Account, bob *aptos.AccountAdd
 	}
 
 	// 1. Build transaction
-	rawTxn, err := client.BuildTransaction(alice.AccountAddress(), aptos.TransactionPayload{
-		Payload: &aptos.Script{
-			Code:     scriptBytes,
-			ArgTypes: []aptos.TypeTag{},
-			Args: []aptos.ScriptArgument{
-				{Variant: aptos.ScriptArgumentAddress, Value: *faMetadataAddress},
-				{Variant: aptos.ScriptArgumentAddress, Value: *bob},
-				{Variant: aptos.ScriptArgumentU64, Value: TransferAmount},
+	rawTxn, err := client.BuildTransaction(
+		alice.AccountAddress(), aptos.TransactionPayload{
+			Payload: &aptos.Script{
+				Code:     scriptBytes,
+				ArgTypes: []aptos.TypeTag{},
+				Args: []aptos.ScriptArgument{
+					{Variant: aptos.ScriptArgumentAddress, Value: *faMetadataAddress},
+					{Variant: aptos.ScriptArgumentAddress, Value: *bob},
+					{Variant: aptos.ScriptArgumentU64, Value: TransferAmount},
+				},
 			},
 		},
-	},
 	)
 	if err != nil {
 		panic("Failed to build transaction:" + err.Error())

--- a/examples/offchain_multisig/main.go
+++ b/examples/offchain_multisig/main.go
@@ -261,20 +261,21 @@ func example(networkConfig aptos.NetworkConfig) {
 	if err != nil {
 		panic("Failed to serialize transfer amount:" + err.Error())
 	}
-	rawTxn, err := client.BuildTransaction(multikeyAddress, aptos.TransactionPayload{
-		Payload: &aptos.EntryFunction{
-			Module: aptos.ModuleId{
-				Address: aptos.AccountOne,
-				Name:    "aptos_account",
-			},
-			Function: "transfer",
-			ArgTypes: []aptos.TypeTag{},
-			Args: [][]byte{
-				accountBytes,
-				amountBytes,
+	rawTxn, err := client.BuildTransaction(
+		multikeyAddress, aptos.TransactionPayload{
+			Payload: &aptos.EntryFunction{
+				Module: aptos.ModuleId{
+					Address: aptos.AccountOne,
+					Name:    "aptos_account",
+				},
+				Function: "transfer",
+				ArgTypes: []aptos.TypeTag{},
+				Args: [][]byte{
+					accountBytes,
+					amountBytes,
+				},
 			},
 		},
-	},
 	)
 	if err != nil {
 		panic("Failed to build transaction:" + err.Error())

--- a/examples/orderless_transaction/main.go
+++ b/examples/orderless_transaction/main.go
@@ -64,32 +64,33 @@ func example(networkConfig aptos.NetworkConfig) {
 		panic("Failed to serialize transfer amount:" + err.Error())
 	}
 	replayNonce := uint64(100)
-	rawTxn, err := client.BuildTransaction(alice.AccountAddress(), aptos.TransactionPayload{
-		Payload: &aptos.TransactionInnerPayload{
-			Payload: &aptos.TransactionInnerPayloadV1{
-				Executable: aptos.TransactionExecutable{
-					Inner: &aptos.EntryFunction{
-						Module: aptos.ModuleId{
-							Address: aptos.AccountOne,
-							Name:    "aptos_account",
-						},
-						Function: "transfer",
-						ArgTypes: []aptos.TypeTag{},
-						Args: [][]byte{
-							accountBytes,
-							amountBytes,
+	rawTxn, err := client.BuildTransaction(
+		alice.AccountAddress(), aptos.TransactionPayload{
+			Payload: &aptos.TransactionInnerPayload{
+				Payload: &aptos.TransactionInnerPayloadV1{
+					Executable: aptos.TransactionExecutable{
+						Inner: &aptos.EntryFunction{
+							Module: aptos.ModuleId{
+								Address: aptos.AccountOne,
+								Name:    "aptos_account",
+							},
+							Function: "transfer",
+							ArgTypes: []aptos.TypeTag{},
+							Args: [][]byte{
+								accountBytes,
+								amountBytes,
+							},
 						},
 					},
-				},
-				ExtraConfig: aptos.TransactionExtraConfig{
-					Inner: &aptos.TransactionExtraConfigV1{
-						MultisigAddress:       nil,
-						ReplayProtectionNonce: &replayNonce,
+					ExtraConfig: aptos.TransactionExtraConfig{
+						Inner: &aptos.TransactionExtraConfigV1{
+							MultisigAddress:       nil,
+							ReplayProtectionNonce: &replayNonce,
+						},
 					},
 				},
 			},
 		},
-	},
 		aptos.ExpirationSeconds(60),
 	)
 	if err != nil {
@@ -146,32 +147,33 @@ func example(networkConfig aptos.NetworkConfig) {
 
 	// Now do it again, but with a different method
 	replayNonce2 := uint64(256)
-	resp, err := client.BuildSignAndSubmitTransaction(alice, aptos.TransactionPayload{
-		Payload: &aptos.TransactionInnerPayload{
-			Payload: &aptos.TransactionInnerPayloadV1{
-				Executable: aptos.TransactionExecutable{
-					Inner: &aptos.EntryFunction{
-						Module: aptos.ModuleId{
-							Address: aptos.AccountOne,
-							Name:    "aptos_account",
-						},
-						Function: "transfer",
-						ArgTypes: []aptos.TypeTag{},
-						Args: [][]byte{
-							accountBytes,
-							amountBytes,
+	resp, err := client.BuildSignAndSubmitTransaction(
+		alice, aptos.TransactionPayload{
+			Payload: &aptos.TransactionInnerPayload{
+				Payload: &aptos.TransactionInnerPayloadV1{
+					Executable: aptos.TransactionExecutable{
+						Inner: &aptos.EntryFunction{
+							Module: aptos.ModuleId{
+								Address: aptos.AccountOne,
+								Name:    "aptos_account",
+							},
+							Function: "transfer",
+							ArgTypes: []aptos.TypeTag{},
+							Args: [][]byte{
+								accountBytes,
+								amountBytes,
+							},
 						},
 					},
-				},
-				ExtraConfig: aptos.TransactionExtraConfig{
-					Inner: &aptos.TransactionExtraConfigV1{
-						MultisigAddress:       nil,
-						ReplayProtectionNonce: &replayNonce2,
+					ExtraConfig: aptos.TransactionExtraConfig{
+						Inner: &aptos.TransactionExtraConfigV1{
+							MultisigAddress:       nil,
+							ReplayProtectionNonce: &replayNonce2,
+						},
 					},
 				},
 			},
 		},
-	},
 		aptos.ExpirationSeconds(60),
 	)
 	if err != nil {

--- a/examples/transfer_coin/main.go
+++ b/examples/transfer_coin/main.go
@@ -63,20 +63,21 @@ func example(networkConfig aptos.NetworkConfig) {
 	if err != nil {
 		panic("Failed to serialize transfer amount:" + err.Error())
 	}
-	rawTxn, err := client.BuildTransaction(alice.AccountAddress(), aptos.TransactionPayload{
-		Payload: &aptos.EntryFunction{
-			Module: aptos.ModuleId{
-				Address: aptos.AccountOne,
-				Name:    "aptos_account",
-			},
-			Function: "transfer",
-			ArgTypes: []aptos.TypeTag{},
-			Args: [][]byte{
-				accountBytes,
-				amountBytes,
+	rawTxn, err := client.BuildTransaction(
+		alice.AccountAddress(), aptos.TransactionPayload{
+			Payload: &aptos.EntryFunction{
+				Module: aptos.ModuleId{
+					Address: aptos.AccountOne,
+					Name:    "aptos_account",
+				},
+				Function: "transfer",
+				ArgTypes: []aptos.TypeTag{},
+				Args: [][]byte{
+					accountBytes,
+					amountBytes,
+				},
 			},
 		},
-	},
 	)
 	if err != nil {
 		panic("Failed to build transaction:" + err.Error())
@@ -129,20 +130,21 @@ func example(networkConfig aptos.NetworkConfig) {
 	fmt.Printf("Bob:%d\n", bobBalance)
 
 	// Now do it again, but with a different method
-	resp, err := client.BuildSignAndSubmitTransaction(alice, aptos.TransactionPayload{
-		Payload: &aptos.EntryFunction{
-			Module: aptos.ModuleId{
-				Address: aptos.AccountOne,
-				Name:    "aptos_account",
-			},
-			Function: "transfer",
-			ArgTypes: []aptos.TypeTag{},
-			Args: [][]byte{
-				accountBytes,
-				amountBytes,
+	resp, err := client.BuildSignAndSubmitTransaction(
+		alice, aptos.TransactionPayload{
+			Payload: &aptos.EntryFunction{
+				Module: aptos.ModuleId{
+					Address: aptos.AccountOne,
+					Name:    "aptos_account",
+				},
+				Function: "transfer",
+				ArgTypes: []aptos.TypeTag{},
+				Args: [][]byte{
+					accountBytes,
+					amountBytes,
+				},
 			},
 		},
-	},
 	)
 	if err != nil {
 		panic("Failed to sign transaction:" + err.Error())

--- a/http.go
+++ b/http.go
@@ -45,13 +45,15 @@ func NewHttpError(response *http.Response) *HttpError {
 //   - [Error]
 func (he *HttpError) Error() string {
 	if len(he.Body) < HttpErrSummaryLength {
-		return fmt.Sprintf("HttpError %s %#v -> %#v %#v",
+		return fmt.Sprintf(
+			"HttpError %s %#v -> %#v %#v",
 			he.Method, he.RequestUrl.String(), he.Status,
 			string(he.Body),
 		)
 	}
 	// Trim if the error is too long
-	return fmt.Sprintf("HttpError %s %#v -> %#v %s %#v...[+%d]",
+	return fmt.Sprintf(
+		"HttpError %s %#v -> %#v %s %#v...[+%d]",
 		he.Method, he.RequestUrl.String(), he.Status,
 		he.Header.Get("Content-Type"),
 		string(he.Body)[:HttpErrSummaryLength-10], len(he.Body)-(HttpErrSummaryLength-10),

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,21 +1,20 @@
 package util
 
 import (
+	"crypto/sha3"
 	"encoding/hex"
 	"fmt"
 	"math"
 	"math/big"
 	"strconv"
 	"strings"
-
-	"golang.org/x/crypto/sha3"
 )
 
 // Sha3256Hash hashes the input bytes using SHA3-256
 func Sha3256Hash(bytes [][]byte) []byte {
 	hasher := sha3.New256()
 	for _, b := range bytes {
-		hasher.Write(b)
+		_, _ = hasher.Write(b)
 	}
 	return hasher.Sum([]byte{})
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
-go = "1.24"
+go = "1.24.2"
 golangci-lint = "2.12.1"
-gofumpt = "latest"
+gofumpt = "0.10.0"
 node = "20.14.0"
 
 [env]
@@ -13,7 +13,16 @@ run = "gofumpt -l -w ."
 
 [tasks.fmt-check]
 description = "Check formatting with gofumpt (CI parity)"
-run = "test \"$(gofumpt -l -e . | wc -l | tr -d ' ')\" = '0' || (echo 'Formatting is wrong, please run: mise run fmt' && gofumpt -l -e . && exit 1)"
+run = """
+set -e
+out=$(gofumpt -l -e .)
+if [ -n "$out" ]; then
+    echo "Formatting is wrong, please run: mise run fmt"
+    echo "$out"
+    exit 1
+fi
+echo "Formatting is good"
+"""
 
 [tasks.lint]
 description = "Run golangci-lint on the v1 module"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,42 @@
+[tools]
+go = "1.24"
+golangci-lint = "2.12.1"
+gofumpt = "latest"
+node = "20.14.0"
+
+[env]
+GOTOOLCHAIN = "local"
+
+[tasks.fmt]
+description = "Format Go source files with gofumpt"
+run = "gofumpt -l -w ."
+
+[tasks.fmt-check]
+description = "Check formatting with gofumpt (CI parity)"
+run = "test \"$(gofumpt -l -e . | wc -l | tr -d ' ')\" = '0' || (echo 'Formatting is wrong, please run: mise run fmt' && gofumpt -l -e . && exit 1)"
+
+[tasks.lint]
+description = "Run golangci-lint on the v1 module"
+run = "golangci-lint run"
+
+[tasks."lint:v2"]
+description = "Run golangci-lint on the v2 module"
+dir = "v2"
+run = "golangci-lint run"
+
+[tasks.test]
+description = "Run unit tests for v1 (use 'go test ./...' for full)"
+run = "go test -short ./..."
+
+[tasks."test:v2"]
+description = "Run v2 unit tests"
+dir = "v2"
+run = "go test -short ./..."
+
+[tasks.vet]
+description = "Run go vet on the v1 module"
+run = "go vet ./..."
+
+[tasks.ci]
+description = "Run all CI checks locally (vet, fmt-check, lint)"
+depends = ["vet", "fmt-check", "lint"]

--- a/nodeClient.go
+++ b/nodeClient.go
@@ -466,7 +466,7 @@ func (rc *NodeClient) AccountTransactions(account AccountAddress, start *uint64,
 			return 0, false
 		}
 		// It will always be a UserTransaction, no other type will come from the API
-		userTxn, _ := ((*txns)[0]).UserTransaction()
+		userTxn, _ := (*txns)[0].UserTransaction()
 		if userTxn.SequenceNumber == 0 {
 			return 0, false
 		}

--- a/rawTransaction.go
+++ b/rawTransaction.go
@@ -1,13 +1,13 @@
 package aptos
 
 import (
+	"crypto/sha3"
 	"encoding/json"
 	"fmt"
 	"sync"
 
 	"github.com/aptos-labs/aptos-go-sdk/bcs"
 	"github.com/aptos-labs/aptos-go-sdk/crypto"
-	"golang.org/x/crypto/sha3"
 )
 
 // region RawTransaction
@@ -233,7 +233,7 @@ func (txn *RawTransactionWithData) ToFeePayerSignedTransaction(
 
 // MarshalTypeScriptBCS converts to RawTransactionWithData to the TypeScript type MultiAgentTransaction
 func (txn *RawTransactionWithData) MarshalTypeScriptBCS(ser *bcs.Serializer) {
-	switch inner := (txn.Inner).(type) {
+	switch inner := txn.Inner.(type) {
 	case *MultiAgentRawTransactionWithData:
 		ser.Struct(inner.RawTxn)
 		bcs.SerializeSequence(inner.SecondarySigners, ser)

--- a/script.go
+++ b/script.go
@@ -76,61 +76,61 @@ func (sa *ScriptArgument) MarshalBCS(ser *bcs.Serializer) {
 	ser.Uleb128(uint32(sa.Variant))
 	switch sa.Variant {
 	case ScriptArgumentU8:
-		value, ok := (sa.Value).(uint8)
+		value, ok := sa.Value.(uint8)
 		if !ok {
 			ser.SetError(fmt.Errorf("invalid input type (%T) for ScriptArgumentU8, must be uint8", sa.Value))
 		}
 		ser.U8(value)
 	case ScriptArgumentU16:
-		value, ok := (sa.Value).(uint16)
+		value, ok := sa.Value.(uint16)
 		if !ok {
 			ser.SetError(fmt.Errorf("invalid input type (%T) for ScriptArgumentU16, must be uint16", sa.Value))
 		}
 		ser.U16(value)
 	case ScriptArgumentU32:
-		value, ok := (sa.Value).(uint32)
+		value, ok := sa.Value.(uint32)
 		if !ok {
 			ser.SetError(fmt.Errorf("invalid input type (%T) for ScriptArgumentU32, must be uint32", sa.Value))
 		}
 		ser.U32(value)
 	case ScriptArgumentU64:
-		value, ok := (sa.Value).(uint64)
+		value, ok := sa.Value.(uint64)
 		if !ok {
 			ser.SetError(fmt.Errorf("invalid input type (%T) for ScriptArgumentU64, must be uint64", sa.Value))
 		}
 		ser.U64(value)
 	case ScriptArgumentU128:
-		value, ok := (sa.Value).(big.Int)
+		value, ok := sa.Value.(big.Int)
 		if !ok {
 			ser.SetError(fmt.Errorf("invalid input type (%T) for ScriptArgument128, must be big.Int", sa.Value))
 		}
 		ser.U128(value)
 	case ScriptArgumentU256:
-		value, ok := (sa.Value).(big.Int)
+		value, ok := sa.Value.(big.Int)
 		if !ok {
 			ser.SetError(fmt.Errorf("invalid input type (%T) for ScriptArgument256, must be big.Int", sa.Value))
 		}
 		ser.U256(value)
 	case ScriptArgumentAddress:
-		addr, ok := (sa.Value).(AccountAddress)
+		addr, ok := sa.Value.(AccountAddress)
 		if !ok {
 			ser.SetError(fmt.Errorf("invalid input type (%T) for ScriptArgumentAddress, must be AccountAddress", sa.Value))
 		}
 		ser.Struct(&addr)
 	case ScriptArgumentU8Vector:
-		bytes, ok := (sa.Value).([]byte)
+		bytes, ok := sa.Value.([]byte)
 		if !ok {
 			ser.SetError(fmt.Errorf("invalid input type (%T) for ScriptArgumentU8Vector, must be []byte", sa.Value))
 		}
 		ser.WriteBytes(bytes)
 	case ScriptArgumentBool:
-		value, ok := (sa.Value).(bool)
+		value, ok := sa.Value.(bool)
 		if !ok {
 			ser.SetError(fmt.Errorf("invalid input type (%T) for ScriptArgumentBool, must be bool", sa.Value))
 		}
 		ser.Bool(value)
 	case ScriptArgumentSerialized:
-		value, ok := (sa.Value).(*bcs.Serialized)
+		value, ok := sa.Value.(*bcs.Serialized)
 		if !ok {
 			ser.SetError(fmt.Errorf("invalid input type (%T) for ScriptArgumentSerialized, must be *bcs.Serialized", sa.Value))
 		}

--- a/spec_bcs_test.go
+++ b/spec_bcs_test.go
@@ -77,21 +77,21 @@ func givenU8(ctx context.Context, input int) (context.Context, error) {
 	if input < 0 || input > 255 {
 		return nil, errors.New("u8 must be between 0 and 255")
 	}
-	return context.WithValue(ctx, godogsCtxKey{}, (uint8)(input)), nil
+	return context.WithValue(ctx, godogsCtxKey{}, uint8(input)), nil
 }
 
 func givenU16(ctx context.Context, input int) (context.Context, error) {
 	if input < 0 || input > 65535 {
 		return nil, errors.New("u16 must be between 0 and 65535")
 	}
-	return context.WithValue(ctx, godogsCtxKey{}, (uint16)(input)), nil
+	return context.WithValue(ctx, godogsCtxKey{}, uint16(input)), nil
 }
 
 func givenU32(ctx context.Context, input int) (context.Context, error) {
 	if input < 0 || input > 4294967295 {
 		return nil, errors.New("u32 must be between 0 and 4294967295")
 	}
-	return context.WithValue(ctx, godogsCtxKey{}, (uint32)(input)), nil
+	return context.WithValue(ctx, godogsCtxKey{}, uint32(input)), nil
 }
 
 func givenU64(ctx context.Context, input string) (context.Context, error) {

--- a/spec_common_test.go
+++ b/spec_common_test.go
@@ -73,7 +73,7 @@ func parseU8(input string) uint8 {
 	if err != nil {
 		panic("invalid u8 input " + input)
 	}
-	return (uint8)(out)
+	return uint8(out)
 }
 
 func parseU16(input string) uint16 {
@@ -81,7 +81,7 @@ func parseU16(input string) uint16 {
 	if err != nil {
 		panic("invalid u16 input " + input)
 	}
-	return (uint16)(out)
+	return uint16(out)
 }
 
 func parseU32(input string) uint32 {
@@ -89,7 +89,7 @@ func parseU32(input string) uint32 {
 	if err != nil {
 		panic("invalid u32 input " + input)
 	}
-	return (uint32)(out)
+	return uint32(out)
 }
 
 func parseU64(input string) uint64 {

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -31,7 +31,8 @@ func Example_basicUsage() {
 
 func Example_clientOptions() {
 	// Create a client with custom options
-	_, _ = aptos.NewClient(aptos.Mainnet,
+	_, _ = aptos.NewClient(
+		aptos.Mainnet,
 		aptos.WithTimeout(60*time.Second),
 		aptos.WithRetry(5, 200*time.Millisecond),
 		aptos.WithAPIKey("your-api-key"),
@@ -76,7 +77,8 @@ func Example_transactionBuilder() {
 	// Build a transfer transaction using the fluent builder
 	txn, err := transaction.New().
 		Sender(sender).
-		EntryFunction("0x1::aptos_account::transfer",
+		EntryFunction(
+			"0x1::aptos_account::transfer",
 			nil, // no type args
 			recipient.Bytes(),
 			amount,

--- a/v2/examples/sponsored_transaction/main.go
+++ b/v2/examples/sponsored_transaction/main.go
@@ -112,7 +112,8 @@ func main() {
 	fmt.Println()
 
 	// Build the transaction with fee payer option
-	rawTxn, err := client.BuildTransaction(ctx, senderAddr, payload,
+	rawTxn, err := client.BuildTransaction(
+		ctx, senderAddr, payload,
 		aptos.WithFeePayer(feePayerAddr),
 		aptos.WithGasEstimation(),
 	)

--- a/v2/examples/transfer_coin/main.go
+++ b/v2/examples/transfer_coin/main.go
@@ -73,7 +73,8 @@ func main() {
 	}
 
 	// Build the transaction with gas estimation
-	rawTxn, err := client.BuildTransaction(ctx, alice, payload,
+	rawTxn, err := client.BuildTransaction(
+		ctx, alice, payload,
 		aptos.WithGasEstimation(),
 	)
 	if err != nil {

--- a/v2/integration_test.go
+++ b/v2/integration_test.go
@@ -566,7 +566,8 @@ func TestIntegration_BuildTransactionWithOptions(t *testing.T) {
 		Args:     []any{AccountTwo.String(), "100"},
 	}
 
-	txn, err := client.BuildTransaction(ctx, AccountOne, payload,
+	txn, err := client.BuildTransaction(
+		ctx, AccountOne, payload,
 		WithSequenceNumber(seqNum),
 		WithMaxGas(50000),
 		WithGasPrice(200),
@@ -608,7 +609,8 @@ func TestIntegration_Timeout(t *testing.T) {
 	_, err = client.Info(ctx)
 	// With a 1-nanosecond timeout, the request should fail with a deadline/timeout error
 	require.Error(t, err, "request with 1ns timeout should fail")
-	assert.True(t,
+	assert.True(
+		t,
 		errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "timeout") || strings.Contains(err.Error(), "deadline"),
 		"expected a timeout-related error, got: %v", err,
 	)

--- a/v2/internal/http/client.go
+++ b/v2/internal/http/client.go
@@ -94,7 +94,8 @@ func (c *RetryClient) Do(req *http.Request) (*http.Response, error) {
 			// Calculate backoff
 			backoff := c.calculateBackoff(attempt)
 
-			c.logger.Debug("retrying request",
+			c.logger.Debug(
+				"retrying request",
 				"attempt", attempt,
 				"max_retries", c.config.MaxRetries,
 				"backoff", backoff,
@@ -123,7 +124,8 @@ func (c *RetryClient) Do(req *http.Request) (*http.Response, error) {
 			// Network errors are retriable
 			lastErr = err
 			lastResp = nil
-			c.logger.Debug("request failed with error",
+			c.logger.Debug(
+				"request failed with error",
 				"attempt", attempt,
 				"error", err,
 				"url", req.URL.String(),
@@ -148,7 +150,8 @@ func (c *RetryClient) Do(req *http.Request) (*http.Response, error) {
 
 			lastResp = resp
 			lastErr = fmt.Errorf("retriable status code: %d", resp.StatusCode)
-			c.logger.Debug("retriable status code",
+			c.logger.Debug(
+				"retriable status code",
 				"attempt", attempt,
 				"status", resp.StatusCode,
 				"url", req.URL.String(),
@@ -285,7 +288,8 @@ func NewLoggingClient(inner HTTPDoer, logger *slog.Logger) *LoggingClient {
 func (c *LoggingClient) Do(req *http.Request) (*http.Response, error) {
 	start := time.Now()
 
-	c.logger.Debug("sending request",
+	c.logger.Debug(
+		"sending request",
 		"method", req.Method,
 		"url", req.URL.String(),
 	)
@@ -294,7 +298,8 @@ func (c *LoggingClient) Do(req *http.Request) (*http.Response, error) {
 	duration := time.Since(start)
 
 	if err != nil {
-		c.logger.Debug("request failed",
+		c.logger.Debug(
+			"request failed",
 			"method", req.Method,
 			"url", req.URL.String(),
 			"error", err,
@@ -303,7 +308,8 @@ func (c *LoggingClient) Do(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	c.logger.Debug("request completed",
+	c.logger.Debug(
+		"request completed",
 		"method", req.Method,
 		"url", req.URL.String(),
 		"status", resp.StatusCode,

--- a/v2/internal/util/util.go
+++ b/v2/internal/util/util.go
@@ -2,6 +2,7 @@
 package util
 
 import (
+	"crypto/sha3"
 	"encoding/hex"
 	"fmt"
 	"hash"
@@ -10,8 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-
-	"golang.org/x/crypto/sha3"
 )
 
 // sha3Pool provides reusable SHA3-256 hashers to reduce allocations.

--- a/v2/telemetry/telemetry.go
+++ b/v2/telemetry/telemetry.go
@@ -212,7 +212,8 @@ func (t *InstrumentedTransport) RoundTrip(req *http.Request) (*http.Response, er
 	// Start span
 	var span trace.Span
 	if !t.config.DisableTracing {
-		ctx, span = t.tracer.Start(ctx, "aptos."+operation,
+		ctx, span = t.tracer.Start(
+			ctx, "aptos."+operation,
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(attrs...),
 		)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`main` has been failing both the `gofumpt` and `golangci-lint` CI jobs since the latest tooling bumps. This PR makes both green, adds a `mise.toml` so contributors install the same tool versions CI uses, and pins the GitHub Actions jobs to use those mise-managed versions.

**`golangci-lint` (v2.12.1) failures**

Three `govet`/`inline` errors caused by the new `inline` analyzer:

```
internal/util/util.go:16:12: inline: Call of sha3.New256 should be inlined (govet)
rawTransaction.go:26:10: inline: Call of sha3.Sum256 should be inlined (govet)
rawTransaction.go:152:10: inline: Call of sha3.Sum256 should be inlined (govet)
```

The `golang.org/x/crypto/sha3` package marks `New256`/`Sum256` with `//go:fix inline` directives that point to the new `crypto/sha3` standard-library package added in Go 1.24. Switched the imports in `internal/util/util.go`, `v2/internal/util/util.go`, and `rawTransaction.go` to `crypto/sha3`. The standard library `hash.Hash.Write` now had its return values discarded explicitly to satisfy `errcheck`.

Also replaced the deprecated `gomodguard` linter (deprecated since v2.12.0) with `gomodguard_v2` to drop the deprecation warning.

**`gofumpt` (v0.10) failures**

Re-ran `gofumpt -l -w .` across both modules to pick up the recent formatter rules (mostly call-site argument re-wrapping and removing redundant parentheses around pointer dereferences). No functional changes.

**`mise.toml`**

Added a `mise.toml` at the repo root that pins:

- `go = "1.24.2"` — matches the `toolchain go1.24.2` directive in `go.mod` so contributors using `GOTOOLCHAIN=local` (set in the same file) don't fail when Go refuses to auto-download a newer toolchain.
- `golangci-lint = "2.12.1"`
- `gofumpt = "0.10.0"`
- `node = "20.14.0"`

Plus a small task runner so contributors can run `mise run fmt`, `mise run lint`, `mise run vet`, or `mise run ci` to mirror CI locally. The `fmt-check` task uses `set -e` and surfaces gofumpt's own non-zero exit status (e.g. parse errors), not just whether `-l` produced output.

**Pinned tool versions in CI**

To make `mise.toml` an actual source of truth, the GitHub Actions jobs now install Go, gofumpt, and golangci-lint via [`jdx/mise-action@v4`](https://github.com/jdx/mise-action) instead of `setup-go@v6` and `golangci/golangci-lint-action@v9`:

- `gofumpt-lint`: composite action installs Go + gofumpt via mise and calls the shared `mise run fmt-check` task.
- `golangci-lint`: workflow installs Go + golangci-lint via mise and runs `mise run lint` (was `version: latest`, which would silently drift).
- `run-go-tests`: composite action installs Go via mise. The localnet step (`aptos-labs/actions/run-local-testnet`) still provides node and pnpm.
- `codecov`: workflow installs Go via mise.

All workflows pass `actionlint`.

### Test Plan

Locally, with `mise install` against the new `mise.toml`:

- `mise run vet` is clean.
- `mise run fmt-check` reports `Formatting is good`.
- `mise run lint` reports `0 issues.`.
- `mise run ci` runs the three above in parallel and exits 0.
- `go test -short ./...` passes for v1.

In CI on this branch (run [`25400326012`](https://github.com/aptos-labs/aptos-go-sdk/actions/runs/25400326012) and friends):

- `gofumpt` ✓
- `golangci-lint` ✓
- `Go Unit Tests` ✓
- `Code Coverage` ✓

### Related Links

CI runs on `main` showing the original failures fixed here:
- gofumpt: https://github.com/aptos-labs/aptos-go-sdk/actions/runs/25350815291
- golangci-lint: https://github.com/aptos-labs/aptos-go-sdk/actions/runs/25350815281
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f17aa6f-b12c-4d4e-ad7a-1b280a1bb573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f17aa6f-b12c-4d4e-ad7a-1b280a1bb573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

