### PR TITLE
SDK audit: fix critical v2 signing bug, race in v1 tests, balance/faucet for FA networks; add real localnet end-to-end test

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -19,43 +19,35 @@ jobs:
         with:
           ref: ${{ env.GIT_SHA }}
 
-      - uses: jdx/mise-action@v4
-        with:
-          install_args: "go"
-          cache: true
-
-      # The v2 module declares `go 1.25.0` while mise pins the v1
-      # toolchain at 1.24.2. Install a *full* Go 1.25.0 toolchain via
-      # actions/setup-go so coverage works end to end. Using
-      # GOTOOLCHAIN=auto with mise's downloaded modular toolchain
-      # almost works, but Go's modular toolchain archives ship without
-      # `covdata`, which `go test -coverprofile` invokes when a
-      # package-main has no tests (e.g. v2/examples/transfer_coin), and
-      # the build fails with `go: no such tool "covdata"`. A full Go
-      # install from setup-go ships the complete cmd/ tree.
+      # Coverage is the only CI job that compiles inside v2/, which
+      # declares `go 1.25.0` in v2/go.mod. The rest of CI (lint, vet,
+      # unit tests) operates on v1 only and goes through mise — that's
+      # fine. Here we deliberately skip mise to avoid two competing Go
+      # installs on PATH/GOROOT (mise's 1.24.2 vs the one we need for
+      # v2), which produces:
       #
-      # Pin the Go version explicitly to the value declared in
-      # v2/go.mod (via go-version-file) — single source of truth.
-      - name: Set up Go 1.25 toolchain for v2
+      #     compile: version "go1.24.2" does not match go tool version "go1.25.0"
+      #
+      # actions/setup-go gives us one full Go install (with the
+      # complete cmd/ tree, including `covdata` — needed for
+      # `go test -coverprofile` on the v2/examples/* package-mains
+      # that have no test files). go-version-file pins the version
+      # to the single source of truth (v2/go.mod), so bumping v2's
+      # minimum Go version automatically updates CI.
+      - name: Set up Go (pinned to v2/go.mod)
         uses: actions/setup-go@v5
         with:
           go-version-file: v2/go.mod
-          cache: false
+          cache: true
 
-      # Run v2 SDK tests with coverage. The leading
-      # `GOTOOLCHAIN=go1.25.0` overrides any GOTOOLCHAIN=local that
-      # mise.toml [env] might re-inject through its shim wrapper —
-      # mise re-exports its env vars on every shim invocation, so a
-      # step-level `env:` block doesn't win; an inline prefix does
-      # because it's part of the same exec call. Pinning here matches
-      # the pin in v2/go.mod; bump them in lockstep.
       - name: Run v2 SDK tests with coverage
         working-directory: v2
         run: |
-          GOTOOLCHAIN=go1.25.0 go test -race -coverprofile=coverage.out -covermode=atomic ./...
+          go test -race -coverprofile=coverage.out -covermode=atomic ./...
 
       # Run v1 SDK tests with coverage (optional, for overall repo coverage).
-      # v1's go.mod pins toolchain go1.24.2 so the mise default is fine.
+      # v1's go.mod declares `go 1.24.0; toolchain go1.24.2`, but a newer
+      # Go (1.25.0 from the step above) is backward-compatible with v1.
       - name: Run v1 SDK tests with coverage
         run: |
           go test -race -coverprofile=coverage-v1.out -covermode=atomic ./...

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -24,20 +24,31 @@ jobs:
           install_args: "go"
           cache: true
 
-      # Run v2 SDK tests with coverage.
+      # The v2 module declares `go 1.25.0` while mise pins the v1
+      # toolchain at 1.24.2. Install a *full* Go 1.25.0 toolchain via
+      # actions/setup-go so coverage works end to end. Using
+      # GOTOOLCHAIN=auto with mise's downloaded modular toolchain
+      # almost works, but Go's modular toolchain archives ship without
+      # `covdata`, which `go test -coverprofile` invokes when a
+      # package-main has no tests (e.g. v2/examples/transfer_coin), and
+      # the build fails with `go: no such tool "covdata"`. A full Go
+      # install from setup-go ships the complete cmd/ tree.
       #
-      # The v2 module declares `go 1.25.0` in v2/go.mod, while mise
-      # pins the system Go install at the v1 toolchain (currently
-      # 1.24.2). With GOTOOLCHAIN=auto (set in mise.toml) Go will
-      # auto-download 1.25.0 to satisfy v2's directive; we also pin
-      # the value explicitly here so the coverage job is robust against
-      # a future mise.toml change re-asserting GOTOOLCHAIN=local. The
-      # inline prefix (rather than a step-level `env:`) is deliberate:
-      # mise's go-shim re-exports vars from mise.toml [env] on every
-      # invocation, which would override a step-level env. An inline
-      # `VAR=value cmd` prefix is part of the same exec call and wins.
-      # Bump this value (and v2/go.mod) in lockstep when the v2 module
-      # advances its minimum Go version.
+      # Pin the Go version explicitly to the value declared in
+      # v2/go.mod (via go-version-file) — single source of truth.
+      - name: Set up Go 1.25 toolchain for v2
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: v2/go.mod
+          cache: false
+
+      # Run v2 SDK tests with coverage. The leading
+      # `GOTOOLCHAIN=go1.25.0` overrides any GOTOOLCHAIN=local that
+      # mise.toml [env] might re-inject through its shim wrapper —
+      # mise re-exports its env vars on every shim invocation, so a
+      # step-level `env:` block doesn't win; an inline prefix does
+      # because it's part of the same exec call. Pinning here matches
+      # the pin in v2/go.mod; bump them in lockstep.
       - name: Run v2 SDK tests with coverage
         working-directory: v2
         run: |

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -28,22 +28,24 @@ jobs:
       #
       # The v2 module requires Go 1.25.0 (see v2/go.mod "go 1.25.0"),
       # but mise pins the system toolchain at the v1 version (currently
-      # 1.24.2) and exports GOTOOLCHAIN=local, which tells Go *not* to
-      # auto-download a newer toolchain. Running v2 tests under those
-      # defaults fails with:
+      # 1.24.2) and re-exports GOTOOLCHAIN=local from mise.toml's [env]
+      # block on every shim invocation. That tells Go *not* to
+      # auto-download a newer toolchain, and v2 tests fail with:
       #
       #     go: go.mod requires go >= 1.25.0 (running go 1.24.2; GOTOOLCHAIN=local)
       #
-      # Pin GOTOOLCHAIN explicitly to the version v2 needs so Go fetches
-      # and uses it for just this step, leaving every other CI job on
-      # the mise-pinned toolchain. Bump this value (and v2/go.mod) in
+      # Setting GOTOOLCHAIN on the step `env:` block alone doesn't win
+      # because mise re-injects its [env] vars when the `go` shim
+      # executes. So we pin it inline on the command — the leading
+      # `GOTOOLCHAIN=go1.25.0` is part of the same process invocation
+      # and survives mise's shim wrapper. Go will fetch and use exactly
+      # 1.25.0 for this step, leaving every other CI job on the
+      # mise-pinned toolchain. Bump this value (and v2/go.mod) in
       # lockstep when the v2 module advances its minimum Go version.
       - name: Run v2 SDK tests with coverage
         working-directory: v2
-        env:
-          GOTOOLCHAIN: go1.25.0
         run: |
-          go test -race -coverprofile=coverage.out -covermode=atomic ./...
+          GOTOOLCHAIN=go1.25.0 go test -race -coverprofile=coverage.out -covermode=atomic ./...
 
       # Run v1 SDK tests with coverage (optional, for overall repo coverage).
       # v1's go.mod pins toolchain go1.24.2 so the mise default is fine.

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -26,22 +26,18 @@ jobs:
 
       # Run v2 SDK tests with coverage.
       #
-      # The v2 module requires Go 1.25.0 (see v2/go.mod "go 1.25.0"),
-      # but mise pins the system toolchain at the v1 version (currently
-      # 1.24.2) and re-exports GOTOOLCHAIN=local from mise.toml's [env]
-      # block on every shim invocation. That tells Go *not* to
-      # auto-download a newer toolchain, and v2 tests fail with:
-      #
-      #     go: go.mod requires go >= 1.25.0 (running go 1.24.2; GOTOOLCHAIN=local)
-      #
-      # Setting GOTOOLCHAIN on the step `env:` block alone doesn't win
-      # because mise re-injects its [env] vars when the `go` shim
-      # executes. So we pin it inline on the command — the leading
-      # `GOTOOLCHAIN=go1.25.0` is part of the same process invocation
-      # and survives mise's shim wrapper. Go will fetch and use exactly
-      # 1.25.0 for this step, leaving every other CI job on the
-      # mise-pinned toolchain. Bump this value (and v2/go.mod) in
-      # lockstep when the v2 module advances its minimum Go version.
+      # The v2 module declares `go 1.25.0` in v2/go.mod, while mise
+      # pins the system Go install at the v1 toolchain (currently
+      # 1.24.2). With GOTOOLCHAIN=auto (set in mise.toml) Go will
+      # auto-download 1.25.0 to satisfy v2's directive; we also pin
+      # the value explicitly here so the coverage job is robust against
+      # a future mise.toml change re-asserting GOTOOLCHAIN=local. The
+      # inline prefix (rather than a step-level `env:`) is deliberate:
+      # mise's go-shim re-exports vars from mise.toml [env] on every
+      # invocation, which would override a step-level env. An inline
+      # `VAR=value cmd` prefix is part of the same exec call and wins.
+      # Bump this value (and v2/go.mod) in lockstep when the v2 module
+      # advances its minimum Go version.
       - name: Run v2 SDK tests with coverage
         working-directory: v2
         run: |

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -24,13 +24,29 @@ jobs:
           install_args: "go"
           cache: true
 
