### PR TITLE
Fix math.MaxUint32 overflow on 32-bit systems in util.go

### DIFF
--- a/bcs/deserializer.go
+++ b/bcs/deserializer.go
@@ -2,6 +2,7 @@ package bcs
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -10,7 +11,7 @@ import (
 
 func uleb128ToInt(length uint32) (int, error) {
 	if uint64(length) > uint64(math.MaxInt) {
-		return 0, fmt.Errorf("uleb128 length overflows int")
+		return 0, errors.New("uleb128 length overflows int")
 	}
 	return int(length), nil
 }
@@ -359,7 +360,7 @@ func DeserializeSequenceWithFunction[T any](des *Deserializer, deserialize func(
 	}
 
 	out := make([]T, lengthInt)
-	for i := 0; i < lengthInt; i++ {
+	for i := range lengthInt {
 		deserialize(des, &out[i])
 
 		if des.Error() != nil {

--- a/bcs/deserializer.go
+++ b/bcs/deserializer.go
@@ -3,9 +3,17 @@ package bcs
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"math/big"
 	"slices"
 )
+
+func uleb128ToInt(length uint32) (int, error) {
+	if uint64(length) > uint64(math.MaxInt) {
+		return 0, fmt.Errorf("uleb128 length overflows int")
+	}
+	return int(length), nil
+}
 
 // Deserializer is a type to deserialize a known set of bytes.
 // The reader must know the types, as the format is not self-describing.
@@ -268,8 +276,14 @@ func (des *Deserializer) ReadBytes() []byte {
 		return nil
 	}
 
-	dest := make([]byte, length)
-	des.readBytes("bytes", int(length), dest)
+	lengthInt, err := uleb128ToInt(length)
+	if err != nil {
+		des.setError("%s", err.Error())
+		return nil
+	}
+
+	dest := make([]byte, lengthInt)
+	des.readBytes("bytes", lengthInt, dest)
 	return dest
 }
 
@@ -337,8 +351,15 @@ func DeserializeSequenceWithFunction[T any](des *Deserializer, deserialize func(
 	if des.Error() != nil {
 		return nil
 	}
-	out := make([]T, length)
-	for i := range length {
+
+	lengthInt, err := uleb128ToInt(length)
+	if err != nil {
+		des.setError("%s", err.Error())
+		return nil
+	}
+
+	out := make([]T, lengthInt)
+	for i := 0; i < lengthInt; i++ {
 		deserialize(des, &out[i])
 
 		if des.Error() != nil {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -69,7 +69,7 @@ func UintToU16(u uint) (uint16, error) {
 
 func UintToU32(u uint) (uint32, error) {
 	if u > math.MaxUint32 {
-		return 0, fmt.Errorf("u %d is greater than %d", u, math.MaxUint32)
+		return 0, fmt.Errorf("u %d is greater than %d", u, uint64(math.MaxUint32))
 	}
 	val := uint32(u)
 	return val, nil
@@ -117,10 +117,11 @@ func IntToU16(u int) (uint16, error) {
 }
 
 func IntToU32(u int) (uint32, error) {
-	if u > math.MaxUint32 {
-		return 0, fmt.Errorf("u %d is greater than %d", u, math.MaxUint32)
-	} else if u < 0 {
+	if u < 0 {
 		return 0, fmt.Errorf("u %d is less than 0", u)
+	}
+	if uint64(u) > math.MaxUint32 {
+		return 0, fmt.Errorf("u %d is greater than %d", u, uint64(math.MaxUint32))
 	}
 
 	val := uint32(u)

--- a/spec_bcs_test.go
+++ b/spec_bcs_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -87,11 +88,12 @@ func givenU16(ctx context.Context, input int) (context.Context, error) {
 	return context.WithValue(ctx, godogsCtxKey{}, uint16(input)), nil
 }
 
-func givenU32(ctx context.Context, input int) (context.Context, error) {
-	if input < 0 || input > 4294967295 {
+func givenU32(ctx context.Context, input string) (context.Context, error) {
+	val, err := strconv.ParseUint(input, 10, 32)
+	if err != nil {
 		return nil, errors.New("u32 must be between 0 and 4294967295")
 	}
-	return context.WithValue(ctx, godogsCtxKey{}, uint32(input)), nil
+	return context.WithValue(ctx, godogsCtxKey{}, uint32(val)), nil
 }
 
 func givenU64(ctx context.Context, input string) (context.Context, error) {
@@ -856,11 +858,12 @@ func u16Result(ctx context.Context, expected int) error {
 	return nil
 }
 
-func u32Result(ctx context.Context, expected int) error {
-	expectedU32, err := util.IntToU32(expected)
+func u32Result(ctx context.Context, expected string) error {
+	val, err := strconv.ParseUint(expected, 10, 32)
 	if err != nil {
 		return errors.New("invalid value for U32")
 	}
+	expectedU32 := uint32(val)
 
 	result, ok := ctx.Value(godogsCtxKey{}).(uint32)
 	if !ok {

--- a/typeConversion_test.go
+++ b/typeConversion_test.go
@@ -1296,13 +1296,13 @@ func TestConvertToI64(t *testing.T) {
 	}{
 		{
 			name:    "int positive",
-			input:   100000000000,
+			input:   int64(100000000000),
 			want:    100000000000,
 			wantErr: false,
 		},
 		{
 			name:    "int negative",
-			input:   -100000000000,
+			input:   int64(-100000000000),
 			want:    -100000000000,
 			wantErr: false,
 		},

--- a/typeConversion_test.go
+++ b/typeConversion_test.go
@@ -1295,13 +1295,13 @@ func TestConvertToI64(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "int positive",
+			name:    "int64 positive",
 			input:   int64(100000000000),
 			want:    100000000000,
 			wantErr: false,
 		},
 		{
-			name:    "int negative",
+			name:    "int64 negative",
 			input:   int64(-100000000000),
 			want:    -100000000000,
 			wantErr: false,

--- a/v2/internal/bcs/bcs.go
+++ b/v2/internal/bcs/bcs.go
@@ -62,6 +62,9 @@ var (
 	ErrInvalidOptionLen = errors.New("bcs: option must have 0 or 1 elements")
 )
 
+// maxU32Length is the maximum value representable as a BCS u32 length prefix.
+const maxU32Length = uint64(0xFFFFFFFF)
+
 // serializerPool provides reusable Serializers to reduce allocations.
 var serializerPool = sync.Pool{
 	New: func() interface{} {

--- a/v2/internal/bcs/deserializer.go
+++ b/v2/internal/bcs/deserializer.go
@@ -226,7 +226,7 @@ func (des *Deserializer) Uleb128() uint32 {
 		}
 	}
 
-	if result > 0xFFFFFFFF {
+	if result > maxU32Length {
 		des.SetError(ErrOverflow)
 		return 0
 	}

--- a/v2/internal/bcs/deserializer.go
+++ b/v2/internal/bcs/deserializer.go
@@ -3,9 +3,17 @@ package bcs
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"math/big"
 	"slices"
 )
+
+func uleb128ToInt(length uint32) (int, error) {
+	if uint64(length) > uint64(math.MaxInt) {
+		return 0, ErrOverflow
+	}
+	return int(length), nil
+}
 
 // Deserializer reads BCS-encoded data from a buffer.
 type Deserializer struct {
@@ -245,7 +253,13 @@ func (des *Deserializer) ReadBytes() []byte {
 		return nil
 	}
 
-	return des.ReadFixedBytes(int(length))
+	lengthInt, err := uleb128ToInt(length)
+	if err != nil {
+		des.SetError(err)
+		return nil
+	}
+
+	return des.ReadFixedBytes(lengthInt)
 }
 
 // ReadBoundedBytes deserializes a byte slice with bounds checking BEFORE allocation.
@@ -261,17 +275,23 @@ func (des *Deserializer) ReadBoundedBytes(minLen, maxLen int) []byte {
 		return nil
 	}
 
-	// Validate bounds BEFORE allocation to prevent DoS
-	if int(length) < minLen {
-		des.SetError(fmt.Errorf("byte slice too short: %d < %d", length, minLen))
-		return nil
-	}
-	if int(length) > maxLen {
-		des.SetError(fmt.Errorf("byte slice too large: %d > %d", length, maxLen))
+	lengthInt, err := uleb128ToInt(length)
+	if err != nil {
+		des.SetError(err)
 		return nil
 	}
 
-	return des.ReadFixedBytes(int(length))
+	// Validate bounds BEFORE allocation to prevent DoS
+	if lengthInt < minLen {
+		des.SetError(fmt.Errorf("byte slice too short: %d < %d", lengthInt, minLen))
+		return nil
+	}
+	if lengthInt > maxLen {
+		des.SetError(fmt.Errorf("byte slice too large: %d > %d", lengthInt, maxLen))
+		return nil
+	}
+
+	return des.ReadFixedBytes(lengthInt)
 }
 
 // ReadBoundedString deserializes a string with bounds checking BEFORE allocation.
@@ -286,13 +306,19 @@ func (des *Deserializer) ReadBoundedString(maxLen int) string {
 		return ""
 	}
 
-	// Validate bounds BEFORE allocation
-	if int(length) > maxLen {
-		des.SetError(fmt.Errorf("string too large: %d > %d", length, maxLen))
+	lengthInt, err := uleb128ToInt(length)
+	if err != nil {
+		des.SetError(err)
 		return ""
 	}
 
-	return string(des.ReadFixedBytes(int(length)))
+	// Validate bounds BEFORE allocation
+	if lengthInt > maxLen {
+		des.SetError(fmt.Errorf("string too large: %d > %d", lengthInt, maxLen))
+		return ""
+	}
+
+	return string(des.ReadFixedBytes(lengthInt))
 }
 
 // ReadString deserializes a UTF-8 string with a ULEB128 length prefix.
@@ -354,8 +380,14 @@ func DeserializeSequence[T Unmarshaler](des *Deserializer, newItem func() T) []T
 		return nil
 	}
 
-	result := make([]T, length)
-	for i := range length {
+	lengthInt, err := uleb128ToInt(length)
+	if err != nil {
+		des.SetError(err)
+		return nil
+	}
+
+	result := make([]T, lengthInt)
+	for i := 0; i < lengthInt; i++ {
 		result[i] = newItem()
 		result[i].UnmarshalBCS(des)
 		if des.err != nil {
@@ -376,8 +408,14 @@ func DeserializeSequenceFunc[T any](des *Deserializer, deserialize func(*Deseria
 		return nil
 	}
 
-	result := make([]T, length)
-	for i := range length {
+	lengthInt, err := uleb128ToInt(length)
+	if err != nil {
+		des.SetError(err)
+		return nil
+	}
+
+	result := make([]T, lengthInt)
+	for i := 0; i < lengthInt; i++ {
 		result[i] = deserialize(des)
 		if des.err != nil {
 			return nil

--- a/v2/internal/bcs/deserializer_intmax_32bit_test.go
+++ b/v2/internal/bcs/deserializer_intmax_32bit_test.go
@@ -1,4 +1,4 @@
-//go:build 386 || arm || mips || mipsle || wasm
+//go:build 386 || arm || riscv || ppc
 
 package bcs
 

--- a/v2/internal/bcs/deserializer_intmax_32bit_test.go
+++ b/v2/internal/bcs/deserializer_intmax_32bit_test.go
@@ -1,0 +1,24 @@
+//go:build 386 || arm || mips || mipsle || wasm
+
+package bcs
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadBytesExceedsIntMax(t *testing.T) {
+	t.Parallel()
+
+	ser := NewSerializer()
+	ser.Uleb128(uint32(math.MaxInt32) + 1)
+	require.NoError(t, ser.Error())
+
+	des := NewDeserializer(ser.ToBytes())
+	result := des.ReadBytes()
+	assert.Nil(t, result)
+	assert.ErrorIs(t, des.Error(), ErrOverflow)
+}

--- a/v2/internal/bcs/deserializer_intmax_32bit_test.go
+++ b/v2/internal/bcs/deserializer_intmax_32bit_test.go
@@ -1,4 +1,4 @@
-//go:build 386 || arm || riscv || ppc
+//go:build 386 || arm || riscv || ppc || wasm
 
 package bcs
 

--- a/v2/internal/bcs/reflect.go
+++ b/v2/internal/bcs/reflect.go
@@ -84,7 +84,7 @@ func marshalValue(ser *Serializer, v reflect.Value) error {
 
 func marshalSlice(ser *Serializer, v reflect.Value) error {
 	length := v.Len()
-	if length > 0xFFFFFFFF {
+	if uint64(length) > maxU32Length {
 		return ErrOverflow
 	}
 	ser.Uleb128(uint32(length))

--- a/v2/internal/bcs/reflect.go
+++ b/v2/internal/bcs/reflect.go
@@ -268,8 +268,14 @@ func unmarshalSlice(des *Deserializer, v reflect.Value) error {
 		return des.err
 	}
 
-	slice := reflect.MakeSlice(v.Type(), int(length), int(length))
-	for i := 0; i < int(length); i++ {
+	lengthInt, err := uleb128ToInt(length)
+	if err != nil {
+		des.SetError(err)
+		return err
+	}
+
+	slice := reflect.MakeSlice(v.Type(), lengthInt, lengthInt)
+	for i := 0; i < lengthInt; i++ {
 		if err := unmarshalValue(des, slice.Index(i)); err != nil {
 			return err
 		}

--- a/v2/internal/bcs/serializer.go
+++ b/v2/internal/bcs/serializer.go
@@ -169,7 +169,7 @@ func (ser *Serializer) Uleb128(v uint32) {
 
 // WriteBytes serializes a byte slice with a ULEB128 length prefix.
 func (ser *Serializer) WriteBytes(v []byte) {
-	if len(v) > 0xFFFFFFFF {
+	if uint64(len(v)) > maxU32Length {
 		ser.SetError(ErrOverflow)
 		return
 	}
@@ -198,7 +198,7 @@ func (ser *Serializer) Struct(v Marshaler) {
 
 // SerializeSequence serializes a slice of Marshaler values with a length prefix.
 func SerializeSequence[T Marshaler](ser *Serializer, items []T) {
-	if len(items) > 0xFFFFFFFF {
+	if uint64(len(items)) > maxU32Length {
 		ser.SetError(ErrOverflow)
 		return
 	}
@@ -214,7 +214,7 @@ func SerializeSequence[T Marshaler](ser *Serializer, items []T) {
 
 // SerializeSequenceFunc serializes a slice using a custom serialization function.
 func SerializeSequenceFunc[T any](ser *Serializer, items []T, serialize func(*Serializer, T)) {
-	if len(items) > 0xFFFFFFFF {
+	if uint64(len(items)) > maxU32Length {
 		ser.SetError(ErrOverflow)
 		return
 	}

--- a/v2/internal/util/util.go
+++ b/v2/internal/util/util.go
@@ -145,7 +145,7 @@ func IntToU16(u int) (uint16, error) {
 
 // IntToU32 converts int to uint32 with bounds checking.
 func IntToU32(u int) (uint32, error) {
-	if u > math.MaxUint32 || u < 0 {
+	if u < 0 || uint64(u) > math.MaxUint32 {
 		return 0, fmt.Errorf("value %d out of uint32 range", u)
 	}
 	return uint32(u), nil

--- a/v2/internal/util/util_inttou32_32bit_test.go
+++ b/v2/internal/util/util_inttou32_32bit_test.go
@@ -1,0 +1,19 @@
+//go:build 386 || arm || mips || mipsle
+
+package util
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntToU32_maxInt32(t *testing.T) {
+	t.Parallel()
+
+	got, err := IntToU32(math.MaxInt32)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(math.MaxInt32), got)
+}

--- a/v2/internal/util/util_inttou32_32bit_test.go
+++ b/v2/internal/util/util_inttou32_32bit_test.go
@@ -1,4 +1,4 @@
-//go:build 386 || arm || mips || mipsle
+//go:build 386 || arm || mips || mipsle || wasm
 
 package util
 

--- a/v2/internal/util/util_inttou32_32bit_test.go
+++ b/v2/internal/util/util_inttou32_32bit_test.go
@@ -1,4 +1,4 @@
-//go:build 386 || arm || riscv || ppc
+//go:build 386 || arm || riscv || ppc || wasm
 
 package util
 

--- a/v2/internal/util/util_inttou32_32bit_test.go
+++ b/v2/internal/util/util_inttou32_32bit_test.go
@@ -1,4 +1,4 @@
-//go:build 386 || arm || mips || mipsle || wasm
+//go:build 386 || arm || riscv || ppc
 
 package util
 

--- a/v2/internal/util/util_inttou32_64bit_test.go
+++ b/v2/internal/util/util_inttou32_64bit_test.go
@@ -1,4 +1,4 @@
-//go:build !(386 || arm || mips || mipsle || wasm)
+//go:build amd64 || arm64 || riscv64 || ppc64 || ppc64le
 
 package util
 

--- a/v2/internal/util/util_inttou32_64bit_test.go
+++ b/v2/internal/util/util_inttou32_64bit_test.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64 || ppc64 || ppc64le || mips64 || mips64le || loong64 || riscv64
+//go:build !(386 || arm || mips || mipsle || wasm)
 
 package util
 

--- a/v2/internal/util/util_inttou32_64bit_test.go
+++ b/v2/internal/util/util_inttou32_64bit_test.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64 || riscv64 || ppc64 || ppc64le
+//go:build amd64 || arm64 || riscv64 || ppc64 || ppc64le || wasm64
 
 package util
 

--- a/v2/internal/util/util_inttou32_64bit_test.go
+++ b/v2/internal/util/util_inttou32_64bit_test.go
@@ -1,0 +1,22 @@
+//go:build amd64 || arm64 || ppc64 || ppc64le || mips64 || mips64le || loong64 || riscv64
+
+package util
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntToU32_maxUint32(t *testing.T) {
+	t.Parallel()
+
+	got, err := IntToU32(int(math.MaxUint32))
+	require.NoError(t, err)
+	assert.Equal(t, uint32(math.MaxUint32), got)
+
+	_, err = IntToU32(int(math.MaxUint32) + 1)
+	assert.Error(t, err)
+}

--- a/v2/internal/util/util_test.go
+++ b/v2/internal/util/util_test.go
@@ -258,8 +258,6 @@ func TestIntToU32(t *testing.T) {
 		wantErr bool
 	}{
 		{"zero", 0, 0, false},
-		{"max", math.MaxUint32, math.MaxUint32, false},
-		{"overflow", math.MaxUint32 + 1, 0, true},
 		{"negative", -1, 0, true},
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

On 32-bit platforms (`GOARCH=386`, `arm`, etc.), `int` is only 32 bits signed, so `math.MaxUint32` (4294967295) and `0xFFFFFFFF` cannot be used directly in `int` comparisons or as `%d` arguments to `fmt.Errorf`. This caused compile failures on TEEs, Raspberry Pi, and other 32-bit targets.

This change:
- Compares via `uint64(u) > math.MaxUint32` in `IntToU32` instead of comparing against `int`
- Casts `math.MaxUint32` to `uint64` in `UintToU32` error messages
- Applies the same `IntToU32` fix in v2
- Adds a shared `maxU32Length` constant in v2 BCS and uses `uint64(len(...))` for length overflow checks in serializer and reflect paths
- Adds `uleb128ToInt` helper to reject lengths that overflow `int` before slice allocation in deserializers (v1 and v2), addressing DoS risk from negative `make()` lengths on malformed input
- Fixes v1 BDD u32 step handlers to parse values from strings (matching u64/u128)
- Fixes v1 test int literals that overflow on 32-bit
- Uses arch-specific test build tags limited to supported targets: x86 (`386`/`amd64`), ARM (`arm`/`arm64`), RISC-V (`riscv`/`riscv64`), PowerPC (`ppc`/`ppc64`/`ppc64le`), and WebAssembly (`wasm`/`wasm64`)

### Test Plan

- `GOARCH=386 go build ./internal/util/...` (v1)
- `GOARCH=386 go build ./internal/bcs/...` (v2)
- `GOARCH=386 go test -short ./...` (v1)
- `GOARCH=386 go test -short ./internal/bcs/... ./internal/util/...` (v2)
- `go test -short ./internal/bcs/... ./internal/util/...` (v2, amd64)

### Related Links

Fixes compile errors from using `math.MaxUint32` and `0xFFFFFFFF` with `int` on 32-bit systems.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47e7f7fa-daa1-4402-bc7f-4c9e6c6a9e95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47e7f7fa-daa1-4402-bc7f-4c9e6c6a9e95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

