### PR TITLE
Document Cursor Cloud development setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,25 +7,25 @@ This is a Go SDK (library) for the Aptos blockchain. There are two separate Go m
 - **v1** (root `/`): `github.com/aptos-labs/aptos-go-sdk`
 - **v2** (`/v2/`): `github.com/aptos-labs/aptos-go-sdk/v2`
 
-Each has its own `go.mod` and must be managed independently (`go mod tidy`, `go test`, etc.).
+Each has its own `go.mod` and must be managed independently (`go mod tidy`, `go test`, etc.). Both modules currently declare Go 1.25.0 with toolchain `go1.25.10`.
 
 ### Running tests
 
 - **Unit tests only** (no network needed): `go test -short ./...` (run from root for v1, from `v2/` for v2)
 - **Full v1 tests** require a local Aptos testnet via `aptos node run-localnet --with-indexer-api` (Aptos CLI not pre-installed in cloud VMs)
-- **v2 integration tests** hit public Aptos networks (no local infra needed): `go test -v -run "TestIntegration_" -timeout 120s ./v2/...`
-- **v2 faucet tests** require env var: `APTOS_TEST_FAUCET=1 go test -v -run "TestIntegrationFaucet_" ./v2/...`
+- **v2 integration tests** hit public Aptos networks (no local infra needed): from `v2/`, run `go test -v -run "TestIntegration_" -timeout 120s ./...`
+- **v2 faucet tests** require env var: from `v2/`, run `APTOS_TEST_FAUCET=1 go test -v -run "TestIntegrationFaucet_" ./...`
 
 ### Lint and format
 
-Both must pass before committing (see `CLAUDE.md`):
+Use the commands in `CLAUDE.md`/`mise.toml`:
 
 ```bash
 gofumpt -l -w .
 golangci-lint run
 ```
 
-`golangci-lint` has pre-existing warnings in both v1 and v2; these are not regressions.
+Root `golangci-lint run` passes. `golangci-lint run` from `v2/` currently reports a pre-existing baseline of lint warnings; these are not regressions.
 
 ### Build
 
@@ -33,6 +33,7 @@ Standard `go build ./...` from root and from `v2/`.
 
 ### Gotchas
 
-- `~/go/bin` must be on `PATH` for `gofumpt` and `golangci-lint` to work. The update script ensures this via `~/.bashrc`.
-- The v2 module's `go.mod` references v1 as a published module (`github.com/aptos-labs/aptos-go-sdk v1.11.0`), not a local replace. Changes to v1 types do not automatically propagate to v2.
+- Cloud VMs may not have `mise`; the startup update script installs `gofumpt` and `golangci-lint` into `$(go env GOPATH)/bin`, so export that directory on `PATH` (or call the tools by full path) before lint/format commands.
+- The root `examples/transfer_coin` demo submits two devnet transfers after one faucet funding. If devnet gas is high, the second transfer can fail with `INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE`; for a smoke test, use a one-transfer variant or increase funding in a throwaway copy.
+- The v2 module's `go.mod` references v1 as a published module (`github.com/aptos-labs/aptos-go-sdk v1.13.0`), not a local replace. Changes to v1 types do not automatically propagate to v2.
 - v2 network presets are `aptos.Testnet`, `aptos.Mainnet`, `aptos.Devnet`, `aptos.Localnet` (not `TestnetConfig`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Each has its own `go.mod` and must be managed independently (`go mod tidy`, `go 
 ### Running tests
 
 - **Unit tests only** (no network needed): `go test -short ./...` (run from root for v1, from `v2/` for v2)
-- **Full v1 tests** require a local Aptos testnet via `aptos node run-localnet --with-indexer-api` (Aptos CLI not pre-installed in cloud VMs)
+- **Full v1 tests** require a local Aptos testnet via `aptos node run-localnet --with-indexer-api` (Aptos CLI and Docker are not pre-installed in cloud VMs)
 - **v2 integration tests** hit public Aptos networks (no local infra needed): from `v2/`, run `go test -v -run "TestIntegration_" -timeout 120s ./...`
 - **v2 faucet tests** require env var: from `v2/`, run `APTOS_TEST_FAUCET=1 go test -v -run "TestIntegrationFaucet_" ./...`
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Document durable Cursor Cloud setup notes discovered while preparing the development environment:
- both Go modules currently use Go 1.25/toolchain go1.25.10
- v2 integration/faucet test commands should be run from `v2/`
- Cloud VMs may need `$(go env GOPATH)/bin` on `PATH` for installed Go tools
- full v1 localnet tests need Aptos CLI and Docker, which are not preinstalled in Cloud VMs
- the root transfer example can fail its second devnet transfer if gas consumes the initial faucet amount
- v2 depends on published v1 module version `v1.13.0`

### Test Plan
- `go install mvdan.cc/gofumpt@v0.10.0`
- `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1`
- `go mod download`
- `go -C v2 mod download`
- `gofumpt -l -e .`
- `golangci-lint run`
- `golangci-lint run` from `v2/` (reports pre-existing baseline issues)
- `go test -short ./...`
- `go test -short ./...` from `v2/`
- `go test -v -run "TestIntegration_" -timeout 120s ./...` from `v2/`
- `go build ./...`
- `go build ./...` from `v2/`
- one-shot devnet transfer smoke test: funded generated account, submitted transfer, waited for success, verified receiver balance increased

### Related Links

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2f674c6-6da2-425f-8250-8591e6e22e0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2f674c6-6da2-425f-8250-8591e6e22e0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

