### PR TITLE
fix(v2): make advertised SDK functionality actually work

### DIFF
--- a/v2/account/account.go
+++ b/v2/account/account.go
@@ -240,21 +240,29 @@ func FromAIP80(aip80Key string) (*Account, error) {
 	}
 }
 
+// aip80Exporter is implemented by private key types that can serialize
+// themselves to an AIP-80 formatted string (e.g. Ed25519PrivateKey,
+// Secp256k1PrivateKey).
+type aip80Exporter interface {
+	ToAIP80() (string, error)
+}
+
 // ToAIP80 returns the account's private key as an AIP-80 formatted string.
-// Returns an error if the underlying key type doesn't support AIP-80 format.
+// Returns an error if the underlying key type doesn't support AIP-80 format
+// (for example, keyless or multi-key signers that have no single private key).
 func (a *Account) ToAIP80() (string, error) {
-	// Handle Ed25519 directly
-	if ed25519Key, ok := a.signer.(*crypto.Ed25519PrivateKey); ok {
-		return ed25519Key.ToAIP80()
+	// Private keys used directly as the signer (e.g. legacy Ed25519).
+	if exporter, ok := a.signer.(aip80Exporter); ok {
+		return exporter.ToAIP80()
 	}
 
-	// Handle Secp256k1 directly (wrapped in SingleSigner)
-	// SingleSigner's inner field is private, so we need to check if the
-	// signer produces a Secp256k1 public key
-
-	// For now, we need to type assert or use a different approach
-	// The cleanest solution is to add a method to extract the private key
-	// but that requires changes to internal/crypto
+	// Keys wrapped in a SingleSigner (e.g. Secp256k1, or Ed25519 created via
+	// NewEd25519SingleKey). Unwrap to reach the underlying private key.
+	if single, ok := a.signer.(*crypto.SingleSigner); ok {
+		if exporter, ok := single.Inner().(aip80Exporter); ok {
+			return exporter.ToAIP80()
+		}
+	}
 
 	return "", errors.New("signer does not support AIP-80 format export")
 }

--- a/v2/account/account_test.go
+++ b/v2/account/account_test.go
@@ -2,6 +2,7 @@ package account
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/aptos-labs/aptos-go-sdk/v2/internal/crypto"
@@ -417,17 +418,21 @@ func TestAccountToAIP80(t *testing.T) {
 	}
 }
 
-func TestSecp256k1ToAIP80_NotSupported(t *testing.T) {
+func TestSecp256k1ToAIP80_Supported(t *testing.T) {
 	t.Parallel()
 	acc, err := NewSecp256k1()
 	if err != nil {
 		t.Fatalf("NewSecp256k1() error = %v", err)
 	}
 
-	// Secp256k1 wrapped in SingleSigner doesn't support ToAIP80
-	_, err = acc.ToAIP80()
-	if err == nil {
-		t.Error("Expected error for SingleSigner ToAIP80")
+	// Secp256k1 wrapped in SingleSigner now exports correctly by unwrapping
+	// the inner private key.
+	aip80Key, err := acc.ToAIP80()
+	if err != nil {
+		t.Fatalf("ToAIP80() error = %v", err)
+	}
+	if !strings.HasPrefix(aip80Key, "secp256k1-priv-") {
+		t.Errorf("expected secp256k1-priv- prefix, got %q", aip80Key)
 	}
 }
 
@@ -557,6 +562,66 @@ func TestFromAIP80_Secp256k1(t *testing.T) {
 	}
 	if !auth.Verify(msg) {
 		t.Error("Signature from AIP-80 Secp256k1 account should verify")
+	}
+}
+
+func TestToAIP80_Secp256k1RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// Secp256k1 accounts wrap the key in a SingleSigner. ToAIP80 must unwrap
+	// it rather than failing (which was the previous behavior).
+	original, err := NewSecp256k1()
+	if err != nil {
+		t.Fatalf("NewSecp256k1() error = %v", err)
+	}
+
+	aip80Key, err := original.ToAIP80()
+	if err != nil {
+		t.Fatalf("ToAIP80() error = %v", err)
+	}
+	if !strings.HasPrefix(aip80Key, "secp256k1-priv-") {
+		t.Errorf("expected secp256k1-priv- prefix, got %q", aip80Key)
+	}
+
+	acc, err := FromAIP80(aip80Key)
+	if err != nil {
+		t.Fatalf("FromAIP80() error = %v", err)
+	}
+	if !bytes.Equal(original.AuthKey()[:], acc.AuthKey()[:]) {
+		t.Error("AuthKey mismatch after ToAIP80/FromAIP80 round trip")
+	}
+}
+
+func TestToAIP80_Ed25519SingleKeyRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// Ed25519 created via the SingleKey scheme is also wrapped in a
+	// SingleSigner and must export correctly.
+	original, err := NewEd25519SingleKey()
+	if err != nil {
+		t.Fatalf("NewEd25519SingleKey() error = %v", err)
+	}
+
+	aip80Key, err := original.ToAIP80()
+	if err != nil {
+		t.Fatalf("ToAIP80() error = %v", err)
+	}
+	if !strings.HasPrefix(aip80Key, "ed25519-priv-") {
+		t.Errorf("expected ed25519-priv- prefix, got %q", aip80Key)
+	}
+
+	acc, err := FromAIP80(aip80Key)
+	if err != nil {
+		t.Fatalf("FromAIP80() error = %v", err)
+	}
+	// FromAIP80 reconstructs an Ed25519 account using the legacy scheme, so
+	// the auth keys differ; the underlying private key bytes are what matter.
+	reExported, err := acc.ToAIP80()
+	if err != nil {
+		t.Fatalf("ToAIP80() (reconstructed) error = %v", err)
+	}
+	if reExported != aip80Key {
+		t.Errorf("private key changed across round trip: %q != %q", reExported, aip80Key)
 	}
 }
 

--- a/v2/ans/client_test.go
+++ b/v2/ans/client_test.go
@@ -1,0 +1,254 @@
+package ans
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	aptos "github.com/aptos-labs/aptos-go-sdk/v2"
+	"github.com/aptos-labs/aptos-go-sdk/v2/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// optionSome builds the decoded JSON shape the node returns for a populated
+// Move Option<T>: {"vec": [value]}.
+func optionSome(value any) map[string]any {
+	return map[string]any{"vec": []any{value}}
+}
+
+// optionNone builds the decoded JSON shape for an empty Move Option<T>.
+func optionNone() map[string]any {
+	return map[string]any{"vec": []any{}}
+}
+
+func futureUnixString() string {
+	return strconv.FormatInt(time.Now().Add(365*24*time.Hour).Unix(), 10)
+}
+
+func TestClient_Resolve_Success(t *testing.T) {
+	t.Parallel()
+	addr := aptos.AccountFour
+	fake := testutil.NewFakeClient().
+		WithViewResult("get_target_addr", []any{optionSome(addr.String())}).
+		WithViewResult("get_expiration", []any{futureUnixString()})
+
+	c := NewClient(fake)
+	got, err := c.Resolve(context.Background(), "alice.apt")
+	require.NoError(t, err)
+	assert.Equal(t, addr, got)
+}
+
+func TestClient_Resolve_Expired(t *testing.T) {
+	t.Parallel()
+	past := strconv.FormatInt(time.Now().Add(-time.Hour).Unix(), 10)
+	fake := testutil.NewFakeClient().
+		WithViewResult("get_target_addr", []any{optionSome(aptos.AccountFour.String())}).
+		WithViewResult("get_expiration", []any{past})
+
+	c := NewClient(fake)
+	_, err := c.Resolve(context.Background(), "alice.apt")
+	require.ErrorIs(t, err, ErrNameExpired)
+}
+
+func TestClient_Resolve_InvalidName(t *testing.T) {
+	t.Parallel()
+	c := NewClient(testutil.NewFakeClient())
+	_, err := c.Resolve(context.Background(), "")
+	require.Error(t, err)
+}
+
+func TestClient_GetNameInfo_NotFound_EmptyOption(t *testing.T) {
+	t.Parallel()
+	fake := testutil.NewFakeClient().
+		WithViewResult("get_target_addr", []any{optionNone()})
+
+	c := NewClient(fake)
+	_, err := c.GetNameInfo(context.Background(), Name{Domain: "bob"})
+	require.ErrorIs(t, err, ErrNameNotFound)
+}
+
+func TestClient_GetNameInfo_NotFound_EmptyResult(t *testing.T) {
+	t.Parallel()
+	fake := testutil.NewFakeClient().
+		WithViewResult("get_target_addr", []any{})
+
+	c := NewClient(fake)
+	_, err := c.GetNameInfo(context.Background(), Name{Domain: "bob"})
+	require.ErrorIs(t, err, ErrNameNotFound)
+}
+
+func TestClient_GetNameInfo_ViewNotFoundError(t *testing.T) {
+	t.Parallel()
+	fake := testutil.NewFakeClient().WithError("View", aptos.ErrNotFound)
+
+	c := NewClient(fake)
+	_, err := c.GetNameInfo(context.Background(), Name{Domain: "bob"})
+	require.ErrorIs(t, err, ErrNameNotFound)
+}
+
+func TestClient_GetNameInfo_ViewGenericError(t *testing.T) {
+	t.Parallel()
+	fake := testutil.NewFakeClient().WithError("View", errors.New("network boom"))
+
+	c := NewClient(fake)
+	_, err := c.GetNameInfo(context.Background(), Name{Domain: "bob"})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNameNotFound)
+}
+
+func TestClient_GetNameInfo_UnexpectedFormat(t *testing.T) {
+	t.Parallel()
+	fake := testutil.NewFakeClient().
+		WithViewResult("get_target_addr", []any{"not-an-option-object"})
+
+	c := NewClient(fake)
+	_, err := c.GetNameInfo(context.Background(), Name{Domain: "bob"})
+	require.Error(t, err)
+}
+
+func TestClient_GetNameInfo_ExpirationFallback(t *testing.T) {
+	t.Parallel()
+	// get_target_addr resolves, but get_expiration returns an empty result.
+	// GetNameInfo must fall back to a far-future expiration rather than fail.
+	fake := testutil.NewFakeClient().
+		WithViewResult("get_target_addr", []any{optionSome(aptos.AccountFour.String())}).
+		WithViewResult("get_expiration", []any{})
+
+	c := NewClient(fake)
+	info, err := c.GetNameInfo(context.Background(), Name{Domain: "alice"})
+	require.NoError(t, err)
+	assert.Equal(t, aptos.AccountFour, info.Target)
+	assert.False(t, info.IsExpired())
+}
+
+func TestClient_GetNameInfo_InvalidTargetAddress(t *testing.T) {
+	t.Parallel()
+	fake := testutil.NewFakeClient().
+		WithViewResult("get_target_addr", []any{optionSome("not-a-hex-address")})
+
+	c := NewClient(fake)
+	_, err := c.GetNameInfo(context.Background(), Name{Domain: "alice"})
+	require.Error(t, err)
+}
+
+func TestClient_GetPrimaryName_DomainOnly(t *testing.T) {
+	t.Parallel()
+	fake := testutil.NewFakeClient().
+		WithViewResult("get_primary_name", []any{
+			optionSome("alice"),
+			optionNone(),
+		})
+
+	c := NewClient(fake)
+	name, err := c.GetPrimaryName(context.Background(), aptos.AccountFour)
+	require.NoError(t, err)
+	assert.Equal(t, "alice.apt", name)
+}
+
+func TestClient_GetPrimaryName_WithSubdomain(t *testing.T) {
+	t.Parallel()
+	fake := testutil.NewFakeClient().
+		WithViewResult("get_primary_name", []any{
+			optionSome("alice"),
+			optionSome("wallet"),
+		})
+
+	c := NewClient(fake)
+	name, err := c.GetPrimaryName(context.Background(), aptos.AccountFour)
+	require.NoError(t, err)
+	assert.Equal(t, "wallet.alice.apt", name)
+}
+
+func TestClient_GetPrimaryName_NotFound(t *testing.T) {
+	t.Parallel()
+	fake := testutil.NewFakeClient().
+		WithViewResult("get_primary_name", []any{
+			optionNone(),
+			optionNone(),
+		})
+
+	c := NewClient(fake)
+	_, err := c.GetPrimaryName(context.Background(), aptos.AccountFour)
+	require.ErrorIs(t, err, ErrNameNotFound)
+}
+
+func TestClient_GetPrimaryName_ShortResult(t *testing.T) {
+	t.Parallel()
+	fake := testutil.NewFakeClient().
+		WithViewResult("get_primary_name", []any{optionSome("alice")})
+
+	c := NewClient(fake)
+	_, err := c.GetPrimaryName(context.Background(), aptos.AccountFour)
+	require.ErrorIs(t, err, ErrNameNotFound)
+}
+
+func TestClient_GetPrimaryName_ViewError(t *testing.T) {
+	t.Parallel()
+	fake := testutil.NewFakeClient().WithError("View", errors.New("boom"))
+
+	c := NewClient(fake)
+	_, err := c.GetPrimaryName(context.Background(), aptos.AccountFour)
+	require.Error(t, err)
+}
+
+func TestClient_IsAvailable_True(t *testing.T) {
+	t.Parallel()
+	fake := testutil.NewFakeClient().
+		WithViewResult("get_target_addr", []any{optionNone()})
+
+	c := NewClient(fake)
+	available, err := c.IsAvailable(context.Background(), "free.apt")
+	require.NoError(t, err)
+	assert.True(t, available)
+}
+
+func TestClient_IsAvailable_False(t *testing.T) {
+	t.Parallel()
+	fake := testutil.NewFakeClient().
+		WithViewResult("get_target_addr", []any{optionSome(aptos.AccountFour.String())}).
+		WithViewResult("get_expiration", []any{futureUnixString()})
+
+	c := NewClient(fake)
+	available, err := c.IsAvailable(context.Background(), "taken.apt")
+	require.NoError(t, err)
+	assert.False(t, available)
+}
+
+func TestClient_IsAvailable_InvalidName(t *testing.T) {
+	t.Parallel()
+	c := NewClient(testutil.NewFakeClient())
+	_, err := c.IsAvailable(context.Background(), "")
+	require.Error(t, err)
+}
+
+func TestClient_IsAvailable_PropagatesError(t *testing.T) {
+	t.Parallel()
+	fake := testutil.NewFakeClient().WithError("View", errors.New("boom"))
+
+	c := NewClient(fake)
+	_, err := c.IsAvailable(context.Background(), "x.apt")
+	require.Error(t, err)
+}
+
+func TestClient_GetNameInfo_ViewFuncRouting(t *testing.T) {
+	t.Parallel()
+	// Exercise WithViewFunc: route by function name dynamically.
+	fake := testutil.NewFakeClient().WithViewFunc(func(p *aptos.ViewPayload) ([]any, error) {
+		switch p.Function {
+		case "get_target_addr":
+			return []any{optionSome(aptos.AccountFour.String())}, nil
+		case "get_expiration":
+			return []any{futureUnixString()}, nil
+		default:
+			return nil, errors.New("unexpected function: " + p.Function)
+		}
+	})
+
+	c := NewClient(fake)
+	info, err := c.GetNameInfo(context.Background(), Name{Domain: "alice"})
+	require.NoError(t, err)
+	assert.Equal(t, aptos.AccountFour, info.Target)
+}