-      # Run v2 SDK tests with coverage
+      # Run v2 SDK tests with coverage.
+      #
+      # The v2 module requires Go 1.25.0 (see v2/go.mod "go 1.25.0"),
+      # but mise pins the system toolchain at the v1 version (currently
+      # 1.24.2) and exports GOTOOLCHAIN=local, which tells Go *not* to
+      # auto-download a newer toolchain. Running v2 tests under those
+      # defaults fails with:
+      #
+      #     go: go.mod requires go >= 1.25.0 (running go 1.24.2; GOTOOLCHAIN=local)
+      #
+      # Pin GOTOOLCHAIN explicitly to the version v2 needs so Go fetches
+      # and uses it for just this step, leaving every other CI job on
+      # the mise-pinned toolchain. Bump this value (and v2/go.mod) in
+      # lockstep when the v2 module advances its minimum Go version.
       - name: Run v2 SDK tests with coverage
         working-directory: v2
+        env:
+          GOTOOLCHAIN: go1.25.0
         run: |
           go test -race -coverprofile=coverage.out -covermode=atomic ./...
 
-      # Run v1 SDK tests with coverage (optional, for overall repo coverage)
+      # Run v1 SDK tests with coverage (optional, for overall repo coverage).
+      # v1's go.mod pins toolchain go1.24.2 so the mise default is fine.
       - name: Run v1 SDK tests with coverage
         run: |
           go test -race -coverprofile=coverage-v1.out -covermode=atomic ./...

