### PR TITLE
Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/actions/run-go-tests/action.yaml
+++ b/.github/actions/run-go-tests/action.yaml
@@ -6,13 +6,13 @@ description: |
 runs:
   using: composite
   steps:
-    - uses: jdx/mise-action@v4
+    - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
       with:
         install_args: "go"
         cache: true
     # Run a local testnet in the background. After this action runs the local testnet
     # should be up and queryable. This also installs node and pnpm for us.
-    - uses: aptos-labs/actions/run-local-testnet@main
+    - uses: aptos-labs/actions/run-local-testnet@fdd3a3a628c840d5c35086a87e9cc3141b635505 # main@2026-05-20
       with:
         PNPM_VERSION: 8.9.0
 

--- a/.github/actions/run-gofumpt/action.yaml
+++ b/.github/actions/run-gofumpt/action.yaml
@@ -5,7 +5,7 @@ description: |
 runs:
   using: composite
   steps:
-    - uses: jdx/mise-action@v4
+    - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
       with:
         install_args: "go gofumpt"
         cache: true

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Generate Coverage Report
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ env.GIT_SHA }}
 
@@ -35,7 +35,7 @@ jobs:
       # to the single source of truth (v2/go.mod), so bumping v2's
       # minimum Go version automatically updates CI.
       - name: Set up Go (pinned to v2/go.mod)
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: v2/go.mod
           cache: true
@@ -55,7 +55,7 @@ jobs:
 
       # Upload v2 coverage to Codecov
       - name: Upload v2 coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           files: ./v2/coverage.out
           flags: v2
@@ -67,7 +67,7 @@ jobs:
 
       # Upload v1 coverage to Codecov (if available)
       - name: Upload v1 coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         if: hashFiles('coverage-v1.out') != ''
         with:
           files: ./coverage-v1.out

--- a/.github/workflows/gofumpt-lint.yaml
+++ b/.github/workflows/gofumpt-lint.yaml
@@ -16,5 +16,5 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/run-gofumpt

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -16,8 +16,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           install_args: "go golangci-lint"
           cache: true

--- a/.github/workflows/run-go-tests.yaml
+++ b/.github/workflows/run-go-tests.yaml
@@ -13,7 +13,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ env.GIT_SHA }}
       - uses: ./.github/actions/run-go-tests


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Replace floating version tags (`@v6`, `@v5`, `@v4`, `@main`) with immutable commit SHAs for all third-party GitHub Actions. Each pin uses the latest release commit that is at least 3 days old, reducing supply-chain risk from freshly published action versions.

| Action | Previous ref | Pinned SHA | Version |
|--------|-------------|------------|---------|
| `actions/checkout` | `@v6` | `df4cb1c0…` | v6.0.3 |
| `actions/setup-go` | `@v5` | `40f1582b…` | v5.6.0 |
| `codecov/codecov-action` | `@v5` | `0fb71748…` | v5.5.5 |
| `jdx/mise-action` | `@v4` | `e6a8b397…` | v4.2.0 |
| `aptos-labs/actions/run-local-testnet` | `@main` | `fdd3a3a6…` | main (2026-05-20) |

Local composite actions (`./.github/actions/*`) are unchanged since they are part of this repository.

### Test Plan

- CI workflows will validate the pinned actions on merge.
- No application code changes; only workflow and composite action references updated.

### Related Links

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f229f-8b68-7ceb-8227-a109b4da9417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f229f-8b68-7ceb-8227-a109b4da9417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

