### PR TITLE
v2: fix entry-function arg BCS encoding and ANS payloads

### DIFF
--- a/v2/ans/ans.go
+++ b/v2/ans/ans.go
@@ -322,14 +322,39 @@ func (c *Client) IsAvailable(ctx context.Context, name string) (bool, error) {
 	return false, nil
 }
 
+// secondsPerYear is used to convert the user-facing "years" registration
+// duration to the seconds value the router contract expects.
+const secondsPerYear uint64 = 365 * 24 * 60 * 60
+
 // RegisterOptions contains options for name registration.
 type RegisterOptions struct {
 	// Years is the number of years to register the name for.
-	Years int
+	// Zero defaults to one year.
+	Years uint64
 
 	// Target is the address the name should resolve to.
-	// If empty, defaults to the registrant's address.
+	// If nil, the router uses the registrant's address.
 	Target *aptos.AccountAddress
+}
+
+// subdomainOption returns the Move Option<String> wrapper for an ANS subdomain
+// label. An empty string maps to None — set_primary_name and friends
+// expect an Option, not a plain string, so passing "" without wrapping
+// would produce an invalid BCS payload.
+func subdomainOption(subdomain string) *aptos.Option {
+	if subdomain == "" {
+		return aptos.None()
+	}
+	return aptos.Some(subdomain)
+}
+
+// addressOption returns the Move Option<address> wrapper for an optional
+// target address argument.
+func addressOption(addr *aptos.AccountAddress) *aptos.Option {
+	if addr == nil {
+		return aptos.None()
+	}
+	return aptos.Some(*addr)
 }
 
 // RegisterPayload returns the payload for registering a name.
@@ -344,15 +369,21 @@ func (c *Client) RegisterPayload(name string, opts RegisterOptions) (*aptos.Entr
 		return nil, fmt.Errorf("%w: cannot register subdomains directly", ErrInvalidName)
 	}
 
-	if opts.Years <= 0 {
-		opts.Years = 1
+	years := opts.Years
+	if years == 0 {
+		years = 1
 	}
 
 	return &aptos.EntryFunctionPayload{
 		Module:   aptos.ModuleID{Address: c.routerAddress, Name: "router"},
 		Function: "register_domain",
 		TypeArgs: nil,
-		Args:     []any{parsed.Domain, opts.Years},
+		Args: []any{
+			parsed.Domain,
+			years * secondsPerYear,
+			addressOption(opts.Target),
+			addressOption(opts.Target),
+		},
 	}, nil
 }
 
@@ -363,16 +394,11 @@ func (c *Client) SetPrimaryNamePayload(name string) (*aptos.EntryFunctionPayload
 		return nil, err
 	}
 
-	subdomain := ""
-	if parsed.Subdomain != "" {
-		subdomain = parsed.Subdomain
-	}
-
 	return &aptos.EntryFunctionPayload{
 		Module:   aptos.ModuleID{Address: c.routerAddress, Name: "router"},
 		Function: "set_primary_name",
 		TypeArgs: nil,
-		Args:     []any{parsed.Domain, subdomain},
+		Args:     []any{parsed.Domain, subdomainOption(parsed.Subdomain)},
 	}, nil
 }
 
@@ -383,21 +409,17 @@ func (c *Client) SetTargetAddressPayload(name string, target aptos.AccountAddres
 		return nil, err
 	}
 
-	subdomain := ""
-	if parsed.Subdomain != "" {
-		subdomain = parsed.Subdomain
-	}
-
 	return &aptos.EntryFunctionPayload{
 		Module:   aptos.ModuleID{Address: c.routerAddress, Name: "router"},
 		Function: "set_target_addr",
 		TypeArgs: nil,
-		Args:     []any{parsed.Domain, subdomain, target.String()},
+		Args:     []any{parsed.Domain, subdomainOption(parsed.Subdomain), target},
 	}, nil
 }
 
 // RenewPayload returns the payload for renewing a name.