--- a/v2/internal/crypto/single_key.go
+++ b/v2/internal/crypto/single_key.go
@@ -38,6 +38,13 @@ func NewSingleSigner(signer MessageSigner) *SingleSigner {
 	return &SingleSigner{inner: signer}
 }
 
+// Inner returns the underlying MessageSigner wrapped by this SingleSigner.
+// This is useful for accessing key-type-specific behavior such as AIP-80
+// export that is not exposed through the Signer interface.
+func (s *SingleSigner) Inner() MessageSigner {
+	return s.inner
+}
+
 // Sign signs a message and returns an AccountAuthenticator.
 //
 // Implements [Signer].

--- a/v2/node_client.go
+++ b/v2/node_client.go
@@ -50,6 +50,11 @@ func newNodeClient(config *ClientConfig) (*nodeClient, error) {
 		logger = slog.Default()
 	}
 
+	// Apply retry / rate-limit handling middleware when configured. This is a
+	// no-op wrapper (returns httpClient unchanged) when neither WithRetry,
+	// WithRetryConfig, nor WithRateLimitHandling were supplied.
+	httpClient = newRetryHTTPClient(httpClient, config.retryConfig, config.rateLimitConfig, logger)
+
 	return &nodeClient{
 		config:     config,
 		httpClient: httpClient,

--- a/v2/retry.go
+++ b/v2/retry.go
@@ -48,38 +48,88 @@ func newRetryHTTPClient(inner HTTPDoer, retry *RetryConfig, rateLimit *RateLimit
 	}
 }
 
-// maxAttempts returns the total number of attempts (including the first) the
-// client will make.
-//
-// An explicit retry config with MaxRetries == 0 means "no error/status
-// retries" and is honored as such (it does not silently inherit the
-// rate-limit default). When rate-limit handling is enabled we still allow a
-// bounded number of attempts so 429 responses can be retried even if
-// error/status retries are disabled.
-func (c *retryHTTPClient) maxAttempts() int {
-	attempts := 1
+// rateLimitMaxRetries bounds how many times a 429 response is retried when
+// rate-limit handling is enabled, so a misbehaving server can't make us loop
+// forever. Overall waiting is additionally bounded by MaxWaitTime per attempt
+// and by the request context.
+const rateLimitMaxRetries = 5
+
+// errorStatusCap is the strict maximum number of retries for network errors
+// and retryable status codes. It is exactly MaxRetries (0 when retries are
+// disabled or no retry config is set) and is never inflated by enabling
+// rate-limit handling.
+func (c *retryHTTPClient) errorStatusCap() int {
 	if c.retry != nil && c.retry.MaxRetries > 0 {
-		attempts = c.retry.MaxRetries + 1
+		return c.retry.MaxRetries
 	}
-	// Rate-limit handling needs to retry 429s even when error/status retries
-	// are disabled (retry config absent or MaxRetries == 0). Use a sensible
-	// bounded default so a misbehaving server can't make us loop forever;
-	// overall waiting is additionally bounded by MaxWaitTime per attempt and
-	// by the request context.
-	if c.rateLimit != nil && c.rateLimit.Enabled && c.rateLimit.WaitOnLimit {
-		const rateLimitAttempts = 6
-		if rateLimitAttempts > attempts {
-			attempts = rateLimitAttempts
-		}
+	return 0
+}
+
+// rateLimitCap is the maximum number of 429 rate-limit retries.
+func (c *retryHTTPClient) rateLimitCap() int {
+	if c.rateLimitActive() {
+		return rateLimitMaxRetries
 	}
-	return attempts
+	return 0
+}
+
+// rateLimitActive reports whether 429 Retry-After handling is enabled.
+func (c *retryHTTPClient) rateLimitActive() bool {
+	return c.rateLimit != nil && c.rateLimit.Enabled && c.rateLimit.WaitOnLimit
 }
 
 // retriesEnabled reports whether network-error and retryable-status-code
 // retries are active. A retry config with MaxRetries == 0 explicitly disables
 // them (only 429 rate-limit handling, if enabled, remains active).
 func (c *retryHTTPClient) retriesEnabled() bool {
-	return c.retry != nil && c.retry.MaxRetries > 0
+	return c.errorStatusCap() > 0
+}
+
+// maxAttempts returns the total number of attempts (including the first) the
+// client will make. Error/status retries and 429 retries are capped
+// independently, so the worst case is one initial attempt plus both caps.
+// This keeps MaxRetries a strict cap on error/status retries even when
+// rate-limit handling reserves additional attempts for 429s.
+func (c *retryHTTPClient) maxAttempts() int {
+	return 1 + c.errorStatusCap() + c.rateLimitCap()
+}
+
+// retryReason classifies why (or whether) a response/error warrants a retry.
+type retryReason int
+
+const (
+	retryNone retryReason = iota
+	retryErrorStatus
+	retryRateLimit
+)
+
+// classifyRetry determines the retry category for a response/error and, for
+// rate-limited responses, the Retry-After wait. The two categories are tracked
+// against separate caps by Do.
+func (c *retryHTTPClient) classifyRetry(resp *http.Response, err error) (retryReason, time.Duration) {
+	// Network/transport errors are retried only when error/status retries are
+	// enabled (an explicit MaxRetries == 0 disables them).
+	if err != nil {
+		if c.retriesEnabled() {
+			return retryErrorStatus, 0
+		}
+		return retryNone, 0
+	}
+	if resp == nil {
+		return retryNone, 0
+	}
+
+	// Rate-limit handling: honor Retry-After (capped) on 429. This stays
+	// active even when error/status retries are disabled.
+	if resp.StatusCode == http.StatusTooManyRequests && c.rateLimitActive() {
+		return retryRateLimit, c.retryAfter(resp)
+	}
+
+	if c.retriesEnabled() && c.isRetriableStatus(resp.StatusCode) {
+		return retryErrorStatus, 0
+	}
+
+	return retryNone, 0
 }
 
 // Do executes the request, retrying transient failures per the configuration.
@@ -90,6 +140,10 @@ func (c *retryHTTPClient) Do(ctx context.Context, req *http.Request) (*http.Resp
 	// cancellation/timeouts propagate even for a custom HTTPDoer that reads
 	// req.Context() instead of the explicit ctx argument.
 	req = req.WithContext(ctx)
+
+	errorStatusCap := c.errorStatusCap()
+	rateLimitCap := c.rateLimitCap()
+	var errorStatusRetries, rateLimitRetries int
 
 	var resp *http.Response
 	var err error
@@ -107,13 +161,26 @@ func (c *retryHTTPClient) Do(ctx context.Context, req *http.Request) (*http.Resp
 
 		resp, err = c.inner.Do(ctx, req)
 
-		// Last attempt: return whatever we got.
-		if attempt == attempts-1 {
-			return resp, err
-		}
+		reason, wait := c.classifyRetry(resp, err)
 
-		retry, wait := c.shouldRetry(resp, err)
-		if !retry {
+		// Each retry category is capped independently. MaxRetries is a strict
+		// cap on error/status retries and is not raised by enabling rate-limit
+		// handling; 429s have their own bounded budget.
+		proceed := false
+		switch reason {
+		case retryErrorStatus:
+			if errorStatusRetries < errorStatusCap {
+				errorStatusRetries++
+				proceed = true
+			}
+		case retryRateLimit:
+			if rateLimitRetries < rateLimitCap {
+				rateLimitRetries++
+				proceed = true
+			}
+		case retryNone:
+		}
+		if !proceed {
 			return resp, err
 		}
 
@@ -124,14 +191,15 @@ func (c *retryHTTPClient) Do(ctx context.Context, req *http.Request) (*http.Resp
 			_ = resp.Body.Close()
 		}
 
-		backoff := c.backoff(attempt + 1)
+		retryNum := errorStatusRetries + rateLimitRetries
+		backoff := c.backoff(retryNum)
 		if wait > backoff {
 			backoff = wait
 		}
 
 		c.logger.Debug(
 			"retrying request",
-			"attempt", attempt+1,
+			"attempt", retryNum,
 			"max_attempts", attempts,
 			"backoff", backoff,
 			"url", req.URL.String(),
@@ -150,31 +218,6 @@ func (c *retryHTTPClient) Do(ctx context.Context, req *http.Request) (*http.Resp
 	}
 
 	return resp, err
-}
-
-// shouldRetry reports whether another attempt should be made and, for
-// rate-limited responses, how long to wait based on the Retry-After header.
-func (c *retryHTTPClient) shouldRetry(resp *http.Response, err error) (bool, time.Duration) {
-	// Network/transport errors are retried only when error/status retries are
-	// enabled (an explicit MaxRetries == 0 disables them).
-	if err != nil {
-		return c.retriesEnabled(), 0
-	}
-	if resp == nil {
-		return false, 0
-	}
-
-	// Rate-limit handling: honor Retry-After (capped) on 429. This stays
-	// active even when error/status retries are disabled.
-	if resp.StatusCode == http.StatusTooManyRequests && c.rateLimit != nil && c.rateLimit.Enabled && c.rateLimit.WaitOnLimit {
-		return true, c.retryAfter(resp)
-	}
-
-	if c.retriesEnabled() && c.isRetriableStatus(resp.StatusCode) {
-		return true, 0
-	}
-
-	return false, 0
 }
 
 // retryAfter parses the Retry-After header (seconds form) and caps it at

--- a/v2/retry.go
+++ b/v2/retry.go
@@ -46,18 +46,36 @@ func newRetryHTTPClient(inner HTTPDoer, retry *RetryConfig, rateLimit *RateLimit
 
 // maxAttempts returns the total number of attempts (including the first) the
 // client will make.
+//
+// An explicit retry config with MaxRetries == 0 means "no error/status
+// retries" and is honored as such (it does not silently inherit the
+// rate-limit default). When rate-limit handling is enabled we still allow a
+// bounded number of attempts so 429 responses can be retried even if
+// error/status retries are disabled.
 func (c *retryHTTPClient) maxAttempts() int {
+	attempts := 1
 	if c.retry != nil && c.retry.MaxRetries > 0 {
-		return c.retry.MaxRetries + 1
+		attempts = c.retry.MaxRetries + 1
 	}
-	// Rate-limit handling without an explicit retry config still needs to
-	// retry 429s. Use a sensible bounded default so a misbehaving server
-	// can't make us loop forever; overall waiting is additionally bounded
-	// by MaxWaitTime per attempt and by the request context.
-	if c.rateLimit != nil && c.rateLimit.Enabled {
-		return 6
+	// Rate-limit handling needs to retry 429s even when error/status retries
+	// are disabled (retry config absent or MaxRetries == 0). Use a sensible
+	// bounded default so a misbehaving server can't make us loop forever;
+	// overall waiting is additionally bounded by MaxWaitTime per attempt and
+	// by the request context.
+	if c.rateLimit != nil && c.rateLimit.Enabled && c.rateLimit.WaitOnLimit {
+		const rateLimitAttempts = 6
+		if rateLimitAttempts > attempts {
+			attempts = rateLimitAttempts
+		}
 	}
-	return 1
+	return attempts
+}
+
+// retriesEnabled reports whether network-error and retryable-status-code
+// retries are active. A retry config with MaxRetries == 0 explicitly disables
+// them (only 429 rate-limit handling, if enabled, remains active).
+func (c *retryHTTPClient) retriesEnabled() bool {
+	return c.retry != nil && c.retry.MaxRetries > 0
 }
 
 // Do executes the request, retrying transient failures per the configuration.
@@ -123,20 +141,22 @@ func (c *retryHTTPClient) Do(ctx context.Context, req *http.Request) (*http.Resp
 // shouldRetry reports whether another attempt should be made and, for
 // rate-limited responses, how long to wait based on the Retry-After header.
 func (c *retryHTTPClient) shouldRetry(resp *http.Response, err error) (bool, time.Duration) {
-	// Network/transport errors are retried only when retry is configured.
+	// Network/transport errors are retried only when error/status retries are
+	// enabled (an explicit MaxRetries == 0 disables them).
 	if err != nil {
-		return c.retry != nil, 0
+		return c.retriesEnabled(), 0
 	}
 	if resp == nil {
 		return false, 0
 	}
 
-	// Rate-limit handling: honor Retry-After (capped) on 429.
+	// Rate-limit handling: honor Retry-After (capped) on 429. This stays
+	// active even when error/status retries are disabled.
 	if resp.StatusCode == http.StatusTooManyRequests && c.rateLimit != nil && c.rateLimit.Enabled && c.rateLimit.WaitOnLimit {
 		return true, c.retryAfter(resp)
 	}
 
-	if c.retry != nil && c.isRetriableStatus(resp.StatusCode) {
+	if c.retriesEnabled() && c.isRetriableStatus(resp.StatusCode) {
 		return true, 0
 	}
 

--- a/v2/retry.go
+++ b/v2/retry.go
@@ -137,10 +137,15 @@ func (c *retryHTTPClient) Do(ctx context.Context, req *http.Request) (*http.Resp
 			"url", req.URL.String(),
 		)
 
+		// Use an explicit timer (stopped on cancellation) rather than
+		// time.After so a cancelled wait doesn't leave a timer running until
+		// it fires.
+		timer := time.NewTimer(backoff)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return nil, ctx.Err()
-		case <-time.After(backoff):
+		case <-timer.C:
 		}
 	}
 

--- a/v2/retry.go
+++ b/v2/retry.go
@@ -147,6 +147,9 @@ func (c *retryHTTPClient) Do(ctx context.Context, req *http.Request) (*http.Resp
 
 	var resp *http.Response
 	var err error
+	// range over an int (Go 1.22+) iterates attempt = 0..attempts-1. This is
+	// required here: go.mod pins go 1.25 and the repo's golangci-lint config
+	// enables the intrange linter, which rejects the equivalent counted loop.
 	for attempt := range attempts {
 		// Re-buffer the request body for every attempt after the first.
 		// http.NewRequestWithContext populates GetBody for the in-memory

--- a/v2/retry.go
+++ b/v2/retry.go
@@ -27,10 +27,14 @@ type retryHTTPClient struct {
 }
 
 // newRetryHTTPClient builds a retrying HTTPDoer. It returns inner unchanged
-// when neither retry nor rate-limit handling is configured so the common
-// path adds no overhead.
+// unless at least one retry path can actually trigger — i.e. error/status
+// retries are enabled (retry.MaxRetries > 0) or 429 rate-limit handling is
+// enabled (rateLimit.Enabled && rateLimit.WaitOnLimit). This keeps the common
+// path (and any effectively-disabled configuration) free of wrapper overhead.
 func newRetryHTTPClient(inner HTTPDoer, retry *RetryConfig, rateLimit *RateLimitConfig, logger *slog.Logger) HTTPDoer {
-	if retry == nil && (rateLimit == nil || !rateLimit.Enabled) {
+	retryActive := retry != nil && retry.MaxRetries > 0
+	rateLimitActive := rateLimit != nil && rateLimit.Enabled && rateLimit.WaitOnLimit
+	if !retryActive && !rateLimitActive {
 		return inner
 	}
 	if logger == nil {
@@ -81,6 +85,11 @@ func (c *retryHTTPClient) retriesEnabled() bool {
 // Do executes the request, retrying transient failures per the configuration.
 func (c *retryHTTPClient) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
 	attempts := c.maxAttempts()
+
+	// Keep req.Context() consistent with the ctx we pass to the inner doer so
+	// cancellation/timeouts propagate even for a custom HTTPDoer that reads
+	// req.Context() instead of the explicit ctx argument.
+	req = req.WithContext(ctx)
 
 	var resp *http.Response
 	var err error

--- a/v2/retry.go
+++ b/v2/retry.go
@@ -1,0 +1,201 @@
+package aptos
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"math"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// retryHTTPClient wraps an HTTPDoer with automatic retry and rate-limit
+// handling. It is installed by newNodeClient when WithRetry, WithRetryConfig,
+// or WithRateLimitHandling are supplied.
+//
+// Retries are attempted on transient failures (network errors and the
+// configured retryable status codes) using exponential backoff with jitter.
+// When rate-limit handling is enabled the client additionally honors the
+// Retry-After header returned with HTTP 429 responses, capped at MaxWaitTime.
+type retryHTTPClient struct {
+	inner     HTTPDoer
+	retry     *RetryConfig
+	rateLimit *RateLimitConfig
+	logger    *slog.Logger
+}
+
+// newRetryHTTPClient builds a retrying HTTPDoer. It returns inner unchanged
+// when neither retry nor rate-limit handling is configured so the common
+// path adds no overhead.
+func newRetryHTTPClient(inner HTTPDoer, retry *RetryConfig, rateLimit *RateLimitConfig, logger *slog.Logger) HTTPDoer {
+	if retry == nil && (rateLimit == nil || !rateLimit.Enabled) {
+		return inner
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &retryHTTPClient{
+		inner:     inner,
+		retry:     retry,
+		rateLimit: rateLimit,
+		logger:    logger,
+	}
+}
+
+// maxAttempts returns the total number of attempts (including the first) the
+// client will make.
+func (c *retryHTTPClient) maxAttempts() int {
+	if c.retry != nil && c.retry.MaxRetries > 0 {
+		return c.retry.MaxRetries + 1
+	}
+	// Rate-limit handling without an explicit retry config still needs to
+	// retry 429s. Use a sensible bounded default so a misbehaving server
+	// can't make us loop forever; overall waiting is additionally bounded
+	// by MaxWaitTime per attempt and by the request context.
+	if c.rateLimit != nil && c.rateLimit.Enabled {
+		return 6
+	}
+	return 1
+}
+
+// Do executes the request, retrying transient failures per the configuration.
+func (c *retryHTTPClient) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
+	attempts := c.maxAttempts()
+
+	var resp *http.Response
+	var err error
+	for attempt := range attempts {
+		// Re-buffer the request body for every attempt after the first.
+		// http.NewRequestWithContext populates GetBody for the in-memory
+		// body types the SDK uses (bytes.Reader), so this is reliable.
+		if attempt > 0 && req.Body != nil && req.GetBody != nil {
+			body, gerr := req.GetBody()
+			if gerr != nil {
+				return nil, gerr
+			}
+			req.Body = body
+		}
+
+		resp, err = c.inner.Do(ctx, req)
+
+		// Last attempt: return whatever we got.
+		if attempt == attempts-1 {
+			return resp, err
+		}
+
+		retry, wait := c.shouldRetry(resp, err)
+		if !retry {
+			return resp, err
+		}
+
+		// Drain and close the response body so the connection can be
+		// reused, then back off before retrying.
+		if resp != nil && resp.Body != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+
+		backoff := c.backoff(attempt + 1)
+		if wait > backoff {
+			backoff = wait
+		}
+
+		c.logger.Debug(
+			"retrying request",
+			"attempt", attempt+1,
+			"max_attempts", attempts,
+			"backoff", backoff,
+			"url", req.URL.String(),
+		)
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(backoff):
+		}
+	}
+
+	return resp, err
+}
+
+// shouldRetry reports whether another attempt should be made and, for
+// rate-limited responses, how long to wait based on the Retry-After header.
+func (c *retryHTTPClient) shouldRetry(resp *http.Response, err error) (bool, time.Duration) {
+	// Network/transport errors are retried only when retry is configured.
+	if err != nil {
+		return c.retry != nil, 0
+	}
+	if resp == nil {
+		return false, 0
+	}
+
+	// Rate-limit handling: honor Retry-After (capped) on 429.
+	if resp.StatusCode == http.StatusTooManyRequests && c.rateLimit != nil && c.rateLimit.Enabled && c.rateLimit.WaitOnLimit {
+		return true, c.retryAfter(resp)
+	}
+
+	if c.retry != nil && c.isRetriableStatus(resp.StatusCode) {
+		return true, 0
+	}
+
+	return false, 0
+}
+
+// retryAfter parses the Retry-After header (seconds form) and caps it at
+// MaxWaitTime. Returns 0 when the header is absent or unparseable.
+func (c *retryHTTPClient) retryAfter(resp *http.Response) time.Duration {
+	header := resp.Header.Get("Retry-After")
+	if header == "" {
+		return 0
+	}
+	seconds, perr := strconv.Atoi(header)
+	if perr != nil || seconds < 0 {
+		return 0
+	}
+	wait := time.Duration(seconds) * time.Second
+	if c.rateLimit.MaxWaitTime > 0 && wait > c.rateLimit.MaxWaitTime {
+		wait = c.rateLimit.MaxWaitTime
+	}
+	return wait
+}
+
+func (c *retryHTTPClient) isRetriableStatus(statusCode int) bool {
+	for _, code := range c.retry.RetryableStatusCodes {
+		if statusCode == code {
+			return true
+		}
+	}
+	return false
+}
+
+// backoff computes the exponential backoff (with +/-10% jitter) for the given
+// attempt number (1-based), capped at MaxBackoff.
+func (c *retryHTTPClient) backoff(attempt int) time.Duration {
+	if c.retry == nil {
+		// Rate-limit-only mode: a small fixed base so non-Retry-After 429s
+		// (or empty headers) still pace themselves.
+		return 100 * time.Millisecond
+	}
+
+	base := float64(c.retry.InitialBackoff)
+	if base <= 0 {
+		base = float64(100 * time.Millisecond)
+	}
+	mult := c.retry.BackoffMultiplier
+	if mult <= 0 {
+		mult = 2.0
+	}
+
+	backoff := base * math.Pow(mult, float64(attempt-1))
+	// +/-10% jitter to avoid synchronized retries (thundering herd).
+	backoff += backoff * 0.1 * (rand.Float64()*2 - 1) //nolint:gosec // non-crypto jitter
+	if maxB := float64(c.retry.MaxBackoff); maxB > 0 && backoff > maxB {
+		backoff = maxB
+	}
+	if backoff < 0 {
+		backoff = 0
+	}
+	return time.Duration(backoff)
+}

--- a/v2/retry_test.go
+++ b/v2/retry_test.go
@@ -2,9 +2,11 @@ package aptos
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -189,4 +191,181 @@ func TestNewRetryHTTPClient_NoConfigReturnsInner(t *testing.T) {
 
 	got = newRetryHTTPClient(inner, nil, &RateLimitConfig{Enabled: false}, nil)
 	assert.Same(t, inner, got, "disabled rate limiting should return the inner client unchanged")
+}
+
+// errDoer is an HTTPDoer that returns a fixed error for the first failN calls,
+// then delegates to a success response.
+type errDoer struct {
+	failN   int
+	calls   int32
+	mkResp  func() *http.Response
+	lastErr error
+}
+
+func (d *errDoer) Do(_ context.Context, _ *http.Request) (*http.Response, error) {
+	n := atomic.AddInt32(&d.calls, 1)
+	if int(n) <= d.failN {
+		d.lastErr = errors.New("simulated network error")
+		return nil, d.lastErr
+	}
+	return d.mkResp(), nil
+}
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"chain_id":4}`)),
+		Header:     make(http.Header),
+	}
+}
+
+func TestRetry_NetworkErrorIsRetried(t *testing.T) {
+	t.Parallel()
+	doer := &errDoer{failN: 2, mkResp: okResponse}
+	client, err := newNodeClient(&ClientConfig{
+		network:     NetworkConfig{NodeURL: "http://example.invalid/v1", ChainID: 4},
+		httpClient:  doer,
+		retryConfig: &RetryConfig{MaxRetries: 3, InitialBackoff: time.Millisecond, BackoffMultiplier: 2, MaxBackoff: time.Second},
+	})
+	require.NoError(t, err)
+
+	info, err := client.Info(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint8(4), info.ChainID)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&doer.calls))
+}
+
+func TestRetry_RateLimitOnly_DoesNotRetryNetworkError(t *testing.T) {
+	t.Parallel()
+	// Rate-limit handling without a retry config must not retry plain network
+	// errors (only 429 responses).
+	doer := &errDoer{failN: 5, mkResp: okResponse}
+	client, err := newNodeClient(&ClientConfig{
+		network:         NetworkConfig{NodeURL: "http://example.invalid/v1", ChainID: 4},
+		httpClient:      doer,
+		rateLimitConfig: &RateLimitConfig{Enabled: true, WaitOnLimit: true, MaxWaitTime: time.Second},
+	})
+	require.NoError(t, err)
+
+	_, err = client.Info(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&doer.calls))
+}
+
+func TestRetryHTTPClient_MaxAttempts(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		client   *retryHTTPClient
+		expected int
+	}{
+		{"retry with max", &retryHTTPClient{retry: &RetryConfig{MaxRetries: 3}}, 4},
+		{"rate-limit only", &retryHTTPClient{rateLimit: &RateLimitConfig{Enabled: true}}, 6},
+		{"neither", &retryHTTPClient{}, 1},
+		{"retry zero", &retryHTTPClient{retry: &RetryConfig{MaxRetries: 0}}, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, tt.client.maxAttempts())
+		})
+	}
+}
+
+func TestRetryHTTPClient_RetryAfter(t *testing.T) {
+	t.Parallel()
+	c := &retryHTTPClient{rateLimit: &RateLimitConfig{Enabled: true, WaitOnLimit: true, MaxWaitTime: 5 * time.Second}}
+
+	cases := []struct {
+		name   string
+		header string
+		want   time.Duration
+	}{
+		{"absent header", "", 0},
+		{"unparseable header", "not-a-number", 0},
+		{"negative header", "-3", 0},
+		{"valid header", "2", 2 * time.Second},
+		{"capped at MaxWaitTime", "100", 5 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := make(http.Header)
+			if tc.header != "" {
+				h.Set("Retry-After", tc.header)
+			}
+			resp := &http.Response{Header: h, Body: http.NoBody}
+			defer func() { _ = resp.Body.Close() }()
+			assert.Equal(t, tc.want, c.retryAfter(resp))
+		})
+	}
+}
+
+func TestRetryHTTPClient_ShouldRetry(t *testing.T) {
+	t.Parallel()
+
+	// Network error: retried only when retry is configured.
+	withRetry := &retryHTTPClient{retry: DefaultRetryConfig()}
+	retry, _ := withRetry.shouldRetry(nil, errors.New("boom"))
+	assert.True(t, retry)
+
+	rateOnly := &retryHTTPClient{rateLimit: &RateLimitConfig{Enabled: true, WaitOnLimit: true}}
+	retry, _ = rateOnly.shouldRetry(nil, errors.New("boom"))
+	assert.False(t, retry, "rate-limit-only must not retry network errors")
+
+	// nil response, no error.
+	retry, _ = withRetry.shouldRetry(nil, nil)
+	assert.False(t, retry)
+
+	// 429 with rate-limit handling.
+	resp429 := &http.Response{StatusCode: http.StatusTooManyRequests, Header: make(http.Header)}
+	retry, _ = rateOnly.shouldRetry(resp429, nil)
+	assert.True(t, retry)
+
+	// Non-retriable success.
+	resp200 := &http.Response{StatusCode: http.StatusOK, Header: make(http.Header)}
+	retry, _ = withRetry.shouldRetry(resp200, nil)
+	assert.False(t, retry)
+}
+
+func TestRetryHTTPClient_Backoff(t *testing.T) {
+	t.Parallel()
+
+	// Rate-limit-only mode (no retry config) uses a small fixed base.
+	rateOnly := &retryHTTPClient{rateLimit: &RateLimitConfig{Enabled: true}}
+	assert.Equal(t, 100*time.Millisecond, rateOnly.backoff(1))
+
+	// Zero/negative config values fall back to defaults without panicking.
+	defaulted := &retryHTTPClient{retry: &RetryConfig{InitialBackoff: 0, BackoffMultiplier: 0}}
+	got := defaulted.backoff(1)
+	assert.Positive(t, got)
+
+	// Growth is capped at MaxBackoff.
+	capped := &retryHTTPClient{retry: &RetryConfig{
+		InitialBackoff:    time.Second,
+		BackoffMultiplier: 10,
+		MaxBackoff:        2 * time.Second,
+	}}
+	assert.LessOrEqual(t, capped.backoff(5), 2*time.Second)
+}
+
+func TestRetry_WithRetryConfigOption(t *testing.T) {
+	t.Parallel()
+	handler, count := countingHandler([]int{
+		http.StatusBadGateway,
+		http.StatusOK,
+	}, `{"chain_id":4}`)
+	cfg := &RetryConfig{
+		MaxRetries:           2,
+		InitialBackoff:       time.Millisecond,
+		MaxBackoff:           time.Second,
+		BackoffMultiplier:    2,
+		RetryableStatusCodes: []int{http.StatusBadGateway},
+	}
+	client := newRetryTestClient(t, handler, WithRetryConfig(cfg))
+
+	info, err := client.Info(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint8(4), info.ChainID)
+	assert.Equal(t, int32(2), atomic.LoadInt32(count))
 }

--- a/v2/retry_test.go
+++ b/v2/retry_test.go
@@ -1,0 +1,192 @@
+package aptos
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingHandler returns a handler that responds with the configured status
+// codes in sequence (the last one repeats), tracking how many requests it saw.
+func countingHandler(statuses []int, body string) (http.HandlerFunc, *int32) {
+	var count int32
+	h := func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&count, 1)
+		idx := int(n) - 1
+		if idx >= len(statuses) {
+			idx = len(statuses) - 1
+		}
+		w.WriteHeader(statuses[idx])
+		_, _ = w.Write([]byte(body))
+	}
+	return h, &count
+}
+
+func newRetryTestClient(t *testing.T, handler http.Handler, opts ...ClientOption) *nodeClient {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	config := &ClientConfig{
+		network: NetworkConfig{NodeURL: server.URL, ChainID: 4},
+		timeout: 0,
+	}
+	for _, opt := range opts {
+		opt(config)
+	}
+	client, err := newNodeClient(config)
+	require.NoError(t, err)
+	return client
+}
+
+func TestRetry_NotConfigured_NoRetry(t *testing.T) {
+	t.Parallel()
+	handler, count := countingHandler([]int{http.StatusServiceUnavailable}, "boom")
+	client := newRetryTestClient(t, handler)
+
+	_, err := client.Info(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(count), "no retry should be attempted without WithRetry")
+}
+
+func TestRetry_RetriesOnServerError(t *testing.T) {
+	t.Parallel()
+	// Two 503s then a 200.
+	handler, count := countingHandler([]int{
+		http.StatusServiceUnavailable,
+		http.StatusServiceUnavailable,
+		http.StatusOK,
+	}, `{"chain_id":4}`)
+	client := newRetryTestClient(t, handler, WithRetry(3, time.Millisecond))
+
+	info, err := client.Info(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint8(4), info.ChainID)
+	assert.Equal(t, int32(3), atomic.LoadInt32(count), "should retry until success")
+}
+
+func TestRetry_ExhaustsAndReturnsError(t *testing.T) {
+	t.Parallel()
+	handler, count := countingHandler([]int{http.StatusInternalServerError}, "nope")
+	client := newRetryTestClient(t, handler, WithRetry(2, time.Millisecond))
+
+	_, err := client.Info(context.Background())
+	require.Error(t, err)
+	// 1 initial + 2 retries = 3 attempts.
+	assert.Equal(t, int32(3), atomic.LoadInt32(count))
+}
+
+func TestRetry_DoesNotRetryNonRetriableStatus(t *testing.T) {
+	t.Parallel()
+	handler, count := countingHandler([]int{http.StatusBadRequest}, "bad")
+	client := newRetryTestClient(t, handler, WithRetry(3, time.Millisecond))
+
+	_, err := client.Info(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(count), "400 is not retriable")
+}
+
+func TestRetry_RetriesPostWithBody(t *testing.T) {
+	t.Parallel()
+	// View is a POST with a JSON body; ensure the body is re-sent on retry.
+	var (
+		mu     sync.Mutex
+		bodies []string
+		count  int32
+	)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&count, 1)
+		buf, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(buf))
+		mu.Unlock()
+		if n < 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`["42"]`))
+	})
+	client := newRetryTestClient(t, handler, WithRetry(3, time.Millisecond))
+
+	result, err := client.View(context.Background(), &ViewPayload{
+		Module:   ModuleID{Address: AccountOne, Name: "coin"},
+		Function: "balance",
+	})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&count))
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, bodies, 2)
+	assert.Equal(t, bodies[0], bodies[1], "request body must be identical on retry")
+	assert.NotEmpty(t, bodies[1])
+}
+
+func TestRateLimit_RetriesOn429(t *testing.T) {
+	t.Parallel()
+	handler, count := countingHandler([]int{
+		http.StatusTooManyRequests,
+		http.StatusOK,
+	}, `{"chain_id":4}`)
+	client := newRetryTestClient(t, handler, WithRateLimitHandling(true, time.Second))
+
+	info, err := client.Info(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint8(4), info.ChainID)
+	assert.Equal(t, int32(2), atomic.LoadInt32(count))
+}
+
+func TestRateLimit_HonorsRetryAfterCappedByMaxWait(t *testing.T) {
+	t.Parallel()
+	var count int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&count, 1)
+		if n < 2 {
+			w.Header().Set("Retry-After", "100") // would be 100s uncapped
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"chain_id":4}`))
+	})
+	// Cap the wait at 10ms so the test stays fast; if the cap were ignored
+	// this test would hang far beyond its deadline.
+	client := newRetryTestClient(t, handler, WithRateLimitHandling(true, 10*time.Millisecond))
+
+	start := time.Now()
+	info, err := client.Info(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint8(4), info.ChainID)
+	assert.Less(t, time.Since(start), 5*time.Second, "Retry-After must be capped by MaxWaitTime")
+}
+
+func TestRetry_RespectsContextCancellation(t *testing.T) {
+	t.Parallel()
+	handler, _ := countingHandler([]int{http.StatusServiceUnavailable}, "boom")
+	client := newRetryTestClient(t, handler, WithRetry(5, 50*time.Millisecond))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := client.Info(ctx)
+	require.Error(t, err)
+}
+
+func TestNewRetryHTTPClient_NoConfigReturnsInner(t *testing.T) {
+	t.Parallel()
+	inner := &defaultHTTPClient{}
+	got := newRetryHTTPClient(inner, nil, nil, nil)
+	assert.Same(t, inner, got, "no config should return the inner client unchanged")
+
+	got = newRetryHTTPClient(inner, nil, &RateLimitConfig{Enabled: false}, nil)
+	assert.Same(t, inner, got, "disabled rate limiting should return the inner client unchanged")
+}

--- a/v2/retry_test.go
+++ b/v2/retry_test.go
@@ -301,14 +301,23 @@ func TestRetryHTTPClient_MaxAttempts(t *testing.T) {
 		{"neither", &retryHTTPClient{}, 1},
 		{"retry zero", &retryHTTPClient{retry: &RetryConfig{MaxRetries: 0}}, 1},
 		{
+			// 1 initial + 0 error/status + 5 rate-limit.
 			"retry zero with rate-limit",
 			&retryHTTPClient{retry: &RetryConfig{MaxRetries: 0}, rateLimit: &RateLimitConfig{Enabled: true, WaitOnLimit: true}},
 			6,
 		},
 		{
-			"retry max larger than rate-limit default",
+			// Error/status and rate-limit budgets are independent: the total
+			// must reserve room for both (1 + 10 + 5), not max(11, 6).
+			"retry plus rate-limit budgets are additive",
 			&retryHTTPClient{retry: &RetryConfig{MaxRetries: 10}, rateLimit: &RateLimitConfig{Enabled: true, WaitOnLimit: true}},
-			11,
+			16,
+		},
+		{
+			// 1 initial + 2 error/status + 5 rate-limit.
+			"small retry with rate-limit",
+			&retryHTTPClient{retry: &RetryConfig{MaxRetries: 2}, rateLimit: &RateLimitConfig{Enabled: true, WaitOnLimit: true}},
+			8,
 		},
 	}
 	for _, tt := range tests {
@@ -348,31 +357,36 @@ func TestRetryHTTPClient_RetryAfter(t *testing.T) {
 	}
 }
 
-func TestRetryHTTPClient_ShouldRetry(t *testing.T) {
+func TestRetryHTTPClient_ClassifyRetry(t *testing.T) {
 	t.Parallel()
 
-	// Network error: retried only when retry is configured.
+	// Network error: classified as error/status only when retries are enabled.
 	withRetry := &retryHTTPClient{retry: DefaultRetryConfig()}
-	retry, _ := withRetry.shouldRetry(nil, errors.New("boom"))
-	assert.True(t, retry)
+	reason, _ := withRetry.classifyRetry(nil, errors.New("boom"))
+	assert.Equal(t, retryErrorStatus, reason)
 
 	rateOnly := &retryHTTPClient{rateLimit: &RateLimitConfig{Enabled: true, WaitOnLimit: true}}
-	retry, _ = rateOnly.shouldRetry(nil, errors.New("boom"))
-	assert.False(t, retry, "rate-limit-only must not retry network errors")
+	reason, _ = rateOnly.classifyRetry(nil, errors.New("boom"))
+	assert.Equal(t, retryNone, reason, "rate-limit-only must not retry network errors")
 
 	// nil response, no error.
-	retry, _ = withRetry.shouldRetry(nil, nil)
-	assert.False(t, retry)
+	reason, _ = withRetry.classifyRetry(nil, nil)
+	assert.Equal(t, retryNone, reason)
 
 	// 429 with rate-limit handling.
 	resp429 := &http.Response{StatusCode: http.StatusTooManyRequests, Header: make(http.Header)}
-	retry, _ = rateOnly.shouldRetry(resp429, nil)
-	assert.True(t, retry)
+	reason, _ = rateOnly.classifyRetry(resp429, nil)
+	assert.Equal(t, retryRateLimit, reason)
+
+	// Retryable 5xx with retries enabled.
+	resp503 := &http.Response{StatusCode: http.StatusServiceUnavailable, Header: make(http.Header)}
+	reason, _ = withRetry.classifyRetry(resp503, nil)
+	assert.Equal(t, retryErrorStatus, reason)
 
 	// Non-retriable success.
 	resp200 := &http.Response{StatusCode: http.StatusOK, Header: make(http.Header)}
-	retry, _ = withRetry.shouldRetry(resp200, nil)
-	assert.False(t, retry)
+	reason, _ = withRetry.classifyRetry(resp200, nil)
+	assert.Equal(t, retryNone, reason)
 }
 
 func TestRetryHTTPClient_Backoff(t *testing.T) {
@@ -394,6 +408,46 @@ func TestRetryHTTPClient_Backoff(t *testing.T) {
 		MaxBackoff:        2 * time.Second,
 	}}
 	assert.LessOrEqual(t, capped.backoff(5), 2*time.Second)
+}
+
+func TestRetry_RateLimitDoesNotRaiseServerErrorCap(t *testing.T) {
+	t.Parallel()
+	// Server returns 503 forever. With MaxRetries=2, enabling rate-limit
+	// handling must NOT allow more than 2 retries for the 503s (regression:
+	// previously the budget was bumped to the rate-limit default of ~6).
+	handler, count := countingHandler([]int{http.StatusServiceUnavailable}, "down")
+	client := newRetryTestClient(
+		t, handler,
+		WithRetry(2, time.Millisecond),
+		WithRateLimitHandling(true, time.Second),
+	)
+
+	_, err := client.Info(context.Background())
+	require.Error(t, err)
+	// 1 initial + 2 retries == 3, strictly capped by MaxRetries.
+	assert.Equal(t, int32(3), atomic.LoadInt32(count))
+}
+
+func TestRetry_ServerErrorAndRateLimitCapsAreIndependent(t *testing.T) {
+	t.Parallel()
+	// 503 (retryable status) then 429 (rate limit) then 200. With MaxRetries=1
+	// the 503 consumes the single error/status retry, and the 429 is handled
+	// by the independent rate-limit budget, so the request still succeeds.
+	handler, count := countingHandler([]int{
+		http.StatusServiceUnavailable,
+		http.StatusTooManyRequests,
+		http.StatusOK,
+	}, `{"chain_id":4}`)
+	client := newRetryTestClient(
+		t, handler,
+		WithRetry(1, time.Millisecond),
+		WithRateLimitHandling(true, time.Second),
+	)
+
+	info, err := client.Info(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint8(4), info.ChainID)
+	assert.Equal(t, int32(3), atomic.LoadInt32(count))
 }
 
 func TestRetry_MaxRetriesZeroWithRateLimit_OnlyRetries429(t *testing.T) {
@@ -441,25 +495,25 @@ func TestRetry_MaxRetriesZeroWithRateLimit_OnlyRetries429(t *testing.T) {
 	})
 }
 
-func TestRetryHTTPClient_ShouldRetry_MaxRetriesZero(t *testing.T) {
+func TestRetryHTTPClient_ClassifyRetry_MaxRetriesZero(t *testing.T) {
 	t.Parallel()
 
 	// retry present but MaxRetries == 0: network errors and retryable statuses
 	// must NOT be retried.
 	c := &retryHTTPClient{retry: &RetryConfig{MaxRetries: 0, RetryableStatusCodes: []int{http.StatusServiceUnavailable}}}
 
-	retry, _ := c.shouldRetry(nil, errors.New("boom"))
-	assert.False(t, retry, "network error must not be retried when MaxRetries==0")
+	reason, _ := c.classifyRetry(nil, errors.New("boom"))
+	assert.Equal(t, retryNone, reason, "network error must not be retried when MaxRetries==0")
 
 	resp503 := &http.Response{StatusCode: http.StatusServiceUnavailable, Header: make(http.Header)}
-	retry, _ = c.shouldRetry(resp503, nil)
-	assert.False(t, retry, "503 must not be retried when MaxRetries==0")
+	reason, _ = c.classifyRetry(resp503, nil)
+	assert.Equal(t, retryNone, reason, "503 must not be retried when MaxRetries==0")
 
 	// With rate-limit handling, a 429 is still retried.
 	c.rateLimit = &RateLimitConfig{Enabled: true, WaitOnLimit: true}
 	resp429 := &http.Response{StatusCode: http.StatusTooManyRequests, Header: make(http.Header)}
-	retry, _ = c.shouldRetry(resp429, nil)
-	assert.True(t, retry, "429 must be retried under rate-limit handling even with MaxRetries==0")
+	reason, _ = c.classifyRetry(resp429, nil)
+	assert.Equal(t, retryRateLimit, reason, "429 must be retried under rate-limit handling even with MaxRetries==0")
 }
 
 func TestRetry_WithRetryConfigOption(t *testing.T) {

--- a/v2/retry_test.go
+++ b/v2/retry_test.go
@@ -260,9 +260,20 @@ func TestRetryHTTPClient_MaxAttempts(t *testing.T) {
 		expected int
 	}{
 		{"retry with max", &retryHTTPClient{retry: &RetryConfig{MaxRetries: 3}}, 4},
-		{"rate-limit only", &retryHTTPClient{rateLimit: &RateLimitConfig{Enabled: true}}, 6},
+		{"rate-limit only", &retryHTTPClient{rateLimit: &RateLimitConfig{Enabled: true, WaitOnLimit: true}}, 6},
+		{"rate-limit enabled but not waiting", &retryHTTPClient{rateLimit: &RateLimitConfig{Enabled: true, WaitOnLimit: false}}, 1},
 		{"neither", &retryHTTPClient{}, 1},
 		{"retry zero", &retryHTTPClient{retry: &RetryConfig{MaxRetries: 0}}, 1},
+		{
+			"retry zero with rate-limit",
+			&retryHTTPClient{retry: &RetryConfig{MaxRetries: 0}, rateLimit: &RateLimitConfig{Enabled: true, WaitOnLimit: true}},
+			6,
+		},
+		{
+			"retry max larger than rate-limit default",
+			&retryHTTPClient{retry: &RetryConfig{MaxRetries: 10}, rateLimit: &RateLimitConfig{Enabled: true, WaitOnLimit: true}},
+			11,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -347,6 +358,72 @@ func TestRetryHTTPClient_Backoff(t *testing.T) {
 		MaxBackoff:        2 * time.Second,
 	}}
 	assert.LessOrEqual(t, capped.backoff(5), 2*time.Second)
+}
+
+func TestRetry_MaxRetriesZeroWithRateLimit_OnlyRetries429(t *testing.T) {
+	t.Parallel()
+
+	// An explicit MaxRetries == 0 disables error/status retries, but enabling
+	// rate-limit handling must still retry 429s.
+	zeroRetry := func() *RetryConfig {
+		return &RetryConfig{MaxRetries: 0, RetryableStatusCodes: []int{http.StatusServiceUnavailable}}
+	}
+
+	// A retryable status (503) must NOT be retried when MaxRetries == 0.
+	t.Run("503 not retried", func(t *testing.T) {
+		t.Parallel()
+		handler, count := countingHandler([]int{
+			http.StatusServiceUnavailable,
+			http.StatusOK,
+		}, `{"chain_id":4}`)
+		client := newRetryTestClient(
+			t, handler,
+			WithRetryConfig(zeroRetry()),
+			WithRateLimitHandling(true, time.Second),
+		)
+		_, err := client.Info(context.Background())
+		require.Error(t, err)
+		assert.Equal(t, int32(1), atomic.LoadInt32(count), "503 must not be retried when MaxRetries==0")
+	})
+
+	// A 429 must still be retried via rate-limit handling.
+	t.Run("429 retried", func(t *testing.T) {
+		t.Parallel()
+		handler, count := countingHandler([]int{
+			http.StatusTooManyRequests,
+			http.StatusOK,
+		}, `{"chain_id":4}`)
+		client := newRetryTestClient(
+			t, handler,
+			WithRetryConfig(zeroRetry()),
+			WithRateLimitHandling(true, time.Second),
+		)
+		info, err := client.Info(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, uint8(4), info.ChainID)
+		assert.Equal(t, int32(2), atomic.LoadInt32(count), "429 must be retried under rate-limit handling")
+	})
+}
+
+func TestRetryHTTPClient_ShouldRetry_MaxRetriesZero(t *testing.T) {
+	t.Parallel()
+
+	// retry present but MaxRetries == 0: network errors and retryable statuses
+	// must NOT be retried.
+	c := &retryHTTPClient{retry: &RetryConfig{MaxRetries: 0, RetryableStatusCodes: []int{http.StatusServiceUnavailable}}}
+
+	retry, _ := c.shouldRetry(nil, errors.New("boom"))
+	assert.False(t, retry, "network error must not be retried when MaxRetries==0")
+
+	resp503 := &http.Response{StatusCode: http.StatusServiceUnavailable, Header: make(http.Header)}
+	retry, _ = c.shouldRetry(resp503, nil)
+	assert.False(t, retry, "503 must not be retried when MaxRetries==0")
+
+	// With rate-limit handling, a 429 is still retried.
+	c.rateLimit = &RateLimitConfig{Enabled: true, WaitOnLimit: true}
+	resp429 := &http.Response{StatusCode: http.StatusTooManyRequests, Header: make(http.Header)}
+	retry, _ = c.shouldRetry(resp429, nil)
+	assert.True(t, retry, "429 must be retried under rate-limit handling even with MaxRetries==0")
 }
 
 func TestRetry_WithRetryConfigOption(t *testing.T) {

--- a/v2/retry_test.go
+++ b/v2/retry_test.go
@@ -183,14 +183,50 @@ func TestRetry_RespectsContextCancellation(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestNewRetryHTTPClient_NoConfigReturnsInner(t *testing.T) {
+func TestNewRetryHTTPClient_ReturnsInnerWhenInactive(t *testing.T) {
 	t.Parallel()
 	inner := &defaultHTTPClient{}
-	got := newRetryHTTPClient(inner, nil, nil, nil)
-	assert.Same(t, inner, got, "no config should return the inner client unchanged")
 
-	got = newRetryHTTPClient(inner, nil, &RateLimitConfig{Enabled: false}, nil)
-	assert.Same(t, inner, got, "disabled rate limiting should return the inner client unchanged")
+	cases := []struct {
+		name      string
+		retry     *RetryConfig
+		rateLimit *RateLimitConfig
+	}{
+		{"no config", nil, nil},
+		{"rate limit disabled", nil, &RateLimitConfig{Enabled: false}},
+		{"rate limit enabled but not waiting", nil, &RateLimitConfig{Enabled: true, WaitOnLimit: false}},
+		{"retry with zero max retries", &RetryConfig{MaxRetries: 0}, nil},
+		{"retry zero and rate limit not waiting", &RetryConfig{MaxRetries: 0}, &RateLimitConfig{Enabled: true, WaitOnLimit: false}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := newRetryHTTPClient(inner, tc.retry, tc.rateLimit, nil)
+			assert.Same(t, inner, got, "inactive config should return the inner client unchanged")
+		})
+	}
+}
+
+func TestNewRetryHTTPClient_WrapsWhenActive(t *testing.T) {
+	t.Parallel()
+	inner := &defaultHTTPClient{}
+
+	cases := []struct {
+		name      string
+		retry     *RetryConfig
+		rateLimit *RateLimitConfig
+	}{
+		{"retries enabled", &RetryConfig{MaxRetries: 1}, nil},
+		{"rate-limit waiting enabled", nil, &RateLimitConfig{Enabled: true, WaitOnLimit: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := newRetryHTTPClient(inner, tc.retry, tc.rateLimit, nil)
+			assert.NotSame(t, inner, got, "active config should wrap the inner client")
+			assert.IsType(t, &retryHTTPClient{}, got)
+		})
+	}
 }
 
 // errDoer is an HTTPDoer that returns a fixed error for the first failN calls,

--- a/v2/testutil/fake_client.go
+++ b/v2/testutil/fake_client.go
@@ -136,7 +136,9 @@ func (c *FakeClient) WithBlock(block *aptos.Block) *FakeClient {
 func (c *FakeClient) WithViewResult(function string, result []any) *FakeClient {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.viewResults[function] = result
+	// Store a copy so later caller mutations of the slice can't change the
+	// stubbed result (and to avoid shared-mutable-state data races).
+	c.viewResults[function] = append([]any(nil), result...)
 	return c
 }
 
@@ -490,7 +492,9 @@ func (c *FakeClient) View(ctx context.Context, payload *aptos.ViewPayload, opts 
 		return fn(payload)
 	}
 	if ok {
-		return result, nil
+		// Return a defensive copy so callers can't mutate the stored stub
+		// (which would affect later View calls or race across goroutines).
+		return append([]any(nil), result...), nil
 	}
 	// Return empty result by default
 	return []any{}, nil

--- a/v2/testutil/fake_client.go
+++ b/v2/testutil/fake_client.go
@@ -24,6 +24,13 @@ type FakeClient struct {
 	transactions map[string]*aptos.Transaction
 	blocks       map[uint64]*aptos.Block
 
+	// View function stubbing. viewResults is keyed by either the bare
+	// function name ("balance") or the fully-qualified name
+	// ("0x1::coin::balance"). viewFunc, when set, takes precedence and is
+	// consulted for every View call.
+	viewResults map[string][]any
+	viewFunc    func(*aptos.ViewPayload) ([]any, error)
+
 	// Error simulation
 	errors map[string]error
 
@@ -47,6 +54,7 @@ func NewFakeClient() *FakeClient {
 		balances:     make(map[aptos.AccountAddress]uint64),
 		transactions: make(map[string]*aptos.Transaction),
 		blocks:       make(map[uint64]*aptos.Block),
+		viewResults:  make(map[string][]any),
 		errors:       make(map[string]error),
 		nodeInfo: &aptos.NodeInfo{
 			ChainID:       4,
@@ -118,6 +126,26 @@ func (c *FakeClient) WithBlock(block *aptos.Block) *FakeClient {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.blocks[block.BlockHeight] = block
+	return c
+}
+
+// WithViewResult stubs the result returned by View for a given function.
+// The function may be specified either by bare name ("get_target_addr") or
+// fully-qualified ("0x1::coin::balance"); View checks the fully-qualified
+// name first, then the bare name.
+func (c *FakeClient) WithViewResult(function string, result []any) *FakeClient {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.viewResults[function] = result
+	return c
+}
+
+// WithViewFunc sets a callback that is consulted for every View call. When
+// set it takes precedence over any results configured via WithViewResult.
+func (c *FakeClient) WithViewFunc(fn func(*aptos.ViewPayload) ([]any, error)) *FakeClient {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.viewFunc = fn
 	return c
 }
 
@@ -442,6 +470,27 @@ func (c *FakeClient) View(ctx context.Context, payload *aptos.ViewPayload, opts 
 	c.record("View", payload)
 	if err := c.getError("View"); err != nil {
 		return nil, err
+	}
+
+	c.mu.RLock()
+	fn := c.viewFunc
+	var (
+		result []any
+		ok     bool
+	)
+	if payload != nil {
+		fullName := payload.Module.String() + "::" + payload.Function
+		if result, ok = c.viewResults[fullName]; !ok {
+			result, ok = c.viewResults[payload.Function]
+		}
+	}
+	c.mu.RUnlock()
+
+	if fn != nil {
+		return fn(payload)
+	}
+	if ok {
+		return result, nil
 	}
 	// Return empty result by default
 	return []any{}, nil

--- a/v2/testutil/fake_client.go
+++ b/v2/testutil/fake_client.go
@@ -136,8 +136,10 @@ func (c *FakeClient) WithBlock(block *aptos.Block) *FakeClient {
 func (c *FakeClient) WithViewResult(function string, result []any) *FakeClient {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	// Store a copy so later caller mutations of the slice can't change the
-	// stubbed result (and to avoid shared-mutable-state data races).
+	// Store a shallow copy so later caller mutations of the slice itself can't
+	// change the stubbed result. Reference-typed elements (maps/slices/
+	// pointers) are still shared, so tests should avoid mutating elements
+	// after stubbing.
 	c.viewResults[function] = append([]any(nil), result...)
 	return c
 }
@@ -492,8 +494,9 @@ func (c *FakeClient) View(ctx context.Context, payload *aptos.ViewPayload, opts 
 		return fn(payload)
 	}
 	if ok {
-		// Return a defensive copy so callers can't mutate the stored stub
-		// (which would affect later View calls or race across goroutines).
+		// Return a defensive (shallow) copy so callers can't mutate the
+		// stored stub slice (which would affect later View calls or race
+		// across goroutines). Reference-typed elements remain shared.
 		return append([]any(nil), result...), nil
 	}
 	// Return empty result by default

--- a/v2/testutil/testutil_test.go
+++ b/v2/testutil/testutil_test.go
@@ -640,3 +640,47 @@ func TestFakeClient_View_Error(t *testing.T) {
 	_, err := client.View(ctx, &aptos.ViewPayload{})
 	assert.ErrorIs(t, err, aptos.ErrNotFound)
 }
+
+func TestFakeClient_View_StubbedByBareName(t *testing.T) {
+	t.Parallel()
+	client := NewFakeClient().WithViewResult("balance", []any{"12345"})
+	ctx := context.Background()
+
+	result, err := client.View(ctx, &aptos.ViewPayload{
+		Module:   aptos.ModuleID{Address: aptos.AccountOne, Name: "coin"},
+		Function: "balance",
+	})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "12345", result[0])
+}
+
+func TestFakeClient_View_StubbedByFullName(t *testing.T) {
+	t.Parallel()
+	client := NewFakeClient().WithViewResult("0x1::coin::balance", []any{"42"})
+	ctx := context.Background()
+
+	result, err := client.View(ctx, &aptos.ViewPayload{
+		Module:   aptos.ModuleID{Address: aptos.AccountOne, Name: "coin"},
+		Function: "balance",
+	})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "42", result[0])
+}
+
+func TestFakeClient_View_Func(t *testing.T) {
+	t.Parallel()
+	client := NewFakeClient().WithViewFunc(func(p *aptos.ViewPayload) ([]any, error) {
+		return []any{p.Function}, nil
+	})
+	ctx := context.Background()
+
+	result, err := client.View(ctx, &aptos.ViewPayload{
+		Module:   aptos.ModuleID{Address: aptos.AccountOne, Name: "coin"},
+		Function: "supply",
+	})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "supply", result[0])
+}

--- a/v2/testutil/testutil_test.go
+++ b/v2/testutil/testutil_test.go
@@ -669,6 +669,31 @@ func TestFakeClient_View_StubbedByFullName(t *testing.T) {
 	assert.Equal(t, "42", result[0])
 }
 
+func TestFakeClient_View_ResultIsImmutable(t *testing.T) {
+	t.Parallel()
+	original := []any{"a", "b"}
+	client := NewFakeClient().WithViewResult("f", original)
+	ctx := context.Background()
+
+	payload := &aptos.ViewPayload{
+		Module:   aptos.ModuleID{Address: aptos.AccountOne, Name: "m"},
+		Function: "f",
+	}
+
+	// Mutating the caller's original slice must not affect stored stub.
+	original[0] = "mutated"
+
+	first, err := client.View(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, []any{"a", "b"}, first)
+
+	// Mutating a returned slice must not affect subsequent View calls.
+	first[0] = "changed"
+	second, err := client.View(ctx, payload)
+	require.NoError(t, err)
+	assert.Equal(t, []any{"a", "b"}, second)
+}
+
 func TestFakeClient_View_Func(t *testing.T) {
 	t.Parallel()
 	client := NewFakeClient().WithViewFunc(func(p *aptos.ViewPayload) ([]any, error) {

--- a/v2/transaction_types.go
+++ b/v2/transaction_types.go
@@ -530,10 +530,19 @@ type MultiEd25519TransactionAuthenticator struct {
 }
 
 func (a *MultiEd25519TransactionAuthenticator) Verify(msg []byte) bool {
+	// Guard against a partially-constructed value (this type is exported, so
+	// callers can build it incorrectly).
+	if a.Sender == nil || a.Sender.Auth == nil {
+		return false
+	}
 	return a.Sender.Verify(msg)
 }
 
 func (a *MultiEd25519TransactionAuthenticator) MarshalBCS(ser *bcs.Serializer) {
+	if a.Sender == nil || a.Sender.Auth == nil {
+		ser.SetError(errors.New("MultiEd25519TransactionAuthenticator: nil sender authenticator"))
+		return
+	}
 	ser.Uleb128(uint32(TransactionAuthenticatorVariantMultiEd25519))
 	// For MultiEd25519, serialize the inner authenticator (public key +
 	// signature) without the AccountAuthenticator variant prefix.

--- a/v2/transaction_types.go
+++ b/v2/transaction_types.go
@@ -520,6 +520,35 @@ func (a *Ed25519TransactionAuthenticator) UnmarshalBCS(des *bcs.Deserializer) {
 	a.Sender.Auth = auth
 }
 
+// MultiEd25519TransactionAuthenticator wraps a MultiEd25519 AccountAuthenticator
+// using the legacy on-chain multisig scheme (TransactionAuthenticator variant 1).
+// It serializes the inner MultiEd25519 public key and signature directly, without
+// an AccountAuthenticator variant prefix, matching the legacy layout (mirroring
+// Ed25519TransactionAuthenticator).
+type MultiEd25519TransactionAuthenticator struct {
+	Sender *AccountAuthenticator
+}
+
+func (a *MultiEd25519TransactionAuthenticator) Verify(msg []byte) bool {
+	return a.Sender.Verify(msg)
+}
+
+func (a *MultiEd25519TransactionAuthenticator) MarshalBCS(ser *bcs.Serializer) {
+	ser.Uleb128(uint32(TransactionAuthenticatorVariantMultiEd25519))
+	// For MultiEd25519, serialize the inner authenticator (public key +
+	// signature) without the AccountAuthenticator variant prefix.
+	a.Sender.Auth.MarshalBCS(ser)
+}
+
+func (a *MultiEd25519TransactionAuthenticator) UnmarshalBCS(des *bcs.Deserializer) {
+	a.Sender = &AccountAuthenticator{
+		Variant: AccountAuthenticatorMultiEd25519,
+	}
+	auth := &MultiEd25519Authenticator{}
+	auth.UnmarshalBCS(des)
+	a.Sender.Auth = auth
+}
+
 // serializeAuthenticator serializes an AccountAuthenticator to BCS.
 func serializeAuthenticator(ser *bcs.Serializer, auth *AccountAuthenticator) {
 	if auth == nil {
@@ -537,6 +566,13 @@ func deserializeTransactionAuthenticator(des *bcs.Deserializer) TransactionAuthe
 		auth := &Ed25519TransactionAuthenticator{}
 		auth.Sender = &AccountAuthenticator{Variant: AccountAuthenticatorEd25519}
 		inner := &Ed25519Authenticator{}
+		inner.UnmarshalBCS(des)
+		auth.Sender.Auth = inner
+		return auth
+	case TransactionAuthenticatorVariantMultiEd25519:
+		auth := &MultiEd25519TransactionAuthenticator{}
+		auth.Sender = &AccountAuthenticator{Variant: AccountAuthenticatorMultiEd25519}
+		inner := &MultiEd25519Authenticator{}
 		inner.UnmarshalBCS(des)
 		auth.Sender.Auth = inner
 		return auth

--- a/v2/transaction_types.go
+++ b/v2/transaction_types.go
@@ -543,6 +543,13 @@ func (a *MultiEd25519TransactionAuthenticator) MarshalBCS(ser *bcs.Serializer) {
 		ser.SetError(errors.New("MultiEd25519TransactionAuthenticator: nil sender authenticator"))
 		return
 	}
+	// The on-the-wire variant byte (1) declares a MultiEd25519 inner
+	// authenticator, so the inner Auth must actually be one. Otherwise we'd
+	// emit bytes tagged "multi-ed25519" that decode into a different layout.
+	if _, ok := a.Sender.Auth.(*MultiEd25519Authenticator); !ok {
+		ser.SetError(fmt.Errorf("MultiEd25519TransactionAuthenticator: sender authenticator is %T, want *MultiEd25519Authenticator", a.Sender.Auth))
+		return
+	}
 	ser.Uleb128(uint32(TransactionAuthenticatorVariantMultiEd25519))
 	// For MultiEd25519, serialize the inner authenticator (public key +
 	// signature) without the AccountAuthenticator variant prefix.

--- a/v2/transaction_types_test.go
+++ b/v2/transaction_types_test.go
@@ -565,6 +565,96 @@ func TestEd25519TransactionAuthenticator_BCSRoundTrip(t *testing.T) {
 	assert.True(t, ok)
 }
 
+func makeMultiEd25519Authenticator(t *testing.T, msg []byte) *AccountAuthenticator {
+	t.Helper()
+	key1, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+	key2, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+
+	pub1, ok := key1.PubKey().(*Ed25519PublicKey)
+	require.True(t, ok)
+	pub2, ok := key2.PubKey().(*Ed25519PublicKey)
+	require.True(t, ok)
+
+	multiKey := &MultiEd25519PublicKey{
+		PubKeys:            []*Ed25519PublicKey{pub1, pub2},
+		SignaturesRequired: 1,
+	}
+
+	sig1, err := key1.SignMessage(msg)
+	require.NoError(t, err)
+	edSig, ok := sig1.(*Ed25519Signature)
+	require.True(t, ok)
+
+	multiSig := &MultiEd25519Signature{
+		Signatures: []*Ed25519Signature{edSig},
+		// First key signed: most-significant bit of the first byte.
+		Bitmap: [4]byte{0x80, 0, 0, 0},
+	}
+
+	return &AccountAuthenticator{
+		Variant: AccountAuthenticatorMultiEd25519,
+		Auth:    &MultiEd25519Authenticator{PubKey: multiKey, Sig: multiSig},
+	}
+}
+
+func TestMultiEd25519TransactionAuthenticator_BCSRoundTrip(t *testing.T) {
+	msg := []byte("test message")
+	auth := makeMultiEd25519Authenticator(t, msg)
+
+	multiAuth := &MultiEd25519TransactionAuthenticator{Sender: auth}
+
+	data, err := bcs.Serialize(multiAuth)
+	require.NoError(t, err)
+
+	// The first ULEB128 byte must be the MultiEd25519 transaction variant (1).
+	require.NotEmpty(t, data)
+	assert.Equal(t, byte(TransactionAuthenticatorVariantMultiEd25519), data[0])
+
+	des := bcs.NewDeserializer(data)
+	txnAuth := deserializeTransactionAuthenticator(des)
+	require.NoError(t, des.Error())
+
+	result, ok := txnAuth.(*MultiEd25519TransactionAuthenticator)
+	require.True(t, ok, "expected *MultiEd25519TransactionAuthenticator, got %T", txnAuth)
+	require.NotNil(t, result.Sender)
+	assert.Equal(t, AccountAuthenticatorMultiEd25519, result.Sender.Variant)
+	assert.True(t, result.Verify(msg))
+	assert.False(t, result.Verify([]byte("wrong message")))
+}
+
+func TestMultiEd25519TransactionAuthenticator_SignedTransactionRoundTrip(t *testing.T) {
+	msg := []byte("signing message")
+	auth := makeMultiEd25519Authenticator(t, msg)
+
+	signed := &SignedTransaction{
+		Transaction: &RawTransaction{
+			Sender:                     AccountOne,
+			SequenceNumber:             7,
+			Payload:                    &ScriptPayload{Code: []byte{0x01, 0x02}},
+			MaxGasAmount:               1000,
+			GasUnitPrice:               100,
+			ExpirationTimestampSeconds: 1234567890,
+			ChainID:                    4,
+		},
+		Authenticator: &MultiEd25519TransactionAuthenticator{Sender: auth},
+	}
+
+	data, err := bcs.Serialize(signed)
+	require.NoError(t, err)
+
+	var decoded SignedTransaction
+	require.NoError(t, bcs.Deserialize(&decoded, data))
+
+	_, ok := decoded.Authenticator.(*MultiEd25519TransactionAuthenticator)
+	require.True(t, ok, "expected *MultiEd25519TransactionAuthenticator, got %T", decoded.Authenticator)
+
+	reEncoded, err := bcs.Serialize(&decoded)
+	require.NoError(t, err)
+	assert.Equal(t, data, reEncoded, "round-trip must be byte-identical")
+}
+
 func TestEd25519TransactionAuthenticator_Verify(t *testing.T) {
 	key, err := GenerateEd25519PrivateKey()
 	require.NoError(t, err)

--- a/v2/transaction_types_test.go
+++ b/v2/transaction_types_test.go
@@ -637,6 +637,20 @@ func TestMultiEd25519TransactionAuthenticator_NilSafety(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestMultiEd25519TransactionAuthenticator_MarshalRejectsWrongInnerType(t *testing.T) {
+	// A sender whose inner Auth is not a MultiEd25519 authenticator must not be
+	// serialized under the multi-ed25519 variant byte (it would produce
+	// undecodable bytes). Use a plain Ed25519 authenticator as the mismatch.
+	key, err := GenerateEd25519PrivateKey()
+	require.NoError(t, err)
+	ed25519Auth, err := key.Sign([]byte("msg"))
+	require.NoError(t, err)
+
+	mismatched := &MultiEd25519TransactionAuthenticator{Sender: ed25519Auth}
+	_, err = bcs.Serialize(mismatched)
+	require.Error(t, err)
+}
+
 func TestMultiEd25519TransactionAuthenticator_SignedTransactionRoundTrip(t *testing.T) {
 	msg := []byte("signing message")
 	auth := makeMultiEd25519Authenticator(t, msg)

--- a/v2/transaction_types_test.go
+++ b/v2/transaction_types_test.go
@@ -624,6 +624,19 @@ func TestMultiEd25519TransactionAuthenticator_BCSRoundTrip(t *testing.T) {
 	assert.False(t, result.Verify([]byte("wrong message")))
 }
 
+func TestMultiEd25519TransactionAuthenticator_NilSafety(t *testing.T) {
+	// Verify must not panic on a partially-constructed value.
+	assert.False(t, (&MultiEd25519TransactionAuthenticator{}).Verify([]byte("x")))
+	assert.False(t, (&MultiEd25519TransactionAuthenticator{Sender: &AccountAuthenticator{}}).Verify([]byte("x")))
+
+	// MarshalBCS must report a serializer error rather than panic.
+	_, err := bcs.Serialize(&MultiEd25519TransactionAuthenticator{})
+	require.Error(t, err)
+
+	_, err = bcs.Serialize(&MultiEd25519TransactionAuthenticator{Sender: &AccountAuthenticator{}})
+	require.Error(t, err)
+}
+
 func TestMultiEd25519TransactionAuthenticator_SignedTransactionRoundTrip(t *testing.T) {
 	msg := []byte("signing message")
 	auth := makeMultiEd25519Authenticator(t, msg)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR evaluates the v2 SDK against the Aptos TypeScript SDK and fixes a set of cases where the v2 SDK **exports/advertises functionality that does not actually work**, plus meaningfully expands test coverage. The focus is on making the existing public API behave as documented, each with unit-test coverage.

## Functionality fixes

### 1. Retry & rate-limit handling are now wired in (`retry.go`, `node_client.go`)
`WithRetry`, `WithRetryConfig`, and `WithRateLimitHandling` were stored on `ClientConfig` but never applied — silent no-ops despite being prominently documented in the README.

Added an `HTTPDoer` middleware that:
- retries transient failures (network errors + configured retryable status codes) with exponential backoff and jitter,
- honors the `Retry-After` header (capped by `MaxWaitTime`) on HTTP 429 when rate-limit handling is enabled,
- re-buffers request bodies on retry (so POSTs like `view`/`submit` retry correctly),
- respects context cancellation,
- is a no-op pass-through when none of the options are set, so the common path is unaffected.

### 2. `Account.ToAIP80()` now works for SingleSigner-wrapped keys (`account/account.go`, `internal/crypto/single_key.go`)
`ToAIP80()` previously returned an error for any account whose key was wrapped in a `SingleSigner` (Secp256k1, and Ed25519 created via `NewEd25519SingleKey`), breaking the documented `FromAIP80`/`ToAIP80` round trip for one of the two main key types. Exposed the inner signer via `SingleSigner.Inner()` and unwrap it in `ToAIP80()`.

### 3. Legacy MultiEd25519 transaction authenticator support (`transaction_types.go`)
The MultiEd25519 transaction-authenticator variant (1) had a constant but no type or deserialization support — `deserializeTransactionAuthenticator` errored on variant 1, so signed transactions using the legacy on-chain multisig scheme could not be decoded. Added `MultiEd25519TransactionAuthenticator` (mirroring `Ed25519TransactionAuthenticator`) and handled variant 1 in the deserializer.

## Test coverage additions

- **`testutil.FakeClient` view stubbing**: added `WithViewResult` (keyed by bare or fully-qualified function name) and `WithViewFunc`, since `View` previously could only return empty/error — making view-parsing code untestable.
- **ANS client tests**: new tests for `Resolve`, `GetNameInfo`, `GetPrimaryName`, `IsAvailable` covering success, not-found, expired, malformed-response, and error-propagation paths. **ANS package coverage: ~45% → ~93%.**
- **Retry middleware tests**: direct unit tests for `maxAttempts`/`shouldRetry`/`retryAfter`/`backoff` and integration tests for network-error retries, rate-limit-only behavior, body replay, context cancellation, and `WithRetryConfig`. **retry.go helpers now 88–100% covered.**
- **AIP-80 / MultiEd25519** round-trip tests (from the fixes above).

## Testing
- `go build ./...`
- `go test -short -race ./...` — all packages pass
- `gofumpt -l .` — clean
- `golangci-lint run` — no new warnings in changed files (pre-existing warning counts unchanged)

## Evaluation notes
A broader gap analysis against the TS SDK identified additional missing/partial areas (dedicated FungibleAsset/DigitalAsset/Object/Staking/Indexer clients, and full keyless ZK signing). Those are larger, network-dependent efforts better tracked separately; this PR concentrates on correctness of already-exposed APIs and their test coverage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9d633ac-aa3f-4240-b759-7d1fadc44376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9d633ac-aa3f-4240-b759-7d1fadc44376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