--- a/client_test.go
+++ b/client_test.go
@@ -471,56 +471,56 @@ func Test_AccountTransactions(t *testing.T) {
 
 	t.Run("Default transaction size, no start", func(t *testing.T) {
 		t.Parallel()
-		transactions, err = client.Transactions(nil, nil)
+		txns, err := client.Transactions(nil, nil)
 		require.NoError(t, err)
-		assert.Len(t, transactions, 25)
+		assert.Len(t, txns, 25)
 	})
 	t.Run("Default transaction size, start from zero", func(t *testing.T) {
 		t.Parallel()
-		transactions, err = client.Transactions(&zero, nil)
+		txns, err := client.Transactions(&zero, nil)
 		require.NoError(t, err)
-		assert.Len(t, transactions, 25)
+		assert.Len(t, txns, 25)
 	})
 	t.Run("Default transaction size, start from one", func(t *testing.T) {
 		t.Parallel()
-		transactions, err = client.Transactions(&one, nil)
+		txns, err := client.Transactions(&one, nil)
 		require.NoError(t, err)
-		assert.Len(t, transactions, 25)
+		assert.Len(t, txns, 25)
 	})
 
 	t.Run("101 transactions, no start", func(t *testing.T) {
 		t.Parallel()
-		transactions, err = client.Transactions(nil, &hundredOne)
+		txns, err := client.Transactions(nil, &hundredOne)
 		require.NoError(t, err)
-		assert.Len(t, transactions, 101)
+		assert.Len(t, txns, 101)
 	})
 
 	t.Run("101 transactions, start zero", func(t *testing.T) {
 		t.Parallel()
-		transactions, err = client.Transactions(&zero, &hundredOne)
+		txns, err := client.Transactions(&zero, &hundredOne)
 		require.NoError(t, err)
-		assert.Len(t, transactions, 101)
+		assert.Len(t, txns, 101)
 	})
 
 	t.Run("101 transactions, start one", func(t *testing.T) {
 		t.Parallel()
-		transactions, err = client.Transactions(&one, &hundredOne)
+		txns, err := client.Transactions(&one, &hundredOne)
 		require.NoError(t, err)
-		assert.Len(t, transactions, 101)
+		assert.Len(t, txns, 101)
 	})
 
 	t.Run("10 transactions, no start", func(t *testing.T) {
 		t.Parallel()
-		transactions, err = client.Transactions(nil, &ten)
+		txns, err := client.Transactions(nil, &ten)
 		require.NoError(t, err)
-		assert.Len(t, transactions, 10)
+		assert.Len(t, txns, 10)
 	})
 
 	t.Run("10 transactions, start one", func(t *testing.T) {
 		t.Parallel()
-		transactions, err = client.Transactions(&one, &ten)
+		txns, err := client.Transactions(&one, &ten)
 		require.NoError(t, err)
-		assert.Len(t, transactions, 10)
+		assert.Len(t, txns, 10)
 	})
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,18 @@ gofumpt = "0.10.0"
 node = "20.14.0"
 
 [env]
-GOTOOLCHAIN = "local"
+# GOTOOLCHAIN=auto so each go.mod controls its own toolchain version:
+#   * v1 (./go.mod) declares `toolchain go1.24.2` — Go uses the mise-pinned 1.24.2.
+#   * v2 (./v2/go.mod) declares `go 1.25.0` — Go fetches and uses 1.25.0.
+# This is required because v2 has advanced beyond v1's Go version. Using
+# GOTOOLCHAIN=local would block the v2 coverage job (the only CI job that
+# enters v2/) from compiling at all:
+#   go: go.mod requires go >= 1.25.0 (running go 1.24.2; GOTOOLCHAIN=local)
+# The version actually used in each tree remains deterministic — it's
+# pinned in the respective go.mod — but Go is now allowed to satisfy
+# those pins by downloading the toolchain Aptos-Labs publishes via the
+# official Go module proxy.
+GOTOOLCHAIN = "auto"
 
 [tasks.fmt]
 description = "Format Go source files with gofumpt"

--- a/v2/compatibility/v1_v2_test.go
+++ b/v2/compatibility/v1_v2_test.go
@@ -1,0 +1,437 @@
+// Package compatibility contains cross-version compatibility tests that
+// pin the v2 SDK's wire format and signing behaviour to v1.
+//
+// v1 (github.com/aptos-labs/aptos-go-sdk) is the long-lived, production
+// SDK whose BCS serialization, transaction hashing, and signing message
+// construction have been validated against the chain for years. v2 is a
+// rewrite that needs to produce byte-identical output for callers to
+// switch without on-chain consequences.
+//
+// These tests import both modules side-by-side (v2's go.mod requires
+// v1 already, see v2/benchmark for prior art) and assert byte equality
+// between the two. They are unit tests — no network access required.
+//
+// A bug in v2 (signing prehash using crypto/sha256 instead of SHA3-256)
+// went undetected for months because there was no such cross-check;
+// every test in v2 only compared v2 against itself. This package exists
+// so a regression like that cannot recur silently.
+package compatibility
+
+import (
+	"bytes"
+	"testing"
+
+	v1 "github.com/aptos-labs/aptos-go-sdk"
+	v1bcs "github.com/aptos-labs/aptos-go-sdk/bcs"
+	v1crypto "github.com/aptos-labs/aptos-go-sdk/crypto"
+	v2 "github.com/aptos-labs/aptos-go-sdk/v2"
+	v2bcs "github.com/aptos-labs/aptos-go-sdk/v2/internal/bcs"
+	v2crypto "github.com/aptos-labs/aptos-go-sdk/v2/internal/crypto"
+	v2types "github.com/aptos-labs/aptos-go-sdk/v2/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixedSeed is a deterministic Ed25519 seed used across both versions so
+// signatures are reproducible. It's only used in unit tests; do not use
+// for any real account.
+var fixedSeed = [32]byte{
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+	0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+}
+
+// sampleAddr is a non-trivial 32-byte address with mixed bytes; using
+// 0x1 or 0x0 would mask byte-order bugs in the address serialization.
+var sampleAddr = [32]byte{
+	0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89,
+	0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89,
+	0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89,
+	0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89,
+}
+
+func newV1Address(t *testing.T, raw [32]byte) v1.AccountAddress {
+	t.Helper()
+	var a v1.AccountAddress
+	copy(a[:], raw[:])
+	return a
+}
+
+func newV2Address(t *testing.T, raw [32]byte) v2.AccountAddress {
+	t.Helper()
+	var a v2.AccountAddress
+	copy(a[:], raw[:])
+	return a
+}
+
+// TestCrossVersion_AccountAddress_BCS verifies AccountAddress serialization
+// is byte-identical. Address bytes are the foundation of every payload, so
+// any disagreement here would cascade through the rest.
+func TestCrossVersion_AccountAddress_BCS(t *testing.T) {
+	t.Parallel()
+
+	addrV1 := newV1Address(t, sampleAddr)
+	addrV2 := newV2Address(t, sampleAddr)
+
+	bytesV1, err := v1bcs.Serialize(&addrV1)
+	require.NoError(t, err)
+	bytesV2, err := v2bcs.Serialize(&addrV2)
+	require.NoError(t, err)
+
+	assert.Equal(t, bytesV1, bytesV2, "AccountAddress BCS must match")
+	assert.Equal(t, sampleAddr[:], bytesV1, "AccountAddress BCS is the raw 32 bytes")
+}
+
+// TestCrossVersion_TypeTag_BCS covers each TypeTag variant that ships in
+// both versions: primitives, vector<T>, and struct (the one with type
+// parameters, where mismatches would actually show up).
+func TestCrossVersion_TypeTag_BCS(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"bool",
+		"u8",
+		"u16",
+		"u32",
+		"u64",
+		"u128",
+		"u256",
+		"address",
+		"signer",
+		"vector<u8>",
+		"vector<address>",
+		"vector<vector<u64>>",
+		"0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+		"0x1::option::Option<vector<u8>>",
+		"0xabcdef01234567890abcdef01234567890abcdef01234567890abcdef0123456::mod::Type<u128, bool>",
+	}
+
+	for _, tt := range cases {
+		t.Run(tt, func(t *testing.T) {
+			t.Parallel()
+
+			v1Tag, err := v1.ParseTypeTag(tt)
+			require.NoError(t, err, "v1 ParseTypeTag")
+			v2Tag, err := v2types.ParseTypeTag(tt)
+			require.NoError(t, err, "v2 ParseTypeTag")
+
+			assert.Equal(t, v1Tag.String(), v2Tag.String(),
+				"both versions should canonicalize to the same string")
+
+			bytesV1, err := v1bcs.Serialize(v1Tag)
+			require.NoError(t, err)
+			bytesV2, err := v2bcs.Serialize(v2Tag)
+			require.NoError(t, err)
+
+			assert.Equal(t, bytesV1, bytesV2, "TypeTag BCS must match for %q", tt)
+		})
+	}
+}
+
+// buildV1EntryFunction is the v1-side construction of the same entry-function
+// payload built by buildV2EntryFunction. They must serialize byte-for-byte
+// the same.
+func buildV1EntryFunction(t *testing.T) *v1.EntryFunction {
+	t.Helper()
+	to := newV1Address(t, sampleAddr)
+	amountBytes, err := v1bcs.SerializeU64(12345)
+	require.NoError(t, err)
+	addrBytes, err := v1bcs.Serialize(&to)
+	require.NoError(t, err)
+	return &v1.EntryFunction{
+		Module: v1.ModuleId{
+			Address: v1.AccountOne,
+			Name:    "aptos_account",
+		},
+		Function: "transfer",
+		ArgTypes: []v1.TypeTag{},
+		Args:     [][]byte{addrBytes, amountBytes},
+	}
+}
+
+func buildV2EntryFunction(t *testing.T) *v2.EntryFunctionPayload {
+	t.Helper()
+	return &v2.EntryFunctionPayload{
+		Module: v2.ModuleID{
+			Address: v2.AccountOne,
+			Name:    "aptos_account",
+		},
+		Function: "transfer",
+		// No type args.
+		Args: []any{newV2Address(t, sampleAddr), uint64(12345)},
+	}
+}
+
+// TestCrossVersion_EntryFunction_BCS asserts that the BCS encoding of an
+// equivalent entry-function payload matches between v1 and v2.
+//
+// We can't directly serialize v1 EntryFunction vs v2 EntryFunctionPayload
+// (their wire shape includes only the inner fields when nested inside a
+// RawTransaction; both versions add the outer variant byte at the
+// TransactionPayload level). So we compare them by serializing each
+// EntryFunction directly — both encode as
+//
+//	module || function_name || type_args_seq || args_seq.
+func TestCrossVersion_EntryFunction_BCS(t *testing.T) {
+	t.Parallel()
+
+	v1Inner := buildV1EntryFunction(t)
+	v1Bytes, err := v1bcs.Serialize(v1Inner)
+	require.NoError(t, err)
+
+	// For v2 the EntryFunctionPayload doesn't implement bcs.Marshaler
+	// directly (serialization is via serializePayload, which prepends a
+	// variant tag). So we drive v2 through RawTransaction with the same
+	// sender/seq/etc as v1 and compare the resulting blobs after
+	// stripping the leading TransactionPayload variant tag.
+	v1Raw := &v1.RawTransaction{
+		Sender:                     newV1Address(t, sampleAddr),
+		SequenceNumber:             7,
+		Payload:                    v1.TransactionPayload{Payload: v1Inner},
+		MaxGasAmount:               2_000_000,
+		GasUnitPrice:               100,
+		ExpirationTimestampSeconds: 1_700_000_000,
+		ChainId:                    4,
+	}
+	v2Raw := &v2.RawTransaction{
+		Sender:                     newV2Address(t, sampleAddr),
+		SequenceNumber:             7,
+		Payload:                    buildV2EntryFunction(t),
+		MaxGasAmount:               2_000_000,
+		GasUnitPrice:               100,
+		ExpirationTimestampSeconds: 1_700_000_000,
+		ChainID:                    4,
+	}
+
+	v1RawBytes, err := v1bcs.Serialize(v1Raw)
+	require.NoError(t, err)
+	v2RawBytes, err := v2bcs.Serialize(v2Raw)
+	require.NoError(t, err)
+
+	assert.Equal(t, v1RawBytes, v2RawBytes,
+		"RawTransaction BCS must match between v1 and v2 (any diff here means a wire-incompatible regression)")
+
+	// Sanity: v1's inner EntryFunction bytes show up verbatim inside the
+	// RawTransaction blob — confirms the v1 reference shape.
+	assert.True(t, bytes.Contains(v1RawBytes, v1Bytes),
+		"v1 raw tx should contain the inner EntryFunction bytes")
+}
+
+// TestCrossVersion_RawTransaction_BCS is the headline cross-version test:
+// build the same RawTransaction in v1 and v2 and assert byte equality.
+//
+// A failure here means the on-chain wire format diverges, which (since
+// SigningMessage is just the prehash + BCS bytes) means signatures will
+// also diverge.
+func TestCrossVersion_RawTransaction_BCS(t *testing.T) {
+	t.Parallel()
+
+	v1Raw := &v1.RawTransaction{
+		Sender:                     newV1Address(t, sampleAddr),
+		SequenceNumber:             42,
+		Payload:                    v1.TransactionPayload{Payload: buildV1EntryFunction(t)},
+		MaxGasAmount:               1_500_000,
+		GasUnitPrice:               150,
+		ExpirationTimestampSeconds: 1_777_777_777,
+		ChainId:                    4,
+	}
+
+	v2Raw := &v2.RawTransaction{
+		Sender:                     newV2Address(t, sampleAddr),
+		SequenceNumber:             42,
+		Payload:                    buildV2EntryFunction(t),
+		MaxGasAmount:               1_500_000,
+		GasUnitPrice:               150,
+		ExpirationTimestampSeconds: 1_777_777_777,
+		ChainID:                    4,
+	}
+
+	v1Bytes, err := v1bcs.Serialize(v1Raw)
+	require.NoError(t, err)
+	v2Bytes, err := v2bcs.Serialize(v2Raw)
+	require.NoError(t, err)
+
+	assert.Equal(t, v1Bytes, v2Bytes, "RawTransaction BCS bytes must match")
+}
+
+// TestCrossVersion_SigningMessage is the test that would have caught the
+// SHA3-vs-SHA256 prehash bug fixed in this PR: it requires the bytes the
+// signer hashes to be identical between v1 and v2.
+func TestCrossVersion_SigningMessage(t *testing.T) {
+	t.Parallel()
+
+	v1Raw := &v1.RawTransaction{
+		Sender:                     newV1Address(t, sampleAddr),
+		SequenceNumber:             99,
+		Payload:                    v1.TransactionPayload{Payload: buildV1EntryFunction(t)},
+		MaxGasAmount:               500_000,
+		GasUnitPrice:               101,
+		ExpirationTimestampSeconds: 1_888_888_888,
+		ChainId:                    4,
+	}
+	v2Raw := &v2.RawTransaction{
+		Sender:                     newV2Address(t, sampleAddr),
+		SequenceNumber:             99,
+		Payload:                    buildV2EntryFunction(t),
+		MaxGasAmount:               500_000,
+		GasUnitPrice:               101,
+		ExpirationTimestampSeconds: 1_888_888_888,
+		ChainID:                    4,
+	}
+
+	msg1, err := v1Raw.SigningMessage()
+	require.NoError(t, err)
+	msg2, err := v2Raw.SigningMessage()
+	require.NoError(t, err)
+
+	assert.Equal(t, msg1, msg2, "SigningMessage bytes must match (prehash + BCS)")
+
+	// And specifically: the first 32 bytes are the SHA3-256 prehash of
+	// the salt string. If someone "fixes" the prehash to crypto/sha256
+	// again, these must diverge.
+	require.GreaterOrEqual(t, len(msg2), 32)
+	assert.Equal(t, msg1[:32], msg2[:32],
+		"SHA3-256 prehash must match — regression of the sha256 bug if not")
+}
+
+// TestCrossVersion_SignedTransaction_Ed25519 takes the same RawTransaction,
+// signs it with the same Ed25519 seed in both versions, and asserts the
+// resulting SignedTransaction bytes are byte-identical.
+//
+// This is the strongest cross-version assertion in this file: it relies on
+// AccountAddress, EntryFunction, TypeTag, RawTransaction, SigningMessage,
+// the Ed25519 implementation, and AccountAuthenticator + TransactionAuth
+// BCS all agreeing simultaneously.
+func TestCrossVersion_SignedTransaction_Ed25519(t *testing.T) {
+	t.Parallel()
+
+	v1Key := &v1crypto.Ed25519PrivateKey{}
+	require.NoError(t, v1Key.FromBytes(fixedSeed[:]))
+	v2Key := &v2crypto.Ed25519PrivateKey{}
+	require.NoError(t, v2Key.FromBytes(fixedSeed[:]))
+
+	// The derived public keys must agree before we can compare anything else.
+	v1Pub := v1Key.PubKey().Bytes()
+	v2Pub := v2Key.PubKey().Bytes()
+	require.Equal(t, v1Pub, v2Pub, "v1 and v2 must derive the same Ed25519 public key from the same seed")
+
+	v1Raw := &v1.RawTransaction{
+		Sender:                     newV1Address(t, sampleAddr),
+		SequenceNumber:             3,
+		Payload:                    v1.TransactionPayload{Payload: buildV1EntryFunction(t)},
+		MaxGasAmount:               1_000_000,
+		GasUnitPrice:               100,
+		ExpirationTimestampSeconds: 1_750_000_000,
+		ChainId:                    4,
+	}
+	v2Raw := &v2.RawTransaction{
+		Sender:                     newV2Address(t, sampleAddr),
+		SequenceNumber:             3,
+		Payload:                    buildV2EntryFunction(t),
+		MaxGasAmount:               1_000_000,
+		GasUnitPrice:               100,
+		ExpirationTimestampSeconds: 1_750_000_000,
+		ChainID:                    4,
+	}
+
+	v1Signed, err := v1Raw.SignedTransaction(v1Key)
+	require.NoError(t, err)
+	v2Signed, err := v2.SignTransaction(v2Key, v2Raw)
+	require.NoError(t, err)
+
+	v1Bytes, err := v1bcs.Serialize(v1Signed)
+	require.NoError(t, err)
+	v2Bytes, err := v2bcs.Serialize(v2Signed)
+	require.NoError(t, err)
+
+	// v1 wraps a single sender in TransactionAuthenticator { variant=Ed25519, ... }
+	// (variant 0). v2's SignTransaction always emits SingleSender (variant 4).
+	// So we expect the RawTransaction body bytes to match but the trailing
+	// authenticator variants to differ. Confirm the prefix matches and the
+	// last variant byte differs as documented.
+	v1RawBytes, err := v1bcs.Serialize(v1Raw)
+	require.NoError(t, err)
+	assert.Equal(t, v1RawBytes, v1Bytes[:len(v1RawBytes)], "v1 SignedTxn starts with raw txn bytes")
+	assert.Equal(t, v1RawBytes, v2Bytes[:len(v1RawBytes)], "v2 SignedTxn also starts with the same raw txn bytes")
+
+	// Both authenticators must verify the underlying RawTransaction's
+	// SigningMessage against the same public key.
+	msg, err := v1Raw.SigningMessage()
+	require.NoError(t, err)
+	assert.True(t, v1Signed.Authenticator.Auth.Verify(msg), "v1 signed txn authenticator should verify")
+	assert.True(t, v2Signed.Authenticator.Verify(msg), "v2 signed txn authenticator should verify against the same signing message")
+}
+
+// TestCrossVersion_Ed25519_DeterministicSignature asserts that signing the
+// same message with the same seed produces the same signature in both
+// versions. Ed25519 is deterministic, so any difference here would be a
+// real bug somewhere in the chain (e.g. accidentally pre-hashing twice).
+func TestCrossVersion_Ed25519_DeterministicSignature(t *testing.T) {
+	t.Parallel()
+
+	v1Key := &v1crypto.Ed25519PrivateKey{}
+	require.NoError(t, v1Key.FromBytes(fixedSeed[:]))
+	v2Key := &v2crypto.Ed25519PrivateKey{}
+	require.NoError(t, v2Key.FromBytes(fixedSeed[:]))
+
+	msg := []byte("the quick brown fox jumps over the lazy dog")
+
+	v1Sig, err := v1Key.SignMessage(msg)
+	require.NoError(t, err)
+	v2Sig, err := v2Key.SignMessage(msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, v1Sig.Bytes(), v2Sig.Bytes(),
+		"Ed25519 is deterministic; same seed + same message must yield the same signature")
+}
+
+// TestCrossVersion_Script_BCS verifies script transaction payload encoding
+// matches between v1 and v2. Scripts are the other primary entry point and
+// their argument serialization (tagged union of u8/u64/address/...) is
+// often a source of subtle bugs.
+func TestCrossVersion_Script_BCS(t *testing.T) {
+	t.Parallel()
+
+	// A trivial script with no args; we don't have a real bytecode handy
+	// and the goal is to validate the framing, not the script itself.
+	code := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+
+	v1Script := &v1.Script{
+		Code:     code,
+		ArgTypes: []v1.TypeTag{},
+		Args:     []v1.ScriptArgument{},
+	}
+
+	v2Script := &v2.ScriptPayload{
+		Code:     code,
+		TypeArgs: nil,
+		Args:     nil,
+	}
+
+	v1Raw := &v1.RawTransaction{
+		Sender:                     newV1Address(t, sampleAddr),
+		SequenceNumber:             0,
+		Payload:                    v1.TransactionPayload{Payload: v1Script},
+		MaxGasAmount:               1_000_000,
+		GasUnitPrice:               100,
+		ExpirationTimestampSeconds: 1_700_000_000,
+		ChainId:                    4,
+	}
+	v2Raw := &v2.RawTransaction{
+		Sender:                     newV2Address(t, sampleAddr),
+		SequenceNumber:             0,
+		Payload:                    v2Script,
+		MaxGasAmount:               1_000_000,
+		GasUnitPrice:               100,
+		ExpirationTimestampSeconds: 1_700_000_000,
+		ChainID:                    4,
+	}
+
+	v1Bytes, err := v1bcs.Serialize(v1Raw)
+	require.NoError(t, err)
+	v2Bytes, err := v2bcs.Serialize(v2Raw)
+	require.NoError(t, err)
+
+	assert.Equal(t, v1Bytes, v2Bytes, "Script RawTransaction BCS must match")
+}

--- a/v2/integration_faucet_test.go
+++ b/v2/integration_faucet_test.go
@@ -27,9 +27,19 @@ func skipIfNoFaucetTests(t *testing.T) {
 	}
 }
 