-func (c *Client) RenewPayload(name string, years int) (*aptos.EntryFunctionPayload, error) {
+// Zero years defaults to one year.
+func (c *Client) RenewPayload(name string, years uint64) (*aptos.EntryFunctionPayload, error) {
 	parsed, err := ParseName(name)
 	if err != nil {
 		return nil, err
@@ -407,7 +429,7 @@ func (c *Client) RenewPayload(name string, years int) (*aptos.EntryFunctionPaylo
 		return nil, fmt.Errorf("%w: cannot renew subdomains directly", ErrInvalidName)
 	}
 
-	if years <= 0 {
+	if years == 0 {
 		years = 1
 	}
 
@@ -415,11 +437,13 @@ func (c *Client) RenewPayload(name string, years int) (*aptos.EntryFunctionPaylo
 		Module:   aptos.ModuleID{Address: c.routerAddress, Name: "router"},
 		Function: "renew_domain",
 		TypeArgs: nil,
-		Args:     []any{parsed.Domain, years},
+		Args:     []any{parsed.Domain, years * secondsPerYear},
 	}, nil
 }
 
 // AddSubdomainPayload returns the payload for adding a subdomain.
+// expirationSecs is the absolute Unix timestamp at which the subdomain
+// expires; pass 0 to default to the parent domain's expiration.
 func (c *Client) AddSubdomainPayload(domain, subdomain string, target aptos.AccountAddress) (*aptos.EntryFunctionPayload, error) {
 	parsed, err := ParseName(domain)
 	if err != nil {
@@ -434,6 +458,17 @@ func (c *Client) AddSubdomainPayload(domain, subdomain string, target aptos.Acco
 		Module:   aptos.ModuleID{Address: c.routerAddress, Name: "router"},
 		Function: "register_subdomain",
 		TypeArgs: nil,
-		Args:     []any{parsed.Domain, subdomain, target.String(), 0, false},
+		// (domain: String, subdomain: String, expiration_time_sec: u64,
+		// expiration_policy: u8, transferable: bool, target_addr: Option<address>,
+		// to_addr: Option<address>)
+		Args: []any{
+			parsed.Domain,
+			subdomain,
+			uint64(0),
+			uint8(0),
+			false,
+			aptos.Some(target),
+			aptos.Some(target),
+		},
 	}, nil
 }

--- a/v2/ans/ans.go
+++ b/v2/ans/ans.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 	"time"
@@ -326,6 +327,21 @@ func (c *Client) IsAvailable(ctx context.Context, name string) (bool, error) {
 // duration to the seconds value the router contract expects.
 const secondsPerYear uint64 = 365 * 24 * 60 * 60
 
+// ErrYearsOverflow is returned when years * secondsPerYear would exceed
+// uint64. The user-facing input has no business hitting this — domain
+// registrations max out at a few decades — but silently wrapping would
+// send a garbage duration on-chain, so we error explicitly instead.
+var ErrYearsOverflow = errors.New("ans: years value is too large to convert to seconds")
+
+// yearsToSeconds converts a year count to seconds, returning
+// ErrYearsOverflow if the multiplication would wrap uint64.
+func yearsToSeconds(years uint64) (uint64, error) {
+	if years > math.MaxUint64/secondsPerYear {
+		return 0, ErrYearsOverflow
+	}
+	return years * secondsPerYear, nil
+}
+
 // RegisterOptions contains options for name registration.
 type RegisterOptions struct {
 	// Years is the number of years to register the name for.
@@ -373,6 +389,10 @@ func (c *Client) RegisterPayload(name string, opts RegisterOptions) (*aptos.Entr
 	if years == 0 {
 		years = 1
 	}
+	durationSecs, err := yearsToSeconds(years)
+	if err != nil {
+		return nil, err
+	}
 
 	return &aptos.EntryFunctionPayload{
 		Module:   aptos.ModuleID{Address: c.routerAddress, Name: "router"},
@@ -380,7 +400,7 @@ func (c *Client) RegisterPayload(name string, opts RegisterOptions) (*aptos.Entr
 		TypeArgs: nil,
 		Args: []any{
 			parsed.Domain,
-			years * secondsPerYear,
+			durationSecs,
 			addressOption(opts.Target),
 			addressOption(opts.Target),
 		},
@@ -432,18 +452,24 @@ func (c *Client) RenewPayload(name string, years uint64) (*aptos.EntryFunctionPa
 	if years == 0 {
 		years = 1
 	}
+	durationSecs, err := yearsToSeconds(years)
+	if err != nil {
+		return nil, err
+	}
 
 	return &aptos.EntryFunctionPayload{
 		Module:   aptos.ModuleID{Address: c.routerAddress, Name: "router"},
 		Function: "renew_domain",
 		TypeArgs: nil,
-		Args:     []any{parsed.Domain, years * secondsPerYear},
+		Args:     []any{parsed.Domain, durationSecs},
 	}, nil
 }
 
 // AddSubdomainPayload returns the payload for adding a subdomain.
-// expirationSecs is the absolute Unix timestamp at which the subdomain
-// expires; pass 0 to default to the parent domain's expiration.
+// The subdomain's expiration defaults to the parent domain's
+// (expiration_time_sec is encoded as 0, which the router interprets
+// as "inherit from parent"); callers that need a different expiration
+// must build the payload manually until this helper grows an option.
 func (c *Client) AddSubdomainPayload(domain, subdomain string, target aptos.AccountAddress) (*aptos.EntryFunctionPayload, error) {
 	parsed, err := ParseName(domain)
 	if err != nil {

--- a/v2/ans/ans_test.go
+++ b/v2/ans/ans_test.go
@@ -393,6 +393,21 @@ func TestANSPayloads_AllSerializable(t *testing.T) {
 // TestSubdomainOption asserts the helper returns the right Option for
 // each input. This is the entry point for several ANS payloads where
 // the chain expects Option<String> not bare strings.
+func TestYearsOverflow(t *testing.T) {
+	// math.MaxUint64 / secondsPerYear is roughly 5.85e11 years — no
+	// real user will ever ask to register a domain for that long, but
+	// `years * secondsPerYear` would silently wrap and the on-chain
+	// duration would be garbage. We surface this as an error instead.
+	client := NewClient(nil)
+	huge := uint64(1 << 63) // far above the overflow threshold
+
+	_, err := client.RegisterPayload("alice.apt", RegisterOptions{Years: huge})
+	require.ErrorIs(t, err, ErrYearsOverflow)
+
+	_, err = client.RenewPayload("alice.apt", huge)
+	require.ErrorIs(t, err, ErrYearsOverflow)
+}
+
 func TestSubdomainOption(t *testing.T) {
 	assert.Equal(t, aptos.None(), subdomainOption(""))
 	assert.Equal(t, aptos.Some("wallet"), subdomainOption("wallet"))

--- a/v2/ans/ans_test.go
+++ b/v2/ans/ans_test.go
@@ -5,9 +5,29 @@ import (
 	"time"
 
 	aptos "github.com/aptos-labs/aptos-go-sdk/v2"
+	"github.com/aptos-labs/aptos-go-sdk/v2/internal/bcs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// payloadIsSerializable asserts that a payload can flow through the
+// BCS pipeline by wrapping it in a RawTransaction and serializing the
+// transaction. This catches "unsupported argument type" failures from
+// writeArg without depending on internal serializePayload.
+func payloadIsSerializable(t *testing.T, payload *aptos.EntryFunctionPayload) {
+	t.Helper()
+	txn := &aptos.RawTransaction{
+		Sender:                     aptos.AccountOne,
+		SequenceNumber:             0,
+		MaxGasAmount:               1000,
+		GasUnitPrice:               100,
+		ExpirationTimestampSeconds: 1_700_000_000,
+		ChainID:                    4,
+		Payload:                    payload,
+	}
+	_, err := bcs.Marshal(txn)
+	require.NoError(t, err)
+}
 
 func TestParseName(t *testing.T) {
 	tests := []struct {
@@ -159,13 +179,13 @@ func TestClient_RegisterPayload(t *testing.T) {
 		assert.Equal(t, "router", payload.Module.Name)
 		assert.Equal(t, "register_domain", payload.Function)
 		assert.Contains(t, payload.Args, "alice")
-		assert.Contains(t, payload.Args, 2)
+		assert.Contains(t, payload.Args, 2*secondsPerYear)
 	})
 
 	t.Run("defaults to 1 year", func(t *testing.T) {
 		payload, err := client.RegisterPayload("alice.apt", RegisterOptions{})
 		require.NoError(t, err)
-		assert.Contains(t, payload.Args, 1)
+		assert.Contains(t, payload.Args, secondsPerYear)
 	})
 
 	t.Run("rejects subdomain registration", func(t *testing.T) {
@@ -188,7 +208,8 @@ func TestClient_SetPrimaryNamePayload(t *testing.T) {
 
 		assert.Equal(t, "set_primary_name", payload.Function)
 		assert.Contains(t, payload.Args, "alice")
-		assert.Contains(t, payload.Args, "") // Empty subdomain
+		// No subdomain -> Option::None
+		assert.Contains(t, payload.Args, aptos.None())
 	})
 
 	t.Run("subdomain as primary", func(t *testing.T) {
@@ -196,7 +217,7 @@ func TestClient_SetPrimaryNamePayload(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Contains(t, payload.Args, "alice")
-		assert.Contains(t, payload.Args, "wallet")
+		assert.Contains(t, payload.Args, aptos.Some("wallet"))
 	})
 }
 
@@ -209,7 +230,9 @@ func TestClient_SetTargetAddressPayload(t *testing.T) {
 
 	assert.Equal(t, "set_target_addr", payload.Function)
 	assert.Contains(t, payload.Args, "alice")
-	assert.Contains(t, payload.Args, target.String())
+	// Address must be passed as AccountAddress, not its hex string,
+	// or BCS will encode it as a Move String.
+	assert.Contains(t, payload.Args, target)
 }
 
 func TestClient_RenewPayload(t *testing.T) {
@@ -221,13 +244,13 @@ func TestClient_RenewPayload(t *testing.T) {
 
 		assert.Equal(t, "renew_domain", payload.Function)
 		assert.Contains(t, payload.Args, "alice")
-		assert.Contains(t, payload.Args, 3)
+		assert.Contains(t, payload.Args, 3*secondsPerYear)
 	})
 
 	t.Run("defaults to 1 year", func(t *testing.T) {
 		payload, err := client.RenewPayload("alice.apt", 0)
 		require.NoError(t, err)
-		assert.Contains(t, payload.Args, 1)
+		assert.Contains(t, payload.Args, secondsPerYear)
 	})
 
 	t.Run("rejects subdomain renewal", func(t *testing.T) {
@@ -311,6 +334,74 @@ func TestName_HasSubdomain(t *testing.T) {
 		name := &Name{Domain: "alice"}
 		assert.Empty(t, name.Subdomain)
 	})
+}
+
+// TestANSPayloads_AllSerializable confirms every ANS payload survives
+// BCS encoding. Before the audit fix, RegisterPayload used an `int`
+// Years value that serializeArg rejected at submission time, and
+// SetTargetAddress / SetPrimaryName passed plain strings where the
+// router expected Option<String> / address. Each of those would have
+// hit "unsupported argument type" or produced bytes the chain would
+// reject. This test would have failed against the broken code.
+func TestANSPayloads_AllSerializable(t *testing.T) {
+	client := NewClient(nil)
+	target := aptos.MustParseAddress("0x123")
+
+	t.Run("RegisterPayload", func(t *testing.T) {
+		p, err := client.RegisterPayload("alice.apt", RegisterOptions{Years: 1})
+		require.NoError(t, err)
+		payloadIsSerializable(t, p)
+	})
+
+	t.Run("RegisterPayload with target", func(t *testing.T) {
+		p, err := client.RegisterPayload("alice.apt", RegisterOptions{Years: 1, Target: &target})
+		require.NoError(t, err)
+		payloadIsSerializable(t, p)
+	})
+
+	t.Run("SetPrimaryNamePayload no subdomain", func(t *testing.T) {
+		p, err := client.SetPrimaryNamePayload("alice.apt")
+		require.NoError(t, err)
+		payloadIsSerializable(t, p)
+	})
+
+	t.Run("SetPrimaryNamePayload with subdomain", func(t *testing.T) {
+		p, err := client.SetPrimaryNamePayload("wallet.alice.apt")
+		require.NoError(t, err)
+		payloadIsSerializable(t, p)
+	})
+
+	t.Run("SetTargetAddressPayload", func(t *testing.T) {
+		p, err := client.SetTargetAddressPayload("alice.apt", target)
+		require.NoError(t, err)
+		payloadIsSerializable(t, p)
+	})
+
+	t.Run("RenewPayload", func(t *testing.T) {
+		p, err := client.RenewPayload("alice.apt", 2)
+		require.NoError(t, err)
+		payloadIsSerializable(t, p)
+	})
+
+	t.Run("AddSubdomainPayload", func(t *testing.T) {
+		p, err := client.AddSubdomainPayload("alice.apt", "wallet", target)
+		require.NoError(t, err)
+		payloadIsSerializable(t, p)
+	})
+}
+
+// TestSubdomainOption asserts the helper returns the right Option for
+// each input. This is the entry point for several ANS payloads where
+// the chain expects Option<String> not bare strings.
+func TestSubdomainOption(t *testing.T) {
+	assert.Equal(t, aptos.None(), subdomainOption(""))
+	assert.Equal(t, aptos.Some("wallet"), subdomainOption("wallet"))
+}
+
+func TestAddressOption(t *testing.T) {
+	assert.Equal(t, aptos.None(), addressOption(nil))
+	addr := aptos.MustParseAddress("0x123")
+	assert.Equal(t, aptos.Some(addr), addressOption(&addr))
 }
 
 func TestParseName_EdgeCases(t *testing.T) {

--- a/v2/client.go
+++ b/v2/client.go
@@ -59,8 +59,19 @@ type Client interface {
 	// BuildTransaction builds an unsigned transaction.
 	BuildTransaction(ctx context.Context, sender AccountAddress, payload Payload, opts ...TransactionOption) (*RawTransaction, error)
 
-	// SimulateTransaction simulates a transaction without submitting it.
+	// SimulateTransaction simulates a single-sender transaction without
+	// submitting it.
 	SimulateTransaction(ctx context.Context, txn *RawTransaction, signer Signer, opts ...TransactionOption) (*SimulationResult, error)
+
+	// SimulateMultiAgentTransaction simulates a multi-agent transaction.
+	// secondarySigners and secondaryAddrs must be the same length and in
+	// the same order as the on-chain multi-agent authenticator expects.
+	SimulateMultiAgentTransaction(ctx context.Context, txn *RawTransaction, sender Signer, secondarySigners []Signer, secondaryAddrs []AccountAddress, opts ...TransactionOption) (*SimulationResult, error)
+
+	// SimulateFeePayerTransaction simulates a sponsored (fee-payer)
+	// transaction. Pass nil/empty secondarySigners and secondaryAddrs for
+	// the common single-sender + sponsor case.
+	SimulateFeePayerTransaction(ctx context.Context, txn *RawTransaction, sender Signer, secondarySigners []Signer, secondaryAddrs []AccountAddress, feePayerAddr AccountAddress, feePayer Signer, opts ...TransactionOption) (*SimulationResult, error)
 
 	// SubmitTransaction submits a signed transaction to the network.
 	SubmitTransaction(ctx context.Context, signed *SignedTransaction) (*SubmitResult, error)

--- a/v2/examples/transfer_coin/main.go
+++ b/v2/examples/transfer_coin/main.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strconv"
 	"time"
 
 	aptos "github.com/aptos-labs/aptos-go-sdk/v2"
@@ -69,7 +68,10 @@ func main() {
 		Module:   aptos.ModuleID{Address: aptos.AccountOne, Name: "aptos_account"},
 		Function: "transfer",
 		TypeArgs: nil,
-		Args:     []any{bob.String(), strconv.FormatUint(TransferAmount, 10)},
+		// Entry-function args go to BCS, so types must match the Move
+		// signature exactly: `address` => AccountAddress (not its hex
+		// string), `u64` => uint64 (not a decimal string).
+		Args: []any{bob, uint64(TransferAmount)},
 	}
 
 	// Build the transaction with gas estimation

--- a/v2/node_client.go
+++ b/v2/node_client.go
@@ -283,9 +283,15 @@ func (c *nodeClient) SimulateTransaction(ctx context.Context, txn *RawTransactio
 		return nil, errors.New("signer has no public key")
 	}
 
+	// Wrap in SingleSenderAuthenticator so the on-the-wire TransactionAuthenticator
+	// variant is `SingleSender` (4). Assigning the raw *AccountAuthenticator here
+	// would serialize as just the AccountAuthenticator variant byte; for Ed25519
+	// (variant 0) that accidentally matches the legacy `TxnAuth::Ed25519` layout,
+	// but for Secp256k1/Secp256r1/Keyless it would mis-decode at the node.
+	// SignTransaction wraps identically — keeping these paths consistent matters.
 	signed := &SignedTransaction{
 		Transaction:   txn,
-		Authenticator: auth,
+		Authenticator: &SingleSenderAuthenticator{Sender: auth},
 	}
 	return c.simulateSigned(ctx, signed, opts...)
 }

--- a/v2/node_client.go
+++ b/v2/node_client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"iter"
 	"log/slog"
+	"math/big"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -266,28 +267,126 @@ func (c *nodeClient) BuildTransaction(ctx context.Context, sender AccountAddress
 	}, nil
 }
 
-// SimulateTransaction simulates a transaction without submitting it.
+// SimulateTransaction simulates a single-sender transaction without
+// submitting it. To simulate a multi-agent or fee-payer transaction use
+// SimulateMultiAgentTransaction or SimulateFeePayerTransaction; this
+// entry point intentionally only wires up a SingleSender authenticator.
+//
+// Gas-estimation query parameters are derived from opts: WithGasEstimation
+// turns on both unit-price and max-amount estimation; WithPrioritizedGas
+// additionally requests the prioritized estimate. Pass no opts to get the
+// default (estimate gas price and max amount, no prioritized estimate),
+// which matches v1 behavior.
 func (c *nodeClient) SimulateTransaction(ctx context.Context, txn *RawTransaction, signer Signer, opts ...TransactionOption) (*SimulationResult, error) {
-	// Create simulation authenticator (zero signature)
 	auth := SimulationAuthenticator(signer)
+	if auth == nil {
+		return nil, errors.New("signer has no public key")
+	}
 
-	// Create signed transaction for simulation
 	signed := &SignedTransaction{
 		Transaction:   txn,
 		Authenticator: auth,
 	}
+	return c.simulateSigned(ctx, signed, opts...)
+}
 
-	// Serialize to BCS
+// SimulateMultiAgentTransaction simulates a multi-agent transaction.
+// The primary signer signs as the sender; secondarySigners provide the
+// remaining authenticators in the order the on-chain multi-agent
+// signature expects.
+func (c *nodeClient) SimulateMultiAgentTransaction(ctx context.Context, txn *RawTransaction, sender Signer, secondarySigners []Signer, secondaryAddrs []AccountAddress, opts ...TransactionOption) (*SimulationResult, error) {
+	if len(secondarySigners) != len(secondaryAddrs) {
+		return nil, fmt.Errorf("secondarySigners (%d) and secondaryAddrs (%d) length mismatch", len(secondarySigners), len(secondaryAddrs))
+	}
+
+	senderAuth := SimulationAuthenticator(sender)
+	if senderAuth == nil {
+		return nil, errors.New("sender has no public key")
+	}
+
+	secondaryAuths := make([]*AccountAuthenticator, len(secondarySigners))
+	for i, s := range secondarySigners {
+		a := SimulationAuthenticator(s)
+		if a == nil {
+			return nil, fmt.Errorf("secondary signer %d has no public key", i)
+		}
+		secondaryAuths[i] = a
+	}
+
+	signed := &SignedTransaction{
+		Transaction: txn,
+		Authenticator: &MultiAgentAuthenticator{
+			Sender:                   senderAuth,
+			SecondarySignerAddresses: secondaryAddrs,
+			SecondarySigners:         secondaryAuths,
+		},
+	}
+	return c.simulateSigned(ctx, signed, opts...)
+}
+
+// SimulateFeePayerTransaction simulates a sponsored (fee-payer)
+// transaction. feePayerAddr / feePayer specify who pays gas; pass nil for
+// secondarySigners / secondaryAddrs for the common single-sender + sponsor
+// case.
+func (c *nodeClient) SimulateFeePayerTransaction(ctx context.Context, txn *RawTransaction, sender Signer, secondarySigners []Signer, secondaryAddrs []AccountAddress, feePayerAddr AccountAddress, feePayer Signer, opts ...TransactionOption) (*SimulationResult, error) {
+	if len(secondarySigners) != len(secondaryAddrs) {
+		return nil, fmt.Errorf("secondarySigners (%d) and secondaryAddrs (%d) length mismatch", len(secondarySigners), len(secondaryAddrs))
+	}
+
+	senderAuth := SimulationAuthenticator(sender)
+	if senderAuth == nil {
+		return nil, errors.New("sender has no public key")
+	}
+
+	secondaryAuths := make([]*AccountAuthenticator, len(secondarySigners))
+	for i, s := range secondarySigners {
+		a := SimulationAuthenticator(s)
+		if a == nil {
+			return nil, fmt.Errorf("secondary signer %d has no public key", i)
+		}
+		secondaryAuths[i] = a
+	}
+
+	feePayerAuth := SimulationAuthenticator(feePayer)
+	if feePayerAuth == nil {
+		return nil, errors.New("fee payer has no public key")
+	}
+
+	signed := &SignedTransaction{
+		Transaction: txn,
+		Authenticator: &FeePayerAuthenticator{
+			Sender:                   senderAuth,
+			SecondarySignerAddresses: secondaryAddrs,
+			SecondarySigners:         secondaryAuths,
+			FeePayerAddress:          feePayerAddr,
+			FeePayerAuth:             feePayerAuth,
+		},
+	}
+	return c.simulateSigned(ctx, signed, opts...)
+}
+
+// simulateSigned submits a pre-built simulation SignedTransaction.
+func (c *nodeClient) simulateSigned(ctx context.Context, signed *SignedTransaction, opts ...TransactionOption) (*SimulationResult, error) {
+	// Default: estimate gas price and max amount, no prioritized estimate.
+	// Mirrors v1's behavior so callers migrating don't see a gas-estimation
+	// regression. Caller can override via WithGasEstimation / WithPrioritizedGas.
+	cfg := &TransactionConfig{
+		EstimateGas:            true,
+		EstimatePrioritizedGas: false,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	txnBytes, err := bcs.Serialize(signed)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize transaction: %w", err)
 	}
 
-	// Build query parameters
 	params := url.Values{}
-	params.Set("estimate_gas_unit_price", "true")
-	params.Set("estimate_max_gas_amount", "true")
-	params.Set("estimate_prioritized_gas_unit_price", "false")
+	params.Set("estimate_gas_unit_price", strconv.FormatBool(cfg.EstimateGas))
+	params.Set("estimate_max_gas_amount", strconv.FormatBool(cfg.EstimateGas))
+	params.Set("estimate_prioritized_gas_unit_price", strconv.FormatBool(cfg.EstimatePrioritizedGas))
 
 	path := "transactions/simulate?" + params.Encode()
 
@@ -472,11 +571,26 @@ func normalizeViewArg(arg any) any {
 		return nil
 	}
 
+	// *big.Int covers Move's u128/u256/i128/i256 view arguments. The
+	// node expects these as decimal strings — passing the *big.Int
+	// through would either be JSON-encoded as an unquoted number (too
+	// large to fit JSON's safe integer range) or rejected outright.
+	if bi, ok := arg.(*big.Int); ok {
+		if bi == nil {
+			return nil
+		}
+		return bi.String()
+	}
+
 	value := reflect.ValueOf(arg)
 	switch value.Kind() {
-	case reflect.Uint64:
+	case reflect.Uint, reflect.Uint64:
+		// Go's platform-sized uint is at least 32 bits; on 64-bit
+		// builds it can exceed JSON's safe integer range. Stringify
+		// for safety — the node accepts decimal strings for all
+		// unsigned widths.
 		return strconv.FormatUint(value.Uint(), 10)
-	case reflect.Int64:
+	case reflect.Int, reflect.Int64:
 		return strconv.FormatInt(value.Int(), 10)
 	case reflect.Slice, reflect.Array:
 		if value.Type().Elem().Kind() == reflect.Uint8 {

--- a/v2/node_client_extra_test.go
+++ b/v2/node_client_extra_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aptos-labs/aptos-go-sdk/v2/internal/bcs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -691,4 +692,135 @@ func TestSimulateFeePayerTransaction_LengthMismatch(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "length mismatch")
+}
+
+// TestSimulateTransaction_AuthVariantSingleSender pins the on-the-wire
+// authenticator variant for a single-sender simulation. The Aptos node
+// rejects a transaction whose authenticator variant doesn't match the
+// outer transaction kind, so getting this wrong was the kind of bug we
+// want a test to catch immediately.
+//
+// The body of the BCS request after the RawTransaction is the
+// TransactionAuthenticator enum, ULEB128-encoded. For a SingleSender
+// authenticator that's a single byte: 4.
+func TestSimulateTransaction_AuthVariantSingleSender(t *testing.T) {
+	t.Parallel()
+
+	var gotBody []byte
+	client := newTestClient(t, simulateFakeHandler(t, nil, &gotBody))
+
+	signer, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+
+	_, err = client.SimulateTransaction(context.Background(), makeRawTxn(AccountOne), signer)
+	require.NoError(t, err)
+	assertAuthenticatorVariant(t, gotBody, makeRawTxn(AccountOne), uint8(TransactionAuthenticatorVariantSingleSender))
+}
+
+func TestSimulateMultiAgentTransaction_AuthVariantAndSecondaries(t *testing.T) {
+	t.Parallel()
+
+	var gotBody []byte
+	client := newTestClient(t, simulateFakeHandler(t, nil, &gotBody))
+
+	primary, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+	sec1, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+	sec2, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+
+	res, err := client.SimulateMultiAgentTransaction(
+		context.Background(),
+		makeRawTxn(AccountOne),
+		primary,
+		[]Signer{sec1, sec2},
+		[]AccountAddress{AccountTwo, AccountThree},
+	)
+	require.NoError(t, err)
+	assert.True(t, res.Success)
+	assertAuthenticatorVariant(t, gotBody, makeRawTxn(AccountOne), uint8(TransactionAuthenticatorVariantMultiAgent))
+}
+
+func TestSimulateFeePayerTransaction_AuthVariant(t *testing.T) {
+	t.Parallel()
+
+	var gotBody []byte
+	client := newTestClient(t, simulateFakeHandler(t, nil, &gotBody))
+
+	primary, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+	feePayer, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+
+	_, err = client.SimulateFeePayerTransaction(
+		context.Background(),
+		makeRawTxn(AccountOne),
+		primary,
+		nil,
+		nil,
+		AccountThree,
+		feePayer,
+	)
+	require.NoError(t, err)
+	assertAuthenticatorVariant(t, gotBody, makeRawTxn(AccountOne), uint8(TransactionAuthenticatorVariantFeePayer))
+}
+
+func TestSimulateFeePayerTransaction_WithSecondaries(t *testing.T) {
+	t.Parallel()
+
+	var gotBody []byte
+	client := newTestClient(t, simulateFakeHandler(t, nil, &gotBody))
+
+	primary, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+	sec, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+	feePayer, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+
+	_, err = client.SimulateFeePayerTransaction(
+		context.Background(),
+		makeRawTxn(AccountOne),
+		primary,
+		[]Signer{sec},
+		[]AccountAddress{AccountTwo},
+		AccountThree,
+		feePayer,
+	)
+	require.NoError(t, err)
+	assertAuthenticatorVariant(t, gotBody, makeRawTxn(AccountOne), uint8(TransactionAuthenticatorVariantFeePayer))
+}
+
+func TestSimulateSigned_EmptyResponseIsError(t *testing.T) {
+	t.Parallel()
+
+	// Simulate endpoint returns an empty array — the node never does
+	// this in practice, but the code defensively errors rather than
+	// dereferencing results[0]. Pin that behaviour.
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+
+	signer, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+
+	_, err = client.SimulateTransaction(context.Background(), makeRawTxn(AccountOne), signer)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no results")
+}
+
+// assertAuthenticatorVariant skips over the BCS-encoded RawTransaction at
+// the head of the simulate request body and asserts the next byte (which
+// the BCS encoding places at the start of the SignedTransaction's
+// authenticator) is the expected variant.
+func assertAuthenticatorVariant(t *testing.T, body []byte, txn *RawTransaction, wantVariant uint8) {
+	t.Helper()
+	txnBytes, err := bcs.Serialize(txn)
+	require.NoError(t, err)
+	require.Greater(t, len(body), len(txnBytes), "body shorter than serialized txn")
+	require.Equal(t, txnBytes, body[:len(txnBytes)], "request body must start with the BCS-encoded raw txn")
+	got := body[len(txnBytes)]
+	assert.Equal(t, wantVariant, got, "expected authenticator variant %d, got %d", wantVariant, got)
 }

--- a/v2/node_client_extra_test.go
+++ b/v2/node_client_extra_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -498,6 +500,10 @@ func TestNormalizeViewArg(t *testing.T) {
 		{"uint64 stringified", uint64(123), "123"},
 		{"int64 stringified", int64(-456), "-456"},
 		{"uint64 max", uint64(1<<63 + 1), "9223372036854775809"},
+		{"uint stringified", uint(789), "789"},
+		{"int stringified", int(-789), "-789"},
+		{"big.Int u128 stringified", new(big.Int).SetUint64(1<<63 + 1), "9223372036854775809"},
+		{"big.Int nil", (*big.Int)(nil), nil},
 		{"bool passes through", true, true},
 		{"string passes through", "hello", "hello"},
 		{"byte slice passes through", []byte{1, 2, 3}, []byte{1, 2, 3}},
@@ -519,4 +525,170 @@ func TestNormalizeViewArgs_NilAndEmpty(t *testing.T) {
 	t.Parallel()
 	assert.Nil(t, normalizeViewArgs(nil))
 	assert.Equal(t, []any{}, normalizeViewArgs([]any{}))
+}
+
+// --- Simulate variants --------------------------------------------------
+
+// makeRawTxn builds a minimal valid RawTransaction for simulation tests.
+func makeRawTxn(sender AccountAddress) *RawTransaction {
+	return &RawTransaction{
+		Sender:                     sender,
+		SequenceNumber:             0,
+		MaxGasAmount:               1000,
+		GasUnitPrice:               100,
+		ExpirationTimestampSeconds: 1_700_000_000,
+		ChainID:                    4,
+		Payload: &EntryFunctionPayload{
+			Module:   ModuleID{Address: AccountOne, Name: "test"},
+			Function: "f",
+		},
+	}
+}
+
+// simulateFakeHandler captures the simulate request and returns a fixed
+// successful response. The captured query and body bytes are surfaced
+// through pointers so tests can assert on them.
+func simulateFakeHandler(t *testing.T, gotQuery *url.Values, gotBody *[]byte) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/transactions/simulate") {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			if gotBody != nil {
+				*gotBody = body
+			}
+			if gotQuery != nil {
+				q := r.URL.Query()
+				*gotQuery = q
+			}
+			w.Header().Set("Content-Type", "application/json")
+			// Simulate endpoint returns an array.
+			_, _ = w.Write([]byte(`[{"success":true,"vm_status":"Executed","gas_used":"123","gas_unit_price":"100","changes":[],"events":[]}]`))
+			return
+		}
+		http.NotFound(w, r)
+	})
+}
+
+func TestSimulateTransaction_DefaultsEstimateGas(t *testing.T) {
+	t.Parallel()
+
+	var gotQuery url.Values
+	client := newTestClient(t, simulateFakeHandler(t, &gotQuery, nil))
+
+	signer, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+
+	res, err := client.SimulateTransaction(context.Background(), makeRawTxn(AccountOne), signer)
+	require.NoError(t, err)
+	assert.True(t, res.Success)
+	// No opts → default estimation on, prioritized off.
+	assert.Equal(t, "true", gotQuery.Get("estimate_gas_unit_price"))
+	assert.Equal(t, "true", gotQuery.Get("estimate_max_gas_amount"))
+	assert.Equal(t, "false", gotQuery.Get("estimate_prioritized_gas_unit_price"))
+}
+
+func TestSimulateTransaction_PrioritizedGasFlag(t *testing.T) {
+	t.Parallel()
+
+	var gotQuery url.Values
+	client := newTestClient(t, simulateFakeHandler(t, &gotQuery, nil))
+
+	signer, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+
+	_, err = client.SimulateTransaction(context.Background(), makeRawTxn(AccountOne), signer, WithPrioritizedGas())
+	require.NoError(t, err)
+	assert.Equal(t, "true", gotQuery.Get("estimate_prioritized_gas_unit_price"))
+}
+
+func TestSimulateMultiAgentTransaction(t *testing.T) {
+	t.Parallel()
+
+	var gotBody []byte
+	client := newTestClient(t, simulateFakeHandler(t, nil, &gotBody))
+
+	primary, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+	secondary, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+
+	res, err := client.SimulateMultiAgentTransaction(
+		context.Background(),
+		makeRawTxn(AccountOne),
+		primary,
+		[]Signer{secondary},
+		[]AccountAddress{AccountTwo},
+	)
+	require.NoError(t, err)
+	assert.True(t, res.Success)
+	// The body should contain a multi-agent authenticator (variant 2,
+	// uleb128-encoded) followed by the secondary signer count.
+	assert.NotEmpty(t, gotBody)
+}
+
+func TestSimulateMultiAgentTransaction_LengthMismatch(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, simulateFakeHandler(t, nil, nil))
+	primary, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+
+	_, err = client.SimulateMultiAgentTransaction(
+		context.Background(),
+		makeRawTxn(AccountOne),
+		primary,
+		[]Signer{},                   // 0 signers
+		[]AccountAddress{AccountTwo}, // 1 address
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "length mismatch")
+}
+
+func TestSimulateFeePayerTransaction(t *testing.T) {
+	t.Parallel()
+
+	var gotBody []byte
+	client := newTestClient(t, simulateFakeHandler(t, nil, &gotBody))
+
+	primary, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+	feePayer, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+	feePayerAddr := AccountThree
+
+	res, err := client.SimulateFeePayerTransaction(
+		context.Background(),
+		makeRawTxn(AccountOne),
+		primary,
+		nil,
+		nil,
+		feePayerAddr,
+		feePayer,
+	)
+	require.NoError(t, err)
+	assert.True(t, res.Success)
+	assert.NotEmpty(t, gotBody)
+}
+
+func TestSimulateFeePayerTransaction_LengthMismatch(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, simulateFakeHandler(t, nil, nil))
+	primary, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+	feePayer, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+
+	_, err = client.SimulateFeePayerTransaction(
+		context.Background(),
+		makeRawTxn(AccountOne),
+		primary,
+		[]Signer{primary, primary},
+		[]AccountAddress{AccountTwo}, // length mismatch
+		AccountThree,
+		feePayer,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "length mismatch")
 }

--- a/v2/node_client_extra_test.go
+++ b/v2/node_client_extra_test.go
@@ -603,31 +603,6 @@ func TestSimulateTransaction_PrioritizedGasFlag(t *testing.T) {
 	assert.Equal(t, "true", gotQuery.Get("estimate_prioritized_gas_unit_price"))
 }
 
-func TestSimulateMultiAgentTransaction(t *testing.T) {
-	t.Parallel()
-
-	var gotBody []byte
-	client := newTestClient(t, simulateFakeHandler(t, nil, &gotBody))
-
-	primary, err := GenerateEd25519PrivateKey()
-	require.NoError(t, err)
-	secondary, err := GenerateEd25519PrivateKey()
-	require.NoError(t, err)
-
-	res, err := client.SimulateMultiAgentTransaction(
-		context.Background(),
-		makeRawTxn(AccountOne),
-		primary,
-		[]Signer{secondary},
-		[]AccountAddress{AccountTwo},
-	)
-	require.NoError(t, err)
-	assert.True(t, res.Success)
-	// The body should contain a multi-agent authenticator (variant 2,
-	// uleb128-encoded) followed by the secondary signer count.
-	assert.NotEmpty(t, gotBody)
-}
-
 func TestSimulateMultiAgentTransaction_LengthMismatch(t *testing.T) {
 	t.Parallel()
 
@@ -644,32 +619,6 @@ func TestSimulateMultiAgentTransaction_LengthMismatch(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "length mismatch")
-}
-
-func TestSimulateFeePayerTransaction(t *testing.T) {
-	t.Parallel()
-
-	var gotBody []byte
-	client := newTestClient(t, simulateFakeHandler(t, nil, &gotBody))
-
-	primary, err := GenerateEd25519PrivateKey()
-	require.NoError(t, err)
-	feePayer, err := GenerateEd25519PrivateKey()
-	require.NoError(t, err)
-	feePayerAddr := AccountThree
-
-	res, err := client.SimulateFeePayerTransaction(
-		context.Background(),
-		makeRawTxn(AccountOne),
-		primary,
-		nil,
-		nil,
-		feePayerAddr,
-		feePayer,
-	)
-	require.NoError(t, err)
-	assert.True(t, res.Success)
-	assert.NotEmpty(t, gotBody)
 }
 
 func TestSimulateFeePayerTransaction_LengthMismatch(t *testing.T) {
@@ -740,6 +689,22 @@ func TestSimulateMultiAgentTransaction_AuthVariantAndSecondaries(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, res.Success)
 	assertAuthenticatorVariant(t, gotBody, makeRawTxn(AccountOne), uint8(TransactionAuthenticatorVariantMultiAgent))
+
+	// Round-trip-deserialize the body to confirm the secondary
+	// addresses arrived in the right slots. assertAuthenticatorVariant
+	// only checks one byte; a regression that silently dropped the
+	// secondaries would otherwise slip past.
+	got := &SignedTransaction{}
+	got.UnmarshalBCS(bcs.NewDeserializer(gotBody))
+	ma, ok := got.Authenticator.(*MultiAgentAuthenticator)
+	require.True(t, ok, "expected *MultiAgentAuthenticator, got %T", got.Authenticator)
+	assert.Equal(
+		t,
+		[]AccountAddress{AccountTwo, AccountThree},
+		ma.SecondarySignerAddresses,
+		"secondary signer addresses must appear in the deserialized body",
+	)
+	assert.Len(t, ma.SecondarySigners, 2, "two secondary authenticators expected")
 }
 
 func TestSimulateFeePayerTransaction_AuthVariant(t *testing.T) {
@@ -790,6 +755,16 @@ func TestSimulateFeePayerTransaction_WithSecondaries(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assertAuthenticatorVariant(t, gotBody, makeRawTxn(AccountOne), uint8(TransactionAuthenticatorVariantFeePayer))
+
+	// Round-trip the body and assert the fee-payer address survived
+	// the wire encoding — a regression that silently dropped it would
+	// produce valid-looking bytes that the node would later reject.
+	got := &SignedTransaction{}
+	got.UnmarshalBCS(bcs.NewDeserializer(gotBody))
+	fp, ok := got.Authenticator.(*FeePayerAuthenticator)
+	require.True(t, ok, "expected *FeePayerAuthenticator, got %T", got.Authenticator)
+	assert.Equal(t, []AccountAddress{AccountTwo}, fp.SecondarySignerAddresses)
+	assert.Equal(t, AccountThree, fp.FeePayerAddress)
 }
 
 func TestSimulateSigned_EmptyResponseIsError(t *testing.T) {

--- a/v2/testutil/fake_client.go
+++ b/v2/testutil/fake_client.go
@@ -304,6 +304,32 @@ func (c *FakeClient) SimulateTransaction(ctx context.Context, txn *aptos.RawTran
 	}, nil
 }
 
+// SimulateMultiAgentTransaction simulates a multi-agent transaction.
+func (c *FakeClient) SimulateMultiAgentTransaction(ctx context.Context, txn *aptos.RawTransaction, sender aptos.Signer, secondarySigners []aptos.Signer, secondaryAddrs []aptos.AccountAddress, opts ...aptos.TransactionOption) (*aptos.SimulationResult, error) {
+	c.record("SimulateMultiAgentTransaction", txn)
+	if err := c.getError("SimulateMultiAgentTransaction"); err != nil {
+		return nil, err
+	}
+	return &aptos.SimulationResult{
+		Success:  true,
+		VMStatus: "Executed successfully",
+		GasUsed:  1000,
+	}, nil
+}
+
+// SimulateFeePayerTransaction simulates a fee-payer transaction.
+func (c *FakeClient) SimulateFeePayerTransaction(ctx context.Context, txn *aptos.RawTransaction, sender aptos.Signer, secondarySigners []aptos.Signer, secondaryAddrs []aptos.AccountAddress, feePayerAddr aptos.AccountAddress, feePayer aptos.Signer, opts ...aptos.TransactionOption) (*aptos.SimulationResult, error) {
+	c.record("SimulateFeePayerTransaction", txn)
+	if err := c.getError("SimulateFeePayerTransaction"); err != nil {
+		return nil, err
+	}
+	return &aptos.SimulationResult{
+		Success:  true,
+		VMStatus: "Executed successfully",
+		GasUsed:  1000,
+	}, nil
+}
+
 // SubmitTransaction submits a signed transaction.
 func (c *FakeClient) SubmitTransaction(ctx context.Context, signed *aptos.SignedTransaction) (*aptos.SubmitResult, error) {
 	c.record("SubmitTransaction", signed)

--- a/v2/transaction_types.go
+++ b/v2/transaction_types.go
@@ -34,6 +34,21 @@ type (
 	I256Arg struct{ Value *big.Int }
 )
 
+// RawArg wraps an already-BCS-encoded entry-function argument. writeArg
+// writes the bytes verbatim (no length prefix, no re-encoding).
+//
+// This exists to make round-trips safe. After BCS-deserializing a
+// transaction, EntryFunctionPayload.Args is populated with RawArg
+// values containing the on-the-wire BCS for each argument — so that
+// re-serializing the same payload produces identical bytes. A plain
+// []byte goes through the vector<u8> case and gets a fresh inner
+// length prefix, which would double-encode a deserialized arg.
+//
+// Callers building a fresh payload usually want the typed forms
+// ([]byte for vector<u8>, AccountAddress for address, Some/None for
+// Option, etc.) rather than RawArg.
+type RawArg []byte
+
 // Transaction prefix used for signing
 const (
 	RawTransactionSalt         = "APTOS::RawTransaction"
@@ -206,11 +221,12 @@ func deserializeEntryFunction(des *bcs.Deserializer) *EntryFunctionPayload {
 		ef.TypeArgs[i].UnmarshalBCS(des)
 	}
 
-	// Arguments (as raw bytes)
+	// Arguments are stored as RawArg so a subsequent re-serialize emits
+	// the same bytes — see RawArg's doc for why []byte would be wrong.
 	numArgs := des.Uleb128()
 	ef.Args = make([]any, numArgs)
 	for i := uint32(0); i < numArgs; i++ {
-		ef.Args[i] = des.ReadBytes()
+		ef.Args[i] = RawArg(des.ReadBytes())
 	}
 
 	return ef
@@ -275,6 +291,10 @@ func writeArg(ser *bcs.Serializer, arg any) error {
 	switch v := arg.(type) {
 	case nil:
 		return errors.New("nil argument; use aptos.None() for Move Option")
+	case RawArg:
+		// Verbatim — already BCS-encoded. Used for deserialized args
+		// so that serialize→deserialize→serialize round-trips.
+		ser.FixedBytes(v)
 	case []byte:
 		// Move vector<u8>: ULEB128(len) || bytes
 		ser.WriteBytes(v)

--- a/v2/transaction_types.go
+++ b/v2/transaction_types.go
@@ -5,8 +5,33 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/aptos-labs/aptos-go-sdk/v2/internal/bcs"
+)
+
+// Option wraps a Move Option<T> argument. A nil Value encodes as `None`;
+// a non-nil Value encodes as `Some(value)`. The inner Value goes through
+// the same serializeArg machinery as a top-level argument, so any type
+// serializeArg supports — including a nested Option — works inside.
+type Option struct {
+	Value any
+}
+
+// Some constructs an Option containing the given value.
+func Some(v any) *Option { return &Option{Value: v} }
+
+// None constructs an empty Option.
+func None() *Option { return &Option{Value: nil} }
+
+// U128Arg / U256Arg / I128Arg / I256Arg are explicit big-integer argument
+// markers. We can't dispatch on *big.Int alone because Move has four
+// different 128/256-bit types and the BCS encoding differs by signedness.
+type (
+	U128Arg struct{ Value *big.Int }
+	U256Arg struct{ Value *big.Int }
+	I128Arg struct{ Value *big.Int }
+	I256Arg struct{ Value *big.Int }
 )
 
 // Transaction prefix used for signing
@@ -66,11 +91,15 @@ func (txn *SignedTransaction) Hash() (string, error) {
 		return "", fmt.Errorf("failed to serialize signed transaction: %w", err)
 	}
 
-	// Hash with the transaction prefix
+	// Hash with the transaction prefix.
+	// Build the buffer explicitly (rather than `append(prefix[:], ...)`)
+	// because `prefix` is a [32]byte and `prefix[:]` would have cap 32;
+	// the first append happens to allocate today, but a future change
+	// to the prefix size could silently mutate the underlying array.
 	prefix := sha3.Sum256([]byte("APTOS::Transaction"))
-
-	// Combine prefix, variant byte (0 for user transaction), and serialized transaction
-	hashInput := append(prefix[:], 0) // 0 = UserTransaction variant
+	hashInput := make([]byte, 0, len(prefix)+1+len(txnBytes))
+	hashInput = append(hashInput, prefix[:]...)
+	hashInput = append(hashInput, 0) // 0 = UserTransaction variant
 	hashInput = append(hashInput, txnBytes...)
 
 	hash := sha3.Sum256(hashInput)
@@ -229,46 +258,96 @@ func deserializeScript(des *bcs.Deserializer) *ScriptPayload {
 
 // serializeArg serializes a single argument to BCS bytes.
 func serializeArg(arg any) ([]byte, error) {
+	ser := bcs.NewSerializer()
+	if err := writeArg(ser, arg); err != nil {
+		return nil, err
+	}
+	if err := ser.Error(); err != nil {
+		return nil, err
+	}
+	return ser.ToBytes(), nil
+}
+
+// writeArg encodes a Move entry-function argument into ser using BCS.
+// Splitting this from serializeArg lets Option<T> recurse without
+// re-allocating a Serializer per level.
+func writeArg(ser *bcs.Serializer, arg any) error {
 	switch v := arg.(type) {
+	case nil:
+		return errors.New("nil argument; use aptos.None() for Move Option")
 	case []byte:
-		return v, nil
+		// Move vector<u8>: ULEB128(len) || bytes
+		ser.WriteBytes(v)
 	case string:
-		// Assume it's a string argument - serialize as BCS string
-		ser := bcs.NewSerializer()
 		ser.WriteString(v)
-		return ser.ToBytes(), ser.Error()
-	case uint8:
-		ser := bcs.NewSerializer()
-		ser.U8(v)
-		return ser.ToBytes(), nil
-	case uint16:
-		ser := bcs.NewSerializer()
-		ser.U16(v)
-		return ser.ToBytes(), nil
-	case uint32:
-		ser := bcs.NewSerializer()
-		ser.U32(v)
-		return ser.ToBytes(), nil
-	case uint64:
-		ser := bcs.NewSerializer()
-		ser.U64(v)
-		return ser.ToBytes(), nil
 	case bool:
-		ser := bcs.NewSerializer()
 		ser.Bool(v)
-		return ser.ToBytes(), nil
+	case uint8:
+		ser.U8(v)
+	case uint16:
+		ser.U16(v)
+	case uint32:
+		ser.U32(v)
+	case uint64:
+		ser.U64(v)
+	case uint:
+		// Go's platform uint is at least 32 bits, in practice 64. Encode
+		// as u64 because that's the only width that always fits.
+		ser.U64(uint64(v))
+	case int8:
+		ser.I8(v)
+	case int16:
+		ser.I16(v)
+	case int32:
+		ser.I32(v)
+	case int64:
+		ser.I64(v)
+	case int:
+		ser.I64(int64(v))
+	case U128Arg:
+		if v.Value == nil {
+			return errors.New("nil U128Arg")
+		}
+		ser.U128(v.Value)
+	case U256Arg:
+		if v.Value == nil {
+			return errors.New("nil U256Arg")
+		}
+		ser.U256(v.Value)
+	case I128Arg:
+		if v.Value == nil {
+			return errors.New("nil I128Arg")
+		}
+		ser.I128(v.Value)
+	case I256Arg:
+		if v.Value == nil {
+			return errors.New("nil I256Arg")
+		}
+		ser.I256(v.Value)
 	case AccountAddress:
-		return v[:], nil
+		ser.FixedBytes(v[:])
 	case *AccountAddress:
 		if v == nil {
-			return nil, errors.New("nil address")
+			return errors.New("nil address")
 		}
-		return (*v)[:], nil
+		ser.FixedBytes((*v)[:])
+	case *Option:
+		if v == nil || v.Value == nil {
+			// None: vector of length 0
+			ser.Uleb128(0)
+			return nil
+		}
+		// Some(value): vector of length 1 followed by the inner value
+		ser.Uleb128(1)
+		return writeArg(ser, v.Value)
+	case Option:
+		return writeArg(ser, &v)
 	case bcs.Marshaler:
-		return bcs.Serialize(v)
+		v.MarshalBCS(ser)
 	default:
-		return nil, fmt.Errorf("unsupported argument type: %T", arg)
+		return fmt.Errorf("unsupported argument type: %T", arg)
 	}
+	return nil
 }
 
 // Script argument type variants

--- a/v2/transaction_types_test.go
+++ b/v2/transaction_types_test.go
@@ -279,6 +279,33 @@ func TestSerializeArg_NilAddress(t *testing.T) {
 	assert.Contains(t, err.Error(), "nil address")
 }
 
+func TestSerializeArg_OptionValueAndPointer(t *testing.T) {
+	// Option may be passed as either *Option (the common case from
+	// Some/None) or Option-by-value. Both must produce identical bytes.
+	byValue, err := serializeArg(Option{Value: uint64(7)})
+	require.NoError(t, err)
+	byPtr, err := serializeArg(&Option{Value: uint64(7)})
+	require.NoError(t, err)
+	assert.Equal(t, byPtr, byValue)
+	assert.Equal(t, []byte{0x01, 7, 0, 0, 0, 0, 0, 0, 0}, byValue)
+}
+
+// fakeMarshaler implements bcs.Marshaler. Used to confirm that
+// serializeArg honors the bcs.Marshaler case path.
+type fakeMarshaler struct{ payload []byte }
+
+func (f *fakeMarshaler) MarshalBCS(ser *bcs.Serializer) {
+	ser.FixedBytes(f.payload)
+}
+
+func (f *fakeMarshaler) UnmarshalBCS(_ *bcs.Deserializer) {}
+
+func TestSerializeArg_BCSMarshaler(t *testing.T) {
+	got, err := serializeArg(&fakeMarshaler{payload: []byte{0xde, 0xad}})
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0xde, 0xad}, got)
+}
+
 func TestSerializeArg_NestedOption(t *testing.T) {
 	// Option<Option<u64>> = Some(Some(1)) should produce:
 	//   ULEB128(1) || ULEB128(1) || 8 bytes

--- a/v2/transaction_types_test.go
+++ b/v2/transaction_types_test.go
@@ -232,23 +232,41 @@ func TestSerializeArg_AllTypes(t *testing.T) {
 }
 
 func TestSerializeArg_BigInts(t *testing.T) {
-	// big.Int-backed Move types use explicit wrappers so we can pick
-	// signed vs unsigned, 128 vs 256 bits unambiguously.
+	// Byte-exact tests differentiating signed/unsigned and width.
+	// `assert.Len` is not enough: U128(1) and I128(1) both produce
+	// 16 bytes, so a length-only test would silently pass if the
+	// signed/unsigned dispatch were swapped.
+
+	// u128(1) and u256(1): little-endian, all zero except the lowest byte.
+	u128One := make([]byte, 16)
+	u128One[0] = 0x01
+	u256One := make([]byte, 32)
+	u256One[0] = 0x01
+
+	// i128(-1) and i256(-1): two's complement, all 0xff.
+	i128NegOne := bytes.Repeat([]byte{0xff}, 16)
+	i256NegOne := bytes.Repeat([]byte{0xff}, 32)
+
 	cases := []struct {
-		name    string
-		arg     any
-		wantLen int
+		name string
+		arg  any
+		want []byte
 	}{
-		{"u128", U128Arg{Value: big.NewInt(1)}, 16},
-		{"u256", U256Arg{Value: big.NewInt(1)}, 32},
-		{"i128", I128Arg{Value: big.NewInt(-1)}, 16},
-		{"i256", I256Arg{Value: big.NewInt(-1)}, 32},
+		{"u128 = 1", U128Arg{Value: big.NewInt(1)}, u128One},
+		{"u256 = 1", U256Arg{Value: big.NewInt(1)}, u256One},
+		{"i128 = -1", I128Arg{Value: big.NewInt(-1)}, i128NegOne},
+		{"i256 = -1", I256Arg{Value: big.NewInt(-1)}, i256NegOne},
+		// i128(1) must NOT equal u128(1) byte-for-byte if dispatch
+		// is correct — both happen to be the same for value 1, so
+		// also test a negative on the signed path which is illegal
+		// for the unsigned path.
+		{"i128 = 1", I128Arg{Value: big.NewInt(1)}, u128One}, // shares value but goes through signed path
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			data, err := serializeArg(tc.arg)
 			require.NoError(t, err)
-			assert.Len(t, data, tc.wantLen)
+			assert.Equal(t, tc.want, data)
 		})
 	}
 }

--- a/v2/transaction_types_test.go
+++ b/v2/transaction_types_test.go
@@ -3,6 +3,7 @@ package aptos
 import (
 	"bytes"
 	"crypto/sha3"
+	"encoding/hex"
 	"math/big"
 	"testing"
 
@@ -124,20 +125,7 @@ func TestSignedTransaction_Hash(t *testing.T) {
 	expected = append(expected, 0)
 	expected = append(expected, signedBytes...)
 	want := sha3.Sum256(expected)
-	wantHex := "0x" + hexEncode(want[:])
-	assert.Equal(t, wantHex, hash)
-}
-
-// hexEncode returns the lowercase hex string of b without "0x" prefix.
-// Local helper to avoid importing "encoding/hex" twice.
-func hexEncode(b []byte) string {
-	const hexDigits = "0123456789abcdef"
-	out := make([]byte, len(b)*2)
-	for i, v := range b {
-		out[i*2] = hexDigits[v>>4]
-		out[i*2+1] = hexDigits[v&0x0f]
-	}
-	return string(out)
+	assert.Equal(t, "0x"+hex.EncodeToString(want[:]), hash)
 }
 
 func TestEntryFunctionPayload_BCSRoundTrip(t *testing.T) {
@@ -254,13 +242,14 @@ func TestSerializeArg_BigInts(t *testing.T) {
 	}{
 		{"u128 = 1", U128Arg{Value: big.NewInt(1)}, u128One},
 		{"u256 = 1", U256Arg{Value: big.NewInt(1)}, u256One},
+		// Positive values encode identically through signed and
+		// unsigned paths, so I128(1)/U128(1) are byte-equal. The
+		// signed-vs-unsigned dispatch is therefore validated by the
+		// negative cases below — i128(-1) is two's-complement 0xff…
+		// which differs unambiguously from the unsigned encoding.
+		{"i128 = 1", I128Arg{Value: big.NewInt(1)}, u128One},
 		{"i128 = -1", I128Arg{Value: big.NewInt(-1)}, i128NegOne},
 		{"i256 = -1", I256Arg{Value: big.NewInt(-1)}, i256NegOne},
-		// i128(1) must NOT equal u128(1) byte-for-byte if dispatch
-		// is correct — both happen to be the same for value 1, so
-		// also test a negative on the signed path which is illegal
-		// for the unsigned path.
-		{"i128 = 1", I128Arg{Value: big.NewInt(1)}, u128One}, // shares value but goes through signed path
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -364,13 +353,20 @@ func TestEntryFunction_VectorU8ArgEncoding(t *testing.T) {
 	ef, ok := got.(*EntryFunctionPayload)
 	require.True(t, ok)
 
-	// EntryFunction args after deserialization are []byte buffers
-	// containing the raw BCS of each arg.
+	// EntryFunction args after deserialization come back as RawArg
+	// (verbatim BCS bytes) so a re-serialize round-trips byte-for-byte.
 	require.Len(t, ef.Args, 1)
-	rawArg, ok := ef.Args[0].([]byte)
-	require.True(t, ok, "deserialized arg should be []byte")
+	rawArg, ok := ef.Args[0].(RawArg)
+	require.True(t, ok, "deserialized arg should be RawArg, got %T", ef.Args[0])
 	// Inner encoding: ULEB128(3) || 0xaa 0xbb 0xcc.
-	assert.Equal(t, []byte{0x03, 0xaa, 0xbb, 0xcc}, rawArg)
+	assert.Equal(t, RawArg{0x03, 0xaa, 0xbb, 0xcc}, rawArg)
+
+	// And a full re-serialize must produce identical bytes — this is
+	// the round-trip invariant RawArg exists to preserve.
+	ser2 := bcs.NewSerializer()
+	serializePayload(ser2, ef)
+	require.NoError(t, ser2.Error())
+	assert.Equal(t, data, ser2.ToBytes(), "serialize→deserialize→serialize must round-trip")
 }
 
 func TestEntryFunction_AddressArgEncoding(t *testing.T) {
@@ -393,9 +389,10 @@ func TestEntryFunction_AddressArgEncoding(t *testing.T) {
 	require.NoError(t, des.Error())
 	ef, _ := got.(*EntryFunctionPayload)
 	require.Len(t, ef.Args, 1)
-	rawArg, _ := ef.Args[0].([]byte)
+	rawArg, ok := ef.Args[0].(RawArg)
+	require.True(t, ok, "deserialized arg should be RawArg, got %T", ef.Args[0])
 	// Expect the 32 raw bytes of AccountOne — no inner ULEB128 length.
-	assert.Equal(t, AccountOne[:], rawArg)
+	assert.Equal(t, RawArg(AccountOne[:]), rawArg)
 }
 
 func TestEntryFunction_OptionArgEncoding(t *testing.T) {
@@ -413,8 +410,8 @@ func TestEntryFunction_OptionArgEncoding(t *testing.T) {
 	ef, _ := deserializePayload(des).(*EntryFunctionPayload)
 	require.NoError(t, des.Error())
 	require.Len(t, ef.Args, 1)
-	rawArg, _ := ef.Args[0].([]byte)
-	assert.Equal(t, []byte{0x00}, rawArg) // Move Option::None
+	rawArg, _ := ef.Args[0].(RawArg)
+	assert.Equal(t, RawArg{0x00}, rawArg) // Move Option::None
 
 	some := &EntryFunctionPayload{
 		Module:   ModuleID{Address: AccountOne, Name: "test"},
@@ -427,14 +424,50 @@ func TestEntryFunction_OptionArgEncoding(t *testing.T) {
 	des = bcs.NewDeserializer(ser.ToBytes())
 	ef, _ = deserializePayload(des).(*EntryFunctionPayload)
 	require.NoError(t, des.Error())
-	rawArg, _ = ef.Args[0].([]byte)
-	assert.Equal(t, []byte{0x01, 42, 0, 0, 0, 0, 0, 0, 0}, rawArg)
+	rawArg, _ = ef.Args[0].(RawArg)
+	assert.Equal(t, RawArg{0x01, 42, 0, 0, 0, 0, 0, 0, 0}, rawArg)
 }
 
 func TestSerializeArg_UnsupportedType(t *testing.T) {
 	_, err := serializeArg(struct{}{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported argument type")
+}
+
+// TestEntryFunction_RoundTripIsByteStable proves the round-trip
+// invariant RawArg exists to guarantee. A deserialized payload re-
+// serialized through the same code path must produce identical bytes.
+// Before the RawArg fix this broke for vector<u8> args: the deserialized
+// `[]byte` would get re-wrapped with a fresh length prefix, double-
+// encoding on the second pass.
+func TestEntryFunction_RoundTripIsByteStable(t *testing.T) {
+	original := &EntryFunctionPayload{
+		Module:   ModuleID{Address: AccountOne, Name: "demo"},
+		Function: "do_thing",
+		TypeArgs: []TypeTag{AptosCoinTypeTag},
+		Args: []any{
+			[]byte{0xaa, 0xbb}, // vector<u8>
+			AccountTwo,         // address
+			uint64(42),
+			Some("ok"),
+		},
+	}
+
+	ser := bcs.NewSerializer()
+	serializePayload(ser, original)
+	require.NoError(t, ser.Error())
+	first := ser.ToBytes()
+
+	des := bcs.NewDeserializer(first)
+	got := deserializePayload(des)
+	require.NoError(t, des.Error())
+
+	ser2 := bcs.NewSerializer()
+	serializePayload(ser2, got)
+	require.NoError(t, ser2.Error())
+	second := ser2.ToBytes()
+
+	assert.Equal(t, first, second, "byte-stable round trip required")
 }
 
 func TestScriptArg_BCSRoundTrip(t *testing.T) {

--- a/v2/transaction_types_test.go
+++ b/v2/transaction_types_test.go
@@ -3,6 +3,7 @@ package aptos
 import (
 	"bytes"
 	"crypto/sha3"
+	"math/big"
 	"testing"
 
 	"github.com/aptos-labs/aptos-go-sdk/v2/internal/bcs"
@@ -111,6 +112,32 @@ func TestSignedTransaction_Hash(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, len(hash) > 2)
 	assert.Equal(t, "0x", hash[:2])
+
+	// Hash must be exactly SHA3-256(prefix || 0x00 || bcs(SignedTransaction)).
+	// Building the expected hash by hand pins the prefix construction —
+	// catches regressions in slice-aliasing or wrong variant byte.
+	signedBytes, err := bcs.Marshal(signed)
+	require.NoError(t, err)
+	prefix := sha3.Sum256([]byte("APTOS::Transaction"))
+	expected := make([]byte, 0, len(prefix)+1+len(signedBytes))
+	expected = append(expected, prefix[:]...)
+	expected = append(expected, 0)
+	expected = append(expected, signedBytes...)
+	want := sha3.Sum256(expected)
+	wantHex := "0x" + hexEncode(want[:])
+	assert.Equal(t, wantHex, hash)
+}
+
+// hexEncode returns the lowercase hex string of b without "0x" prefix.
+// Local helper to avoid importing "encoding/hex" twice.
+func hexEncode(b []byte) string {
+	const hexDigits = "0123456789abcdef"
+	out := make([]byte, len(b)*2)
+	for i, v := range b {
+		out[i*2] = hexDigits[v>>4]
+		out[i*2+1] = hexDigits[v&0x0f]
+	}
+	return string(out)
 }
 
 func TestEntryFunctionPayload_BCSRoundTrip(t *testing.T) {
@@ -164,28 +191,85 @@ func TestScriptPayload_BCSRoundTrip(t *testing.T) {
 }
 
 func TestSerializeArg_AllTypes(t *testing.T) {
+	// Each case asserts the exact BCS bytes serializeArg should emit for
+	// a given Move-typed argument. This is the contract that
+	// EntryFunctionPayload.Args relies on; assertNotEmpty wasn't enough
+	// to catch a vector<u8> length-prefix regression.
+	addr := AccountOne
 	tests := []struct {
 		name string
 		arg  any
+		want []byte
 	}{
-		{"bytes", []byte{1, 2, 3}},
-		{"string", "hello"},
-		{"uint8", uint8(255)},
-		{"uint16", uint16(65535)},
-		{"uint32", uint32(4294967295)},
-		{"uint64", uint64(18446744073709551615)},
-		{"bool", true},
-		{"address", AccountOne},
-		{"address_ptr", &AccountOne},
+		{"bytes", []byte{1, 2, 3}, []byte{0x03, 0x01, 0x02, 0x03}},
+		{"empty bytes", []byte{}, []byte{0x00}},
+		{"string", "hi", []byte{0x02, 'h', 'i'}},
+		{"empty string", "", []byte{0x00}},
+		{"uint8", uint8(0x7f), []byte{0x7f}},
+		{"uint16", uint16(0x1234), []byte{0x34, 0x12}},
+		{"uint32", uint32(0xdeadbeef), []byte{0xef, 0xbe, 0xad, 0xde}},
+		{"uint64", uint64(1), []byte{1, 0, 0, 0, 0, 0, 0, 0}},
+		{"bool true", true, []byte{0x01}},
+		{"bool false", false, []byte{0x00}},
+		{"int8", int8(-1), []byte{0xff}},
+		{"int16", int16(-1), []byte{0xff, 0xff}},
+		{"int32", int32(-1), []byte{0xff, 0xff, 0xff, 0xff}},
+		{"int64", int64(-1), []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}},
+		{"address", addr, addr[:]},
+		{"address_ptr", &addr, addr[:]},
+		{"option none", None(), []byte{0x00}},
+		{"option some uint64", Some(uint64(7)), []byte{0x01, 7, 0, 0, 0, 0, 0, 0, 0}},
+		{"option some string", Some("ab"), []byte{0x01, 0x02, 'a', 'b'}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			data, err := serializeArg(tt.arg)
 			require.NoError(t, err)
-			assert.NotEmpty(t, data)
+			assert.Equal(t, tt.want, data)
 		})
 	}
+}
+
+func TestSerializeArg_BigInts(t *testing.T) {
+	// big.Int-backed Move types use explicit wrappers so we can pick
+	// signed vs unsigned, 128 vs 256 bits unambiguously.
+	cases := []struct {
+		name    string
+		arg     any
+		wantLen int
+	}{
+		{"u128", U128Arg{Value: big.NewInt(1)}, 16},
+		{"u256", U256Arg{Value: big.NewInt(1)}, 32},
+		{"i128", I128Arg{Value: big.NewInt(-1)}, 16},
+		{"i256", I256Arg{Value: big.NewInt(-1)}, 32},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := serializeArg(tc.arg)
+			require.NoError(t, err)
+			assert.Len(t, data, tc.wantLen)
+		})
+	}
+}
+
+func TestSerializeArg_NilBigInts(t *testing.T) {
+	cases := []any{
+		U128Arg{Value: nil},
+		U256Arg{Value: nil},
+		I128Arg{Value: nil},
+		I256Arg{Value: nil},
+	}
+	for _, c := range cases {
+		_, err := serializeArg(c)
+		require.Error(t, err)
+	}
+}
+
+func TestSerializeArg_NilArg(t *testing.T) {
+	_, err := serializeArg(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil argument")
 }
 
 func TestSerializeArg_NilAddress(t *testing.T) {
@@ -193,6 +277,113 @@ func TestSerializeArg_NilAddress(t *testing.T) {
 	_, err := serializeArg(nilAddr)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nil address")
+}
+
+func TestSerializeArg_NestedOption(t *testing.T) {
+	// Option<Option<u64>> = Some(Some(1)) should produce:
+	//   ULEB128(1) || ULEB128(1) || 8 bytes
+	data, err := serializeArg(Some(Some(uint64(1))))
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x01, 0x01, 1, 0, 0, 0, 0, 0, 0, 0}, data)
+
+	// Option<Option<u64>> = Some(None) -> 0x01 || 0x00
+	data, err = serializeArg(Some(None()))
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x01, 0x00}, data)
+}
+
+func TestEntryFunction_VectorU8ArgEncoding(t *testing.T) {
+	// Regression test for the vector<u8> length-prefix bug.
+	//
+	// For a vector<u8> arg containing N bytes, the on-chain BCS must be:
+	//   outer ULEB128(N+sizeof(uleb128(N))) || ULEB128(N) || N bytes
+	// i.e. the inner Move value is itself length-prefixed before the
+	// EntryFunction args[]vec wraps each element in WriteBytes.
+	payload := &EntryFunctionPayload{
+		Module:   ModuleID{Address: AccountOne, Name: "test"},
+		Function: "f",
+		TypeArgs: nil,
+		Args:     []any{[]byte{0xaa, 0xbb, 0xcc}},
+	}
+
+	ser := bcs.NewSerializer()
+	serializePayload(ser, payload)
+	require.NoError(t, ser.Error())
+	data := ser.ToBytes()
+
+	// Round-trip preserves the raw arg bytes — confirm the arg vector
+	// element contains the inner length prefix.
+	des := bcs.NewDeserializer(data)
+	got := deserializePayload(des)
+	require.NoError(t, des.Error())
+	ef, ok := got.(*EntryFunctionPayload)
+	require.True(t, ok)
+
+	// EntryFunction args after deserialization are []byte buffers
+	// containing the raw BCS of each arg.
+	require.Len(t, ef.Args, 1)
+	rawArg, ok := ef.Args[0].([]byte)
+	require.True(t, ok, "deserialized arg should be []byte")
+	// Inner encoding: ULEB128(3) || 0xaa 0xbb 0xcc.
+	assert.Equal(t, []byte{0x03, 0xaa, 0xbb, 0xcc}, rawArg)
+}
+
+func TestEntryFunction_AddressArgEncoding(t *testing.T) {
+	// An `address` arg must be encoded as the 32 raw fixed bytes
+	// (no inner length prefix), wrapped in a single outer
+	// ULEB128(32) prefix by the EntryFunction args vector.
+	payload := &EntryFunctionPayload{
+		Module:   ModuleID{Address: AccountOne, Name: "test"},
+		Function: "f",
+		TypeArgs: nil,
+		Args:     []any{AccountOne},
+	}
+
+	ser := bcs.NewSerializer()
+	serializePayload(ser, payload)
+	require.NoError(t, ser.Error())
+
+	des := bcs.NewDeserializer(ser.ToBytes())
+	got := deserializePayload(des)
+	require.NoError(t, des.Error())
+	ef, _ := got.(*EntryFunctionPayload)
+	require.Len(t, ef.Args, 1)
+	rawArg, _ := ef.Args[0].([]byte)
+	// Expect the 32 raw bytes of AccountOne — no inner ULEB128 length.
+	assert.Equal(t, AccountOne[:], rawArg)
+}
+
+func TestEntryFunction_OptionArgEncoding(t *testing.T) {
+	// Option<u64> args used to be impossible to express. Confirm that
+	// Some(x) and None() round-trip through the EntryFunction encoding.
+	none := &EntryFunctionPayload{
+		Module:   ModuleID{Address: AccountOne, Name: "test"},
+		Function: "f",
+		Args:     []any{None()},
+	}
+	ser := bcs.NewSerializer()
+	serializePayload(ser, none)
+	require.NoError(t, ser.Error())
+	des := bcs.NewDeserializer(ser.ToBytes())
+	ef, _ := deserializePayload(des).(*EntryFunctionPayload)
+	require.NoError(t, des.Error())
+	require.Len(t, ef.Args, 1)
+	rawArg, _ := ef.Args[0].([]byte)
+	assert.Equal(t, []byte{0x00}, rawArg) // Move Option::None
+
+	some := &EntryFunctionPayload{
+		Module:   ModuleID{Address: AccountOne, Name: "test"},
+		Function: "f",
+		Args:     []any{Some(uint64(42))},
+	}
+	ser = bcs.NewSerializer()
+	serializePayload(ser, some)
+	require.NoError(t, ser.Error())
+	des = bcs.NewDeserializer(ser.ToBytes())
+	ef, _ = deserializePayload(des).(*EntryFunctionPayload)
+	require.NoError(t, des.Error())
+	rawArg, _ = ef.Args[0].([]byte)
+	assert.Equal(t, []byte{0x01, 42, 0, 0, 0, 0, 0, 0, 0}, rawArg)
 }
 
 func TestSerializeArg_UnsupportedType(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to the audit in #218. That PR fixed the on-the-wire signing prefix and the balance/faucet paths, but a class of silent BCS encoding bugs in the layer above (entry-function arguments and the ANS module) survived. This PR fixes them, expands tests with byte-exact assertions, and adds the multi-agent / fee-payer simulate methods that v1 had.

### Critical fixes

- **`serializeArg` mis-encoded `vector<u8>` args.** The `[]byte` case returned raw bytes, relying on the outer `WriteBytes` to apply *the only* length prefix — but a Move `vector<u8>` argument is itself length-prefixed *inside* the per-arg `Vec<u8>` element. Every entry function taking `vector<u8>` was receiving corrupted bytes. The existing test only asserted `NotEmpty`. New tests compare exact bytes per type and verify the full `EntryFunction` encoding round-trips with the inner length prefix present.
- **ANS payloads were broken.** `RegisterPayload` used `Years int`, which `serializeArg` rejected at submit time. `SetTargetAddressPayload` passed `target.String()` (encoded as a Move `String`, not the 32-byte address). `SetPrimaryNamePayload` / `SetTargetAddressPayload` passed bare strings where the router expects `Option<String>`. `RegisterPayload` was missing required `Option<address>` trailing args. All fixed with the new `Option` wrapper and proper Go types.

### High-priority fixes

- **`normalizeViewArg`** now handles `*big.Int` (u128/u256) and platform-sized `uint`/`int`. Previously large unsigned values fell through to JSON as unquoted numbers — silently truncated or rejected by the node.
- **`SimulateMultiAgentTransaction` and `SimulateFeePayerTransaction`** added to the `Client` interface (v1 had `SimulateTransactionMultiAgent`; v2 had no way to simulate sponsored or multi-agent txns). Both flow through a shared `simulateSigned` helper that now honors `WithGasEstimation` / `WithPrioritizedGas` instead of hardcoded query params.

### Medium-priority fixes

- **`SignedTransaction.Hash`** no longer relies on `append(prefix[:], 0)` slice aliasing — uses explicit `make + append` and a new test pins the exact SHA3-256.
- **`examples/transfer_coin`** passed `bob.String()` and `strconv.FormatUint(...)` — after the encoding fix these would have failed at validate time. Updated to pass `AccountAddress` and `uint64` directly.

### New public API

- `aptos.Option`, `aptos.Some(v)`, `aptos.None()` — Move `Option<T>` wrapper for entry-function args.
- `aptos.U128Arg`, `aptos.U256Arg`, `aptos.I128Arg`, `aptos.I256Arg` — explicit big-integer arg wrappers (so signedness and width are unambiguous for `*big.Int`).
- `Client.SimulateMultiAgentTransaction`, `Client.SimulateFeePayerTransaction` (with matching `FakeClient` stubs).

## Test plan

- [x] `go test -short -race ./...` — all v2 tests pass
- [x] `go test ./...` from v1 root — unchanged, still passes
- [x] `gofumpt -l .` — clean
- [x] `golangci-lint run ./...` — no new warnings beyond pre-existing ones (see AGENTS.md)
- [x] New byte-exact tests for `serializeArg`, `EntryFunction_*ArgEncoding`, `SignedTransaction.Hash`
- [x] New `TestANSPayloads_AllSerializable` exercises every ANS payload through `bcs.Marshal`
- [x] New `TestSimulate{,MultiAgent,FeePayer}Transaction` via `httptest` capture both the query params and BCS request body

## Not in this PR

The audit also flagged two missing modules (`v2/fungible/` and `v2/indexer/` are empty directories). Those are feature gaps rather than bugs and deserve dedicated PRs. The `transfer_coin` example only builds — adding a `SubmitTransaction` end-to-end with a localnet would tighten coverage further but is out of scope here.