### PR TITLE
release: prep v1.14.0 and v2.2.0 changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 
 # Unreleased
 
+# v1.15.0 (7/2/2026)
+
 - [`Feature`] Add BIP-39 mnemonic and BIP-44 derivation path support for Ed25519 accounts
   - `NewEd25519AccountFromMnemonic` and `NewEd25519AccountFromDerivationPath` for wallet import
   - `crypto.ValidateMnemonic`, `crypto.DefaultDerivationPath`, and `crypto.Ed25519PrivateKeyFromDerivationPath`
   - SLIP-0010 hardened derivation on the standard Aptos path `m/44'/637'/0'/0'/0'`
+- [`Fix`] Fix 32-bit overflow in `IntToU32` — values above `math.MaxInt32` now return an error instead of wrapping on 32-bit systems
+- [`Fix`] Fix BCS deserializer uleb128 length conversion to safely reject values that overflow `int` on 32-bit systems
 
 # v1.14.0 (5/26/2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 
 # Unreleased
 
-# v1.15.0 (7/2/2026)
+# v1.14.0 (7/2/2026)
 
 - [`Feature`] Add BIP-39 mnemonic and BIP-44 derivation path support for Ed25519 accounts
   - `NewEd25519AccountFromMnemonic` and `NewEd25519AccountFromDerivationPath` for wallet import
@@ -13,9 +13,6 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
   - SLIP-0010 hardened derivation on the standard Aptos path `m/44'/637'/0'/0'/0'`
 - [`Fix`] Fix 32-bit overflow in `IntToU32` — values above `math.MaxInt32` now return an error instead of wrapping on 32-bit systems
 - [`Fix`] Fix BCS deserializer uleb128 length conversion to safely reject values that overflow `int` on 32-bit systems
-
-# v1.14.0 (5/26/2026)
-
 - [`Security`] Upgrade Go toolchain from go1.24.2 to go1.25.10, resolving 37 stdlib CVEs (Go 1.24 is EOL)
 - [`Security`] Upgrade `golang.org/x/crypto` v0.46.0 → v0.52.0
 - [`Security`] Upgrade `github.com/decred/dcrd/dcrec/secp256k1/v4` v4.4.0 → v4.4.1

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -5,11 +5,24 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 
 # Unreleased
 
+# v2.3.0 (7/2/2026)
+
 - [`Feature`] Add BIP-39 mnemonic and BIP-44 derivation path support for Ed25519 accounts
   - `account.FromMnemonic` and `account.FromDerivationPath` for wallet import
   - Optional BIP-39 passphrase and SingleKey authentication scheme via `account.DerivationConfig`
   - `aptos.ValidateMnemonic`, `aptos.DefaultDerivationPath`, and `aptos.Ed25519PrivateKeyFromDerivationPath`
   - SLIP-0010 hardened derivation on the standard Aptos path `m/44'/637'/0'/0'/0'`
+- [`Feature`] Add automatic retry middleware to the node client with configurable backoff, rate-limit (429) handling, and `MaxRetries`
+- [`Feature`] Support legacy `MultiEd25519` transaction authenticators alongside fee-payer and multi-agent flows
+- [`Fix`] Fix AIP-80 private key export for `SingleSigner`-wrapped keys
+- [`Fix`] Guard `MultiEd25519TransactionAuthenticator` against nil sender authenticator
+- [`Fix`] Validate inner authenticator type in `MultiEd25519` BCS marshaling
+- [`Fix`] Make `FakeClient` view-result stubs return defensive copies to prevent mutation
+- [`Fix`] Honor explicit `MaxRetries == 0` in retry middleware to disable retries
+- [`Fix`] Keep `MaxRetries` as a strict cap on error/status retries
+- [`Fix`] Fix 32-bit overflow in BCS length checks and `IntToU32` conversion on 32-bit systems
+- [`Perf`] Use a stoppable timer for retry backoff to avoid goroutine leaks on context cancellation
+- [`Dependency`] Upgrade `github.com/aptos-labs/aptos-go-sdk` v1.13.0 → v1.15.0
 
 # v2.2.0 (5/26/2026)
 

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -5,7 +5,7 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 
 # Unreleased
 
-# v2.3.0 (7/2/2026)
+# v2.2.0 (7/2/2026)
 
 - [`Feature`] Add BIP-39 mnemonic and BIP-44 derivation path support for Ed25519 accounts
   - `account.FromMnemonic` and `account.FromDerivationPath` for wallet import
@@ -22,16 +22,12 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 - [`Fix`] Keep `MaxRetries` as a strict cap on error/status retries
 - [`Fix`] Fix 32-bit overflow in BCS length checks and `IntToU32` conversion on 32-bit systems
 - [`Perf`] Use a stoppable timer for retry backoff to avoid goroutine leaks on context cancellation
-- [`Dependency`] Upgrade `github.com/aptos-labs/aptos-go-sdk` v1.13.0 → v1.15.0
-
-# v2.2.0 (5/26/2026)
-
 - [`Security`] Upgrade Go toolchain from go1.25.0 to go1.25.10, resolving 18 stdlib CVEs
 - [`Security`] Upgrade `golang.org/x/crypto` v0.46.0 → v0.52.0
 - [`Security`] Upgrade `github.com/decred/dcrd/dcrec/secp256k1/v4` v4.4.0 → v4.4.1
 - [`Dependency`] Upgrade `filippo.io/edwards25519` v1.1.1 → v1.2.0
-- [`Dependency`] Upgrade `github.com/aptos-labs/aptos-go-sdk` v1.11.0 → v1.14.0
-- [`Dependency`] Upgrade `github.com/hasura/go-graphql-client` v0.14.4 → v0.15.1
+- [`Dependency`] Upgrade `github.com/aptos-labs/aptos-go-sdk` v1.13.0 → v1.14.0
+- [`Dependency`] Upgrade `github.com/hasura/go-graphql-client` v0.14.4 → v0.16.0
 - [`Dependency`] Upgrade `golang.org/x/sys` v0.42.0 → v0.45.0
 
 # v2.1.0 (5/21/2026)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rebased on latest `main` and updated the v1.14.0 / v2.2.0 release changelogs (dated **8/4/2026**) to include changes landed since the prior prep:

- **#219** — `confidentialasset` package and examples
- **#221** — optional `v2/fasthttp` sub-module and HTTP benchmarks
- **#233** — object helpers, orderless transactions, `GetTableItem`, `AccountBalanceOf`, `AccountModules`

Also moves misplaced `confidentialasset` and SHA3-256 signing fix entries out of the v2.1.0 section into v2.2.0.

## v1.14.0 (8/4/2026)

Unchanged from prior prep: mnemonic support, 32-bit overflow fixes, security/dependency upgrades, Go 1.25 minimum.

## v2.2.0 (8/4/2026)

All prior v2.2.0 entries plus:

- Confidential fungible asset client (`confidentialasset` + `confidentialasset/native`)
- Object APIs, orderless transactions, table items, arbitrary balances, module listing
- Optional `v2/fasthttp` HTTPDoer module
- SHA3-256 signing prehash fix
- New dependency on `confidential-asset-bindings` v1.1.2

## Tagging checklist (after merge)

1. Tag and push **v1.14.0** at merge commit
2. Bump `v2/go.mod` to `github.com/aptos-labs/aptos-go-sdk@v1.14.0`, run `go mod tidy`, commit
3. Tag and push **v2/2.2.0** at the go.mod bump commit
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20f61db5-2b14-4486-886e-4930cdd78c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20f61db5-2b14-4486-886e-4930cdd78c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