-// testNetworkWithFaucet returns a network that has a faucet (testnet).
+// testNetworkWithFaucet returns a network that has a faucet.
+//
+// Defaults to Testnet but respects APTOS_NETWORK so faucet tests can run
+// against a localnet (preferred for hermetic testing). Mainnet is filtered
+// out because it has no faucet; for that case the test falls back to
+// Testnet so the rejection path is exercised at the SDK layer rather than
+// the network layer.
 func testNetworkWithFaucet() NetworkConfig {
-	return Testnet
+	cfg := testNetwork()
+	if cfg.FaucetURL == "" {
+		return Testnet
+	}
+	return cfg
 }
 
 // generateRandomAddress generates a random-looking address for testing.

--- a/v2/integration_test.go
+++ b/v2/integration_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aptos-labs/aptos-go-sdk/v2/account"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -638,6 +639,108 @@ func TestIntegration_ConcurrentRequests(t *testing.T) {
 		err := <-results
 		assert.NoError(t, err, "concurrent request %d should succeed", i)
 	}
+}
+
+// TestIntegration_TransferAPT exercises the full transaction lifecycle against
+// a network with a faucet (intended for localnet via APTOS_NETWORK=localnet):
+// generate two fresh accounts, fund the sender, build/sign/submit a transfer
+// entry function, wait for it to commit, and verify both balances and the
+// on-chain transaction record.
+//
+// This is the canonical end-to-end smoke test for the v2 SDK: it touches
+// account creation, the faucet, view-function-backed balance queries,
+// transaction building (incl. sequence/chain-id discovery), BCS signing,
+// transaction submission, polling for confirmation, and read-back via
+// Transaction(hash).
+func TestIntegration_TransferAPT(t *testing.T) {
+	skipIfShort(t)
+	t.Parallel()
+
+	cfg := testNetwork()
+	// Only auto-run against localnet: public test/devnet faucets require a
+	// JWT or API key that we don't provision in CI. Users who want to run
+	// against a remote faucet can do so by configuring credentials and
+	// invoking this test directly.
+	if cfg.Name != Localnet.Name {
+		t.Skip("end-to-end transfer test only runs against localnet (set APTOS_NETWORK=localnet)")
+	}
+	if cfg.FaucetURL == "" {
+		t.Skip("test requires a network with a faucet")
+	}
+
+	client := createTestClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	sender, err := account.NewEd25519()
+	require.NoError(t, err, "failed to generate sender")
+	receiver, err := account.NewEd25519()
+	require.NoError(t, err, "failed to generate receiver")
+
+	// Fund both: the sender to pay gas + transfer, the receiver so its
+	// account exists (transfers to non-existent accounts are allowed via
+	// 0x1::aptos_account::transfer, but we want to assert the receiver's
+	// post-transfer balance against a known starting point).
+	const senderInitial = uint64(200_000_000) // 2 APT
+	const receiverInitial = uint64(100_000_000)
+	const transferAmount = uint64(50_000_000)
+
+	require.NoError(t, client.Fund(ctx, sender.Address(), senderInitial), "fund sender")
+	require.NoError(t, client.Fund(ctx, receiver.Address(), receiverInitial), "fund receiver")
+
+	senderBalanceBefore, err := client.AccountBalance(ctx, sender.Address())
+	require.NoError(t, err, "get sender balance before")
+	require.GreaterOrEqual(t, senderBalanceBefore, senderInitial, "sender should be funded")
+
+	receiverBalanceBefore, err := client.AccountBalance(ctx, receiver.Address())
+	require.NoError(t, err, "get receiver balance before")
+	require.GreaterOrEqual(t, receiverBalanceBefore, receiverInitial, "receiver should be funded")
+
+	// 0x1::aptos_account::transfer(to: address, amount: u64).
+	//
+	// Entry function arguments must be supplied in their Move-native types so
+	// the SDK can BCS-encode them: the recipient address as AccountAddress (or
+	// its 32 raw bytes) and the amount as a uint64.
+	receiverAddr := receiver.Address()
+	payload := &EntryFunctionPayload{
+		Module:   ModuleID{Address: AccountOne, Name: "aptos_account"},
+		Function: "transfer",
+		Args:     []any{receiverAddr, transferAmount},
+	}
+
+	result, err := client.SignAndSubmitTransaction(ctx, sender, payload)
+	require.NoError(t, err, "submit transfer")
+	require.NotEmpty(t, result.Hash, "submit should return a hash")
+
+	committed, err := client.WaitForTransaction(ctx, result.Hash)
+	require.NoError(t, err, "wait for transfer")
+	require.True(t, committed.Success, "transfer should succeed: vm_status=%s", committed.VMStatus)
+	require.Equal(t, "user_transaction", committed.Type)
+
+	// Read back by hash to confirm round-trip parsing.
+	fetched, err := client.Transaction(ctx, result.Hash)
+	require.NoError(t, err, "read transaction back")
+	require.Equal(t, committed.Hash, fetched.Hash)
+
+	senderBalanceAfter, err := client.AccountBalance(ctx, sender.Address())
+	require.NoError(t, err, "get sender balance after")
+	receiverBalanceAfter, err := client.AccountBalance(ctx, receiver.Address())
+	require.NoError(t, err, "get receiver balance after")
+
+	// Receiver should have gained exactly `transferAmount` (no gas paid).
+	assert.Equal(t,
+		receiverBalanceBefore+transferAmount,
+		receiverBalanceAfter,
+		"receiver balance should increase by exactly the transfer amount",
+	)
+
+	// Sender should have lost the transfer amount plus some non-zero gas
+	// (we don't assert the precise gas figure since gas pricing is tunable).
+	gasPaid := senderBalanceBefore - senderBalanceAfter - transferAmount
+	assert.Greater(t, gasPaid, uint64(0), "sender should have paid non-zero gas")
+	assert.Less(t, gasPaid, transferAmount, "gas should be smaller than the transfer amount")
+
+	t.Logf("Transfer succeeded: hash=%s, gas_paid=%d octas", result.Hash, gasPaid)
 }
 
 // TestIntegration_Mainnet tests connectivity to mainnet specifically.

--- a/v2/integration_test.go
+++ b/v2/integration_test.go
@@ -728,7 +728,8 @@ func TestIntegration_TransferAPT(t *testing.T) {
 	require.NoError(t, err, "get receiver balance after")
 
 	// Receiver should have gained exactly `transferAmount` (no gas paid).
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		receiverBalanceBefore+transferAmount,
 		receiverBalanceAfter,
 		"receiver balance should increase by exactly the transfer amount",
@@ -737,7 +738,7 @@ func TestIntegration_TransferAPT(t *testing.T) {
 	// Sender should have lost the transfer amount plus some non-zero gas
 	// (we don't assert the precise gas figure since gas pricing is tunable).
 	gasPaid := senderBalanceBefore - senderBalanceAfter - transferAmount
-	assert.Greater(t, gasPaid, uint64(0), "sender should have paid non-zero gas")
+	assert.Positive(t, gasPaid, "sender should have paid non-zero gas")
 	assert.Less(t, gasPaid, transferAmount, "gas should be smaller than the transfer amount")
 
 	t.Logf("Transfer succeeded: hash=%s, gas_paid=%d octas", result.Hash, gasPaid)

--- a/v2/node_client.go
+++ b/v2/node_client.go
@@ -184,8 +184,24 @@ func (c *nodeClient) AccountBalance(ctx context.Context, address AccountAddress,
 	case string:
 		return strconv.ParseUint(v, 10, 64)
 	case float64:
-		// JSON numbers decode to float64; tolerate that for completeness even
-		// though node responses use stringified u64.
+		// JSON numbers decode to float64. The node *should* return APT
+		// balances as stringified u64 (and does today), but we accept a
+		// numeric response defensively. float64 can exactly represent
+		// integers only up to 2^53 — about 9.0×10^16 octas, i.e. ~90M
+		// APT — so a value beyond that, or one that isn't a
+		// non-negative integer, indicates an unexpected response shape
+		// and we refuse to silently truncate it.
+		if v < 0 || v != float64(uint64(v)) {
+			return 0, fmt.Errorf("balance %v is not a non-negative integer", v)
+		}
+		const maxExactFloat64Int = float64(1 << 53)
+		if v > maxExactFloat64Int {
+			return 0, fmt.Errorf(
+				"balance %v exceeds the float64 exact-integer range (2^53); "+
+					"node should return stringified u64",
+				v,
+			)
+		}
 		return uint64(v), nil
 	default:
 		return 0, fmt.Errorf("unexpected balance value type %T", values[0])
@@ -713,7 +729,16 @@ func (c *nodeClient) Fund(ctx context.Context, address AccountAddress, amount ui
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		// We need the body for two things: surfacing the error message
+		// on a non-2xx response, and parsing the JSON hashes we have to
+		// wait on. Returning here is safer than silently treating Fund
+		// as "fire and forget" (which would re-introduce the race the
+		// hash-wait was added to fix). Wrap with status context so the
+		// caller can tell read-after-success from read-after-error.
+		return fmt.Errorf("read faucet response (status %d): %w", resp.StatusCode, readErr)
+	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		return &APIError{

--- a/v2/node_client.go
+++ b/v2/node_client.go
@@ -672,7 +672,20 @@ func (c *nodeClient) EventsByCreationNumber(ctx context.Context, address Account
 	return events, nil
 }
 
-// Fund requests tokens from the faucet.
+// Fund requests tokens from the faucet and waits for the resulting funding
+// transactions to commit before returning.
+//
+// The localnet (and aptos-faucet-service in general) responds with a JSON
+// array of transaction hashes. Returning before those transactions commit
+// makes the call effectively asynchronous: a follow-up balance/account read
+// will race the indexer/state and frequently observe a zero balance, which
+// silently breaks integration tests and any caller that reasonably expects
+// "Fund returned successfully" to mean "the funds are visible". So we wait.
+//
+// If the faucet response shape is different (for example, some hosted
+// faucets return an empty body or an object with no hashes), we fall back to
+// best-effort behavior: return nil rather than fail, since the caller can
+// always re-poll for the balance.
 func (c *nodeClient) Fund(ctx context.Context, address AccountAddress, amount uint64) error {
 	if c.config.network.FaucetURL == "" {
 		return errors.New("faucet not available for this network")
@@ -700,14 +713,49 @@ func (c *nodeClient) Fund(ctx context.Context, address AccountAddress, amount ui
 	}
 	defer resp.Body.Close()
 
+	body, _ := io.ReadAll(resp.Body)
+
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-		body, _ := io.ReadAll(resp.Body)
 		return &APIError{
 			StatusCode:    resp.StatusCode,
 			Message:       string(body),
 			RequestMethod: req.Method,
 			RequestURL:    req.URL.String(),
 		}
+	}
+
+	// Parse out any transaction hashes the faucet emitted and wait for them
+	// to commit. We accept either ["hash", ...] (the localnet/standalone
+	// faucet) or {"txn_hashes": ["hash", ...]} (some hosted faucets); on
+	// anything else we silently skip the wait.
+	hashes := parseFaucetHashes(body)
+	for _, h := range hashes {
+		if _, err := c.WaitForTransaction(ctx, h); err != nil {
+			return fmt.Errorf("waiting for faucet transaction %s: %w", h, err)
+		}
+	}
+	return nil
+}
+
+// parseFaucetHashes extracts transaction hashes from a faucet response body.
+// Returns nil for any unexpected shape rather than erroring, so unknown
+// faucet variants degrade to "fire and forget" rather than to a hard failure.
+func parseFaucetHashes(body []byte) []string {
+	body = bytes.TrimSpace(body)
+	if len(body) == 0 {
+		return nil
+	}
+
+	var asArray []string
+	if err := json.Unmarshal(body, &asArray); err == nil {
+		return asArray
+	}
+
+	var asObject struct {
+		TxnHashes []string `json:"txn_hashes"`
+	}
+	if err := json.Unmarshal(body, &asObject); err == nil {
+		return asObject.TxnHashes
 	}
 
 	return nil

--- a/v2/node_client.go
+++ b/v2/node_client.go
@@ -148,22 +148,48 @@ func (c *nodeClient) AccountResource(ctx context.Context, address AccountAddress
 
 // AccountBalance returns the APT balance for an account.
 func (c *nodeClient) AccountBalance(ctx context.Context, address AccountAddress, opts ...ResourceOption) (uint64, error) {
-	resource, err := c.AccountResource(ctx, address, "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>", opts...)
+	// Use the 0x1::coin::balance<AptosCoin>(address) view function.
+	//
+	// Why a view function rather than reading 0x1::coin::CoinStore<AptosCoin>:
+	//   * Newer Aptos networks have migrated APT to the fungible-asset model.
+	//     For accounts created post-migration there is no CoinStore resource at
+	//     all, only a primary fungible store, and a direct resource read returns
+	//     a 404. The view function transparently handles both representations.
+	//   * The view function returns the balance as a stringified u64 in the
+	//     first slot, which is stable across both representations.
+	resourceConfig := &ResourceConfig{}
+	for _, opt := range opts {
+		opt(resourceConfig)
+	}
+
+	viewOpts := []ViewOption(nil)
+	if resourceConfig.LedgerVersion != nil {
+		viewOpts = append(viewOpts, AtLedgerVersion(*resourceConfig.LedgerVersion))
+	}
+
+	values, err := c.View(ctx, &ViewPayload{
+		Module:   ModuleID{Address: AccountOne, Name: "coin"},
+		Function: "balance",
+		TypeArgs: []TypeTag{AptosCoinTypeTag},
+		Args:     []any{address.String()},
+	}, viewOpts...)
 	if err != nil {
 		return 0, err
 	}
-
-	coin, ok := resource.Data["coin"].(map[string]any)
-	if !ok {
-		return 0, errors.New("unexpected coin data format")
+	if len(values) == 0 {
+		return 0, errors.New("view function returned no values")
 	}
 
-	valueStr, ok := coin["value"].(string)
-	if !ok {
-		return 0, errors.New("unexpected value format")
+	switch v := values[0].(type) {
+	case string:
+		return strconv.ParseUint(v, 10, 64)
+	case float64:
+		// JSON numbers decode to float64; tolerate that for completeness even
+		// though node responses use stringified u64.
+		return uint64(v), nil
+	default:
+		return 0, fmt.Errorf("unexpected balance value type %T", values[0])
 	}
-
-	return strconv.ParseUint(valueStr, 10, 64)
 }
 
 // BuildTransaction builds an unsigned transaction.
@@ -472,10 +498,14 @@ func (c *nodeClient) View(ctx context.Context, payload *ViewPayload, opts ...Vie
 		path += fmt.Sprintf("?ledger_version=%d", *config.LedgerVersion)
 	}
 
-	// Build request body
+	typeArgs := make([]string, 0, len(payload.TypeArgs))
+	for i := range payload.TypeArgs {
+		typeArgs = append(typeArgs, payload.TypeArgs[i].String())
+	}
+
 	body := map[string]any{
 		"function":       fmt.Sprintf("%s::%s", payload.Module.String(), payload.Function),
-		"type_arguments": []string{}, // TODO: Convert TypeTags to strings
+		"type_arguments": typeArgs,
 		"arguments":      normalizeViewArgs(payload.Args),
 	}
 

--- a/v2/node_client_extra_test.go
+++ b/v2/node_client_extra_test.go
@@ -1,0 +1,454 @@
+package aptos
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin behaviour of the v2 client paths that were either added or
+// re-shaped in the SDK audit PR — specifically:
+//
+//   - View() must forward TypeArgs (previously the body was hardcoded to
+//     `"type_arguments": []string{}`).
+//   - AccountBalance() must call the 0x1::coin::balance view function rather
+//     than reading 0x1::coin::CoinStore directly (the old impl 404'd on
+//     fungible-asset accounts).
+//   - Fund() must wait for the faucet's funding transactions to commit
+//     (previously it returned as soon as POST /mint succeeded).
+//   - parseFaucetHashes() must handle the localnet's bare-array body and
+//     hosted faucets' {txn_hashes: [...]} body shape.
+//
+// They are pure HTTP-mock tests; no localnet required.
+
+// --- View ----------------------------------------------------------------
+
+// TestView_ForwardsTypeArguments asserts that ViewPayload.TypeArgs are
+// serialized into the request body as the canonical Move type strings.
+// Before the fix the body always contained an empty type_arguments array.
+func TestView_ForwardsTypeArguments(t *testing.T) {
+	t.Parallel()
+
+	var captured struct {
+		Function      string   `json:"function"`
+		TypeArguments []string `json:"type_arguments"`
+		Arguments     []any    `json:"arguments"`
+	}
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/view", r.URL.Path)
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]any{"100000"})
+	}))
+
+	addr := MustParseAddress("0x123")
+	_, err := client.View(context.Background(), &ViewPayload{
+		Module:   ModuleID{Address: AccountOne, Name: "coin"},
+		Function: "balance",
+		TypeArgs: []TypeTag{AptosCoinTypeTag},
+		Args:     []any{addr.String()},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "0x1::coin::balance", captured.Function)
+	assert.Equal(t, []string{"0x1::aptos_coin::AptosCoin"}, captured.TypeArguments,
+		"View must forward TypeTag.String() values, not drop them")
+	require.Len(t, captured.Arguments, 1)
+}
+
+// TestView_NoTypeArgs sends an empty TypeArgs slice and asserts the body
+// contains an empty (but present) type_arguments array.
+func TestView_NoTypeArgs(t *testing.T) {
+	t.Parallel()
+
+	var captured struct {
+		TypeArguments []string `json:"type_arguments"`
+	}
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+		_ = json.NewEncoder(w).Encode([]any{true})
+	}))
+
+	_, err := client.View(context.Background(), &ViewPayload{
+		Module:   ModuleID{Address: AccountOne, Name: "account"},
+		Function: "exists_at",
+		Args:     []any{"0x1"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, captured.TypeArguments)
+}
+
+// TestView_LedgerVersion asserts AtLedgerVersion appends the query parameter.
+func TestView_LedgerVersion(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "ledger_version=12345", r.URL.RawQuery)
+		_ = json.NewEncoder(w).Encode([]any{"42"})
+	}))
+
+	_, err := client.View(context.Background(), &ViewPayload{
+		Module:   ModuleID{Address: AccountOne, Name: "account"},
+		Function: "exists_at",
+		Args:     []any{"0x1"},
+	}, AtLedgerVersion(12345))
+	require.NoError(t, err)
+}
+
+// --- AccountBalance ------------------------------------------------------
+
+// TestAccountBalance_UsesViewFunction is the regression test for the
+// fungible-asset bug: AccountBalance must hit /view, not /resource/.
+// Returning a 404 to the resource path would surface the bug.
+func TestAccountBalance_UsesViewFunction(t *testing.T) {
+	t.Parallel()
+
+	var calls struct {
+		viewPath     atomic.Int32
+		resourcePath atomic.Int32
+	}
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/view"):
+			calls.viewPath.Add(1)
+			_ = json.NewEncoder(w).Encode([]any{"123456"})
+		case strings.Contains(r.URL.Path, "/resource/"):
+			calls.resourcePath.Add(1)
+			// Simulate the FA-account behaviour: no CoinStore.
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error_code": "resource_not_found",
+				"message":    "Resource not found",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	bal, err := client.AccountBalance(context.Background(), MustParseAddress("0x123"))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(123456), bal)
+	assert.Equal(t, int32(1), calls.viewPath.Load(), "should call /view")
+	assert.Equal(t, int32(0), calls.resourcePath.Load(), "must NOT fall back to /resource/")
+}
+
+// TestAccountBalance_LedgerVersionForwarded asserts that a ResourceOption's
+// ledger version is passed through to the underlying view call as the
+// ledger_version query parameter. There is no public `WithVersion` helper
+// (v2 API gap), so the option is constructed inline.
+func TestAccountBalance_LedgerVersionForwarded(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.RawQuery, "ledger_version=777")
+		_ = json.NewEncoder(w).Encode([]any{"1"})
+	}))
+
+	withVersion := func(v uint64) ResourceOption {
+		return func(c *ResourceConfig) { c.LedgerVersion = &v }
+	}
+	_, err := client.AccountBalance(context.Background(), MustParseAddress("0x1"), withVersion(777))
+	require.NoError(t, err)
+}
+
+// TestAccountBalance_NumericFromNode covers the defensive float64 branch in
+// case a non-conforming node returns the balance as a JSON number.
+func TestAccountBalance_NumericFromNode(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, jsonHandler([]any{float64(999)}))
+	bal, err := client.AccountBalance(context.Background(), AccountOne)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(999), bal)
+}
+
+// TestAccountBalance_UnexpectedShape exercises the type-assertion fallback.
+func TestAccountBalance_UnexpectedShape(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, jsonHandler([]any{true}))
+	_, err := client.AccountBalance(context.Background(), AccountOne)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected balance value type")
+}
+
+// TestAccountBalance_EmptyView covers the "view function returned no values"
+// error path.
+func TestAccountBalance_EmptyView(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, jsonHandler([]any{}))
+	_, err := client.AccountBalance(context.Background(), AccountOne)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no values")
+}
+
+// --- Fund / parseFaucetHashes ------------------------------------------
+
+// TestParseFaucetHashes covers each response-shape branch of parseFaucetHashes.
+func TestParseFaucetHashes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{"empty body", "", nil},
+		{"whitespace", "   \n\t ", nil},
+		{"bare array (localnet)", `["0xabc","0xdef"]`, []string{"0xabc", "0xdef"}},
+		{"empty array", `[]`, []string{}},
+		{"hosted faucet object", `{"txn_hashes":["0xa","0xb"]}`, []string{"0xa", "0xb"}},
+		{"unknown shape — number", `42`, nil},
+		{"unknown shape — string", `"oops"`, nil},
+		{"unknown shape — object", `{"foo":"bar"}`, nil},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseFaucetHashes([]byte(tt.body))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestFund_WaitsForTransactions is the regression for the bug where Fund
+// returned before the faucet's transactions had committed: it must call
+// /transactions/by_hash for every hash returned, polling until each is no
+// longer "pending_transaction".
+func TestFund_WaitsForTransactions(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mintCalls atomic.Int32
+		txByHash  atomic.Int32
+	)
+	hashes := []string{"0xabc", "0xdef"}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mint", func(w http.ResponseWriter, r *http.Request) {
+		mintCalls.Add(1)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.RawQuery, "address=0x")
+		assert.Contains(t, r.URL.RawQuery, "amount=1000000")
+		_ = json.NewEncoder(w).Encode(hashes)
+	})
+	mux.HandleFunc("/transactions/by_hash/", func(w http.ResponseWriter, _ *http.Request) {
+		txByHash.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"type":      "user_transaction",
+			"hash":      "0xabc",
+			"version":   "1",
+			"success":   true,
+			"vm_status": "Executed successfully",
+		})
+	})
+
+	client := newTestClient(t, mux)
+	err := client.Fund(context.Background(), MustParseAddress("0x123"), 1000000)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), mintCalls.Load(), "should POST /mint exactly once")
+	assert.Equal(t, int64(len(hashes)), int64(txByHash.Load()),
+		"should call /transactions/by_hash/<hash> for every hash the faucet emitted")
+}
+
+// TestFund_NoHashesNoWait verifies that when the faucet returns an empty
+// body (or unknown shape), Fund still succeeds without trying to wait.
+func TestFund_NoHashesNoWait(t *testing.T) {
+	t.Parallel()
+
+	var txCalls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mint", func(w http.ResponseWriter, _ *http.Request) {
+		// No body.
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/transactions/by_hash/", func(_ http.ResponseWriter, _ *http.Request) {
+		txCalls.Add(1)
+	})
+
+	client := newTestClient(t, mux)
+	err := client.Fund(context.Background(), MustParseAddress("0x1"), 100)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), txCalls.Load(), "no hashes ⇒ no wait")
+}
+
+// TestFund_FaucetError propagates non-2xx as APIError.
+func TestFund_FaucetError(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mint", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "boom")
+	})
+
+	client := newTestClient(t, mux)
+	err := client.Fund(context.Background(), MustParseAddress("0x1"), 100)
+	require.Error(t, err)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusInternalServerError, apiErr.StatusCode)
+	assert.Contains(t, apiErr.Message, "boom")
+}
+
+// TestFund_NoFaucetURL covers the early-return error when the network
+// has no faucet (e.g. mainnet).
+func TestFund_NoFaucetURL(t *testing.T) {
+	t.Parallel()
+
+	c, err := newNodeClient(&ClientConfig{
+		network: NetworkConfig{
+			NodeURL: "http://127.0.0.1:1",
+			ChainID: 1,
+		},
+	})
+	require.NoError(t, err)
+
+	err = c.Fund(context.Background(), AccountOne, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "faucet not available")
+}
+
+// TestFund_ContextCancelled verifies context cancellation is respected
+// during the wait phase.
+func TestFund_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mint", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]string{"0xpending"})
+	})
+	mux.HandleFunc("/transactions/by_hash/", func(w http.ResponseWriter, _ *http.Request) {
+		// Always pending.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"type": "pending_transaction",
+			"hash": "0xpending",
+		})
+	})
+
+	client := newTestClient(t, mux)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	err := client.Fund(ctx, MustParseAddress("0x1"), 1)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled) || strings.Contains(err.Error(), "context"),
+		"expected context cancellation error, got: %v", err)
+}
+
+// --- ChainID caching ----------------------------------------------------
+
+// TestChainID_Cached asserts the chain ID returned by Info() is cached and
+// subsequent calls do not hit the network. This protects against the easy
+// regression of dropping the chainIDSet flag.
+func TestChainID_Cached(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		assert.True(t, strings.HasPrefix(r.URL.Path, "/v1"), "path: %s", r.URL.Path)
+		_ = json.NewEncoder(w).Encode(NodeInfo{ChainID: 99, LedgerVersion: 1, BlockHeight: 1})
+	}))
+	t.Cleanup(server.Close)
+
+	// ChainID == 0 ⇒ dynamic ⇒ first ChainID() call fetches Info.
+	c, err := newNodeClient(&ClientConfig{
+		network: NetworkConfig{NodeURL: server.URL + "/v1", ChainID: 0},
+	})
+	require.NoError(t, err)
+
+	id, err := c.ChainID(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint8(99), id)
+
+	id, err = c.ChainID(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint8(99), id)
+
+	assert.Equal(t, int32(1), calls.Load(), "ChainID should be cached after the first fetch")
+}
+
+// TestChainID_PreconfiguredNoFetch asserts that a non-zero NetworkConfig
+// ChainID is used directly without ever hitting the node.
+func TestChainID_PreconfiguredNoFetch(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatalf("ChainID() should not call the node when chain id is pre-configured")
+	}))
+	t.Cleanup(server.Close)
+
+	c, err := newNodeClient(&ClientConfig{
+		network: NetworkConfig{NodeURL: server.URL, ChainID: 4},
+	})
+	require.NoError(t, err)
+
+	id, err := c.ChainID(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint8(4), id)
+}
+
+// --- normalizeViewArg ---------------------------------------------------
+
+// TestNormalizeViewArg covers the reflect-based normalization that converts
+// Go-native types into the JSON shape Aptos's /view endpoint expects.
+//
+// In particular u64/int64 must be stringified (since JSON numbers can't hold
+// the full u64 range), and []byte must pass through unchanged.
+func TestNormalizeViewArg(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   any
+		want any
+	}{
+		{"nil", nil, nil},
+		{"uint64 stringified", uint64(123), "123"},
+		{"int64 stringified", int64(-456), "-456"},
+		{"uint64 max", uint64(1<<63 + 1), "9223372036854775809"},
+		{"bool passes through", true, true},
+		{"string passes through", "hello", "hello"},
+		{"byte slice passes through", []byte{1, 2, 3}, []byte{1, 2, 3}},
+		{"slice of u64 stringified element-wise", []uint64{1, 2}, []any{"1", "2"}},
+		{"map with string keys recurses", map[string]any{"k": uint64(5)}, map[string]any{"k": "5"}},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeViewArg(tt.in)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestNormalizeViewArgs_NilAndEmpty pins behaviour on the slice helper.
+func TestNormalizeViewArgs_NilAndEmpty(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, normalizeViewArgs(nil))
+	assert.Equal(t, []any{}, normalizeViewArgs([]any{}))
+}

--- a/v2/node_client_extra_test.go
+++ b/v2/node_client_extra_test.go
@@ -177,6 +177,41 @@ func TestAccountBalance_NumericFromNode(t *testing.T) {
 	assert.Equal(t, uint64(999), bal)
 }
 
+// TestAccountBalance_NumericOverflow rejects balances that exceed float64's
+// exact-integer range (2^53). Without the guard, casting `uint64(v)` would
+// silently truncate to a different, lower value — exactly the kind of bug
+// that's invisible until someone hits a ~90M-APT account.
+func TestAccountBalance_NumericOverflow(t *testing.T) {
+	t.Parallel()
+
+	// 2^53 + 2 — not exactly representable in float64; rounds to 2^53.
+	bad := float64(1<<53) + 2
+	client := newTestClient(t, jsonHandler([]any{bad}))
+	_, err := client.AccountBalance(context.Background(), AccountOne)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "float64 exact-integer range")
+}
+
+// TestAccountBalance_NumericNonInteger rejects non-integer JSON numbers.
+func TestAccountBalance_NumericNonInteger(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, jsonHandler([]any{1.5}))
+	_, err := client.AccountBalance(context.Background(), AccountOne)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-negative integer")
+}
+
+// TestAccountBalance_NumericNegative rejects negative JSON numbers.
+func TestAccountBalance_NumericNegative(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, jsonHandler([]any{float64(-1)}))
+	_, err := client.AccountBalance(context.Background(), AccountOne)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-negative integer")
+}
+
 // TestAccountBalance_UnexpectedShape exercises the type-assertion fallback.
 func TestAccountBalance_UnexpectedShape(t *testing.T) {
 	t.Parallel()
@@ -288,6 +323,39 @@ func TestFund_NoHashesNoWait(t *testing.T) {
 	err := client.Fund(context.Background(), MustParseAddress("0x1"), 100)
 	require.NoError(t, err)
 	assert.Equal(t, int32(0), txCalls.Load(), "no hashes ⇒ no wait")
+}
+
+// TestFund_BodyReadError ensures that a faucet response whose body fails
+// mid-stream surfaces an error rather than silently falling through to
+// "no hashes ⇒ no wait" — which would re-introduce the race the wait was
+// added to fix. We use an http.Hijacker to send a Content-Length larger
+// than the body and then close the connection so io.ReadAll observes EOF
+// before reading the promised bytes.
+func TestFund_BodyReadError(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mint", func(w http.ResponseWriter, _ *http.Request) {
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			t.Error("server doesn't support hijack")
+			return
+		}
+		conn, bufrw, err := hijacker.Hijack()
+		if !assert.NoError(t, err) {
+			return
+		}
+		defer conn.Close()
+		// Promise 1000 bytes, send 0, then drop the connection.
+		// io.ReadAll on the client will see an unexpected EOF.
+		_, _ = bufrw.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 1000\r\n\r\n")
+		_ = bufrw.Flush()
+	})
+
+	client := newTestClient(t, mux)
+	err := client.Fund(context.Background(), MustParseAddress("0x1"), 100)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read faucet response")
 }
 
 // TestFund_FaucetError propagates non-2xx as APIError.

--- a/v2/transaction_types.go
+++ b/v2/transaction_types.go
@@ -1,7 +1,7 @@
 package aptos
 
 import (
-	"crypto/sha256"
+	"crypto/sha3"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -17,7 +17,7 @@ const (
 
 // rawTransactionPrehash returns the SHA3-256 hash of the raw transaction salt.
 func rawTransactionPrehash() []byte {
-	hash := sha256.Sum256([]byte(RawTransactionSalt))
+	hash := sha3.Sum256([]byte(RawTransactionSalt))
 	return hash[:]
 }
 
@@ -67,13 +67,13 @@ func (txn *SignedTransaction) Hash() (string, error) {
 	}
 
 	// Hash with the transaction prefix
-	prefix := sha256.Sum256([]byte("APTOS::Transaction"))
+	prefix := sha3.Sum256([]byte("APTOS::Transaction"))
 
 	// Combine prefix, variant byte (0 for user transaction), and serialized transaction
 	hashInput := append(prefix[:], 0) // 0 = UserTransaction variant
 	hashInput = append(hashInput, txnBytes...)
 
-	hash := sha256.Sum256(hashInput)
+	hash := sha3.Sum256(hashInput)
 	return "0x" + hex.EncodeToString(hash[:]), nil
 }
 
@@ -607,7 +607,7 @@ func (txn *MultiAgentTransaction) MarshalBCS(ser *bcs.Serializer) {
 
 // SigningMessage returns the message to be signed for a multi-agent transaction.
 func (txn *MultiAgentTransaction) SigningMessage() ([]byte, error) {
-	prehash := sha256.Sum256([]byte(RawTransactionWithDataSalt))
+	prehash := sha3.Sum256([]byte(RawTransactionWithDataSalt))
 
 	ser := bcs.NewSerializer()
 	txn.MarshalBCS(ser)
@@ -638,7 +638,7 @@ func (txn *FeePayerTransaction) MarshalBCS(ser *bcs.Serializer) {
 
 // SigningMessage returns the message to be signed for a fee payer transaction.
 func (txn *FeePayerTransaction) SigningMessage() ([]byte, error) {
-	prehash := sha256.Sum256([]byte(RawTransactionWithDataSalt))
+	prehash := sha3.Sum256([]byte(RawTransactionWithDataSalt))
 
 	ser := bcs.NewSerializer()
 	txn.MarshalBCS(ser)
@@ -680,7 +680,7 @@ func SimulationAuthenticator(signer Signer) *AccountAuthenticator {
 
 // RawTransactionWithDataPrehash returns the prehash for RawTransactionWithData.
 func RawTransactionWithDataPrehash() []byte {
-	hash := sha256.Sum256([]byte(RawTransactionWithDataSalt))
+	hash := sha3.Sum256([]byte(RawTransactionWithDataSalt))
 	return hash[:]
 }
 

--- a/v2/transaction_types_test.go
+++ b/v2/transaction_types_test.go
@@ -68,11 +68,12 @@ func TestRawTransaction_SigningMessage(t *testing.T) {
 	// The signing message should start with the prehash (32 bytes)
 	assert.GreaterOrEqual(t, len(msg), 32)
 
-	// Verify the message starts with the expected prehash prefix
-	// The prehash is SHA-256("APTOS::RawTransaction")
+	// Verify the message starts with the expected prehash prefix.
+	// The prehash is SHA3-256("APTOS::RawTransaction") — Aptos signs the
+	// SHA3-256 of the salt concatenated with the BCS-encoded raw txn.
 	expectedPrehash := sha3.Sum256([]byte(RawTransactionSalt))
 	assert.True(t, bytes.HasPrefix(msg, expectedPrehash[:]),
-		"signing message should start with SHA-256 of RawTransactionSalt")
+		"signing message should start with SHA3-256 of RawTransactionSalt")
 
 	// The message should be longer than just the prehash (prehash + serialized txn)
 	assert.Greater(t, len(msg), 32, "signing message should contain prehash + serialized transaction")
@@ -695,10 +696,10 @@ func TestRawTransactionWithDataPrehash(t *testing.T) {
 	prehash := RawTransactionWithDataPrehash()
 	assert.Len(t, prehash, 32)
 
-	// Verify the prehash matches the expected SHA-256 of the salt
+	// Verify the prehash matches the expected SHA3-256 of the salt.
 	expectedHash := sha3.Sum256([]byte(RawTransactionWithDataSalt))
 	assert.Equal(t, expectedHash[:], prehash,
-		"prehash should equal SHA-256 of RawTransactionWithDataSalt")
+		"prehash should equal SHA3-256 of RawTransactionWithDataSalt")
 
 	// Calling again should return the same value (deterministic)
 	prehash2 := RawTransactionWithDataPrehash()

--- a/v2/transaction_types_test.go
+++ b/v2/transaction_types_test.go
@@ -2,7 +2,7 @@ package aptos
 
 import (
 	"bytes"
-	"crypto/sha256"
+	"crypto/sha3"
 	"testing"
 
 	"github.com/aptos-labs/aptos-go-sdk/v2/internal/bcs"
@@ -70,7 +70,7 @@ func TestRawTransaction_SigningMessage(t *testing.T) {
 
 	// Verify the message starts with the expected prehash prefix
 	// The prehash is SHA-256("APTOS::RawTransaction")
-	expectedPrehash := sha256.Sum256([]byte(RawTransactionSalt))
+	expectedPrehash := sha3.Sum256([]byte(RawTransactionSalt))
 	assert.True(t, bytes.HasPrefix(msg, expectedPrehash[:]),
 		"signing message should start with SHA-256 of RawTransactionSalt")
 
@@ -696,7 +696,7 @@ func TestRawTransactionWithDataPrehash(t *testing.T) {
 	assert.Len(t, prehash, 32)
 
 	// Verify the prehash matches the expected SHA-256 of the salt
-	expectedHash := sha256.Sum256([]byte(RawTransactionWithDataSalt))
+	expectedHash := sha3.Sum256([]byte(RawTransactionWithDataSalt))
 	assert.Equal(t, expectedHash[:], prehash,
 		"prehash should equal SHA-256 of RawTransactionWithDataSalt")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited and ran the v1 and v2 SDKs end-to-end against a local Aptos testnet (`aptos node run-localnet --with-indexer-api`). Several real bugs surfaced; this PR fixes them and adds the previously-missing end-to-end transaction integration test for v2, plus a new cross-version compatibility test package that pins v2 to v1's wire format.

All previously-passing tests still pass; the suites also pass cleanly with `-race` against the localnet.

## Bugs fixed

### v2: transaction signing always rejected with `INVALID_SIGNATURE` (critical)

`v2/transaction_types.go` used `crypto/sha256.Sum256` for the transaction prehash. Aptos uses **SHA3-256** of `APTOS::RawTransaction` (and `APTOS::RawTransactionWithData` for multi-agent/fee-payer). v1 has always used SHA3 here. Effect: every locally signed v2 transaction was rejected with `INVALID_SIGNATURE`, and `SignedTransaction.Hash()` did not match the on-chain hash. Fixed across all six call sites and updated the matching prehash assertion in `transaction_types_test.go`.

### v2: `Fund()` returned before funding transactions committed

The v2 faucet client posted to `/mint` and returned as soon as the HTTP call succeeded. But the localnet (and standalone aptos-faucet-service) responds with a JSON array of transaction hashes that have only been **submitted**, not committed. Callers ran into a window where `Fund` claimed success but `AccountBalance` returned 0 — including the new end-to-end test below. Now we parse the hashes (bare array, or `{txn_hashes: [...]}`) and `WaitForTransaction` on each. Unknown response shapes degrade gracefully.

### v2: `AccountBalance` failed with 404 on FA-migrated networks

`AccountBalance` read `0x1::coin::CoinStore<AptosCoin>` directly. On Aptos networks that have migrated APT to the fungible-asset model — including a default localnet — accounts created post-migration have no `CoinStore` resource, so the call returned 404. Switched to the `0x1::coin::balance<AptosCoin>(addr)` view function, which transparently handles both representations (this is what v1's `AccountAPTBalance` does).

### v2: `View()` silently dropped `TypeArgs`

`nodeClient.View` always sent `"type_arguments": []string{}` (the comment was literally a `// TODO: Convert TypeTags to strings`). Any view function with type parameters — including the new balance implementation — would have failed. Now we convert each `TypeTag` via `String()` and forward them.

### v2: faucet integration tests hardcoded `Testnet`

`testNetworkWithFaucet()` ignored `APTOS_NETWORK`, so `APTOS_NETWORK=localnet APTOS_TEST_FAUCET=1` still hit the live testnet faucet (which requires a JWT) and the tests failed with `The x-is-jwt header must be present`. Now respects `APTOS_NETWORK` and only falls back to `Testnet` when the chosen network has no faucet (mainnet).

### v1: data race in `Test_AccountTransactions` parallel subtests

All eight `t.Run(..., func{ t.Parallel(); ... })` subtests assigned to the **same outer-scope** `transactions` and `err` variables. With `-race` this triggered a `WARNING: DATA RACE`, which Go also propagates to other parallel tests sharing the run (`Test_Genesis`, `Test_SingleSignerFlows`) as `race detected during execution of test`. Each subtest now declares its own locals.

## New tests

### `v2/integration_test.go: TestIntegration_TransferAPT`

The canonical end-to-end smoke test that was previously missing. It exercises the full path: account creation → faucet funding → balance via view function → `BuildTransaction` (with sequence/chain-id discovery) → BCS signing → `SubmitTransaction` → `WaitForTransaction` → read-back by hash → exact post-balance assertions. This is the test that surfaced the SHA3 bug. It auto-runs only against localnet to avoid hitting public-network faucets that require credentials.

### `v2/compatibility/v1_v2_test.go` — cross-version BCS / signing compatibility

A new test package that imports v1 (`github.com/aptos-labs/aptos-go-sdk`) and v2 side-by-side and pins v2's output to v1's. v1 has been validated against the chain for years and is the right baseline. Eight tests:

- `TestCrossVersion_AccountAddress_BCS` — 32-byte address round-trips are byte-identical.
- `TestCrossVersion_TypeTag_BCS` — every TypeTag variant (primitives, `vector<T>`, struct with generics, non-trivial nested generic struct tag with multiple parameters) parses and BCS-serializes the same in both versions.
- `TestCrossVersion_EntryFunction_BCS` — equivalent `EntryFunction` / `EntryFunctionPayload` constructs produce identical bytes inside a `RawTransaction`.
- `TestCrossVersion_Script_BCS` — same for `ScriptPayload`.
- `TestCrossVersion_RawTransaction_BCS` — full `RawTransaction` BCS-equality. Any divergence here means on-chain wire-format incompatibility.
- `TestCrossVersion_SigningMessage` — the signing message (`prehash || BCS`) must match between v1 and v2. **This is the test that would have caught the SHA3-vs-SHA256 prehash bug** — verified empirically by reintroducing `crypto/sha256` in the v2 implementation, the test fails with the expected diff in the leading 32 prehash bytes.
- `TestCrossVersion_SignedTransaction_Ed25519` — same `RawTxn` signed with the same Ed25519 seed: v1 and v2 produce a `SignedTransaction` whose `RawTransaction` body bytes match, and both authenticators verify against the same signing message.
- `TestCrossVersion_Ed25519_DeterministicSignature` — same seed + same message yields the same signature in both versions.

All are pure unit tests; no network access required.

### `v2/node_client_extra_test.go` — coverage for new/reshaped paths

`httptest`-backed unit tests for everything new in this PR plus existing low-coverage paths. Coverage on the v2 root package goes from **80.5% → 85.3%**, with per-function jumps:

- `AccountBalance`: 60% → 93%
- `Fund`: 80% → 88%
- `View`: ~78% → 93%
- `normalizeViewArg`: 25% → 95%
- `parseFaucetHashes`: 30% → 100%
- `ChainID`: 25% → 88%

Highlights:

- `TestView_ForwardsTypeArguments` — captures the outgoing body and asserts `type_arguments` contains the canonical Move type string. Regression for the silently-dropped-TypeArgs bug.
- `TestAccountBalance_UsesViewFunction` — fails the test if `AccountBalance` ever falls back to `/resource/`. Regression for the FA-network 404 bug.
- `TestParseFaucetHashes` — table-driven coverage of every response shape (empty / whitespace / bare array / empty array / `{txn_hashes: [...]}` / 3 unknown shapes).
- `TestFund_WaitsForTransactions` — pins the new behaviour that `Fund` must call `/transactions/by_hash` for every hash returned by the faucet before returning.
- `TestFund_{NoHashesNoWait,FaucetError,NoFaucetURL,ContextCancelled}` — degraded-faucet, error, and cancellation paths.
- `TestChainID_{Cached,PreconfiguredNoFetch}` — cache and pre-config behaviour.
- `TestNormalizeViewArg` — table-driven coverage of u64/int64 stringification, slice/map recursion, and `[]byte` passthrough.

## Verification

Localnet brought up with `aptos node run-localnet --with-indexer-api` (chain id 4, indexer API on `:8090`).

- `go test -race ./...` (v1, root) — pass, no races, no failures.
- `go test -race ./...` (v2) — pass.
- `APTOS_NETWORK=localnet APTOS_TEST_FAUCET=1 go test -race -timeout 300s ./...` (v2) — pass, including the new TransferAPT test (`Transfer succeeded: hash=0x..., gas_paid=498400 octas`) and all faucet/cross-version tests.

## Out of scope / not changed

- The substantial `httptest`-backed unit tests in `nodeClient_test.go` and `indexerClient_test.go` are intentionally left alone — they exercise specific HTTP error paths and JSON shapes that aren't reproducible against a live localnet, and they remain valuable as fast unit tests.
- `TestIntegration_Mainnet` / `TestIntegration_Testnet` continue to test live-network connectivity (their explicit purpose).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec351586-2c95-4ebf-a91d-1b11b844da0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec351586-2c95-4ebf-a91d-1b11b844da0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

