### PR TITLE
[v2] Fill SDK feature gaps: objects, orderless txns, table items, arbitrary balances, modules

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -48,8 +48,18 @@ type Client interface {
 	// AccountBalance returns the APT balance for an account.
 	AccountBalance(ctx context.Context, address AccountAddress, opts ...ResourceOption) (uint64, error)
 
+	// AccountBalanceOf returns an account's balance of an arbitrary asset,
+	// identified either by a coin type's struct id (e.g.
+	// "0x1::aptos_coin::AptosCoin") or a fungible asset metadata address
+	// (e.g. "0xa").
+	AccountBalanceOf(ctx context.Context, address AccountAddress, asset string, opts ...ResourceOption) (uint64, error)
+
 	// AccountModule returns the bytecode and ABI for a module.
 	AccountModule(ctx context.Context, address AccountAddress, moduleName string, opts ...ResourceOption) (*ModuleBytecode, error)
+
+	// AccountModules returns every Move module published under an address,
+	// following the node's pagination cursor until exhausted.
+	AccountModules(ctx context.Context, address AccountAddress, opts ...ResourceOption) ([]*ModuleBytecode, error)
 
 	// AccountTransactions returns transactions sent by an account.
 	AccountTransactions(ctx context.Context, address AccountAddress, start *uint64, limit *uint64) ([]*Transaction, error)
@@ -102,6 +112,11 @@ type Client interface {
 
 	// View executes a view function and returns the results.
 	View(ctx context.Context, payload *ViewPayload, opts ...ViewOption) ([]any, error)
+
+	// GetTableItem reads a single item from an on-chain Move table, decoding
+	// the value into result. Direct table reads are discouraged; prefer the
+	// indexer where possible.
+	GetTableItem(ctx context.Context, handle string, req TableItemRequest, result any, opts ...ResourceOption) error
 
 	// Block Operations
 

--- a/v2/compatibility/v1_v2_test.go
+++ b/v2/compatibility/v1_v2_test.go
@@ -218,6 +218,50 @@ func TestCrossVersion_EntryFunction_BCS(t *testing.T) {
 		"v1 raw tx should contain the inner EntryFunction bytes")
 }
 
+// TestCrossVersion_OrderlessInnerPayload_BCS pins v2's orderless
+// (TransactionPayload::Payload, variant 4) wire format to v1's
+// production-validated implementation. A diff here means orderless
+// transactions built by v2 would be rejected or mis-decoded on chain.
+func TestCrossVersion_OrderlessInnerPayload_BCS(t *testing.T) {
+	t.Parallel()
+
+	nonce := uint64(0xdead_beef_0000_0001)
+
+	v1Inner := &v1.TransactionInnerPayload{
+		Payload: &v1.TransactionInnerPayloadV1{
+			Executable:  v1.TransactionExecutable{Inner: buildV1EntryFunction(t)},
+			ExtraConfig: v1.TransactionExtraConfig{Inner: &v1.TransactionExtraConfigV1{ReplayProtectionNonce: &nonce}},
+		},
+	}
+
+	v1Raw := &v1.RawTransaction{
+		Sender:                     newV1Address(t, sampleAddr),
+		SequenceNumber:             ^uint64(0), // u64::MAX for orderless
+		Payload:                    v1.TransactionPayload{Payload: v1Inner},
+		MaxGasAmount:               2_000_000,
+		GasUnitPrice:               100,
+		ExpirationTimestampSeconds: 1_700_000_000,
+		ChainId:                    4,
+	}
+	v2Raw := &v2.RawTransaction{
+		Sender:                     newV2Address(t, sampleAddr),
+		SequenceNumber:             ^uint64(0),
+		Payload:                    &v2.TransactionInnerPayload{Executable: buildV2EntryFunction(t), ReplayProtectionNonce: &nonce},
+		MaxGasAmount:               2_000_000,
+		GasUnitPrice:               100,
+		ExpirationTimestampSeconds: 1_700_000_000,
+		ChainID:                    4,
+	}
+
+	v1Bytes, err := v1bcs.Serialize(v1Raw)
+	require.NoError(t, err)
+	v2Bytes, err := v2bcs.Serialize(v2Raw)
+	require.NoError(t, err)
+
+	assert.Equal(t, v1Bytes, v2Bytes,
+		"orderless RawTransaction BCS must match between v1 and v2")
+}
+
 // TestCrossVersion_RawTransaction_BCS is the headline cross-version test:
 // build the same RawTransaction in v1 and v2 and assert byte equality.
 //

--- a/v2/inner_payload.go
+++ b/v2/inner_payload.go
@@ -1,0 +1,138 @@
+package aptos
+
+import (
+	"fmt"
+
+	"github.com/aptos-labs/aptos-go-sdk/v2/internal/bcs"
+)
+
+// Inner (TransactionPayload::Payload) BCS variant constants. These mirror the
+// on-chain enum layout for the newer transaction payload format that carries a
+// replay-protection nonce (enabling orderless transactions) and an optional
+// multisig address.
+const (
+	// PayloadVariantInner is the TransactionPayload variant for the wrapped
+	// TransactionInnerPayload format (AIP-123).
+	PayloadVariantInner = 4
+
+	innerPayloadVariantV1 = 0
+
+	executableVariantScript        = 0
+	executableVariantEntryFunction = 1
+	executableVariantEmpty         = 2
+
+	extraConfigVariantV1 = 0
+)
+
+// TransactionInnerPayload wraps an executable (entry function or script) with
+// extra configuration using the TransactionPayload::Payload format (variant 4).
+//
+// Its main use is orderless transactions: setting ReplayProtectionNonce lets a
+// transaction be validated by a one-time nonce instead of the account's
+// sequence number, so transactions need not be ordered. When built through
+// [Client.BuildTransaction] with [WithReplayProtectionNonce], the wrapping and
+// the u64::MAX sequence number are handled automatically.
+type TransactionInnerPayload struct {
+	// Executable is the payload to run: *EntryFunctionPayload, *ScriptPayload,
+	// or nil for an empty executable.
+	Executable Payload
+	// MultisigAddress, when set, targets an on-chain multisig account.
+	MultisigAddress *AccountAddress
+	// ReplayProtectionNonce, when set, makes the transaction orderless.
+	ReplayProtectionNonce *uint64
+}
+
+func (p *TransactionInnerPayload) payloadType() string {
+	return "inner_payload"
+}
+
+// wrapOrderless wraps an entry-function or script payload in a
+// TransactionInnerPayload carrying the replay-protection nonce. A payload that
+// is already a TransactionInnerPayload is returned unchanged (with its nonce
+// set if not already present) to avoid double-wrapping.
+func wrapOrderless(payload Payload, nonce *uint64) Payload {
+	if inner, ok := payload.(*TransactionInnerPayload); ok {
+		if inner.ReplayProtectionNonce == nil {
+			inner.ReplayProtectionNonce = nonce
+		}
+		return inner
+	}
+	return &TransactionInnerPayload{
+		Executable:            payload,
+		ReplayProtectionNonce: nonce,
+	}
+}
+
+// serializeInnerPayload writes the inner-payload body (everything after the
+// TransactionPayload variant tag).
+func serializeInnerPayload(ser *bcs.Serializer, p *TransactionInnerPayload) {
+	ser.Uleb128(innerPayloadVariantV1)
+	serializeExecutable(ser, p.Executable)
+	serializeExtraConfig(ser, p)
+}
+
+func serializeExecutable(ser *bcs.Serializer, executable Payload) {
+	switch e := executable.(type) {
+	case nil:
+		ser.Uleb128(executableVariantEmpty)
+	case *EntryFunctionPayload:
+		ser.Uleb128(executableVariantEntryFunction)
+		serializeEntryFunction(ser, e)
+	case *ScriptPayload:
+		ser.Uleb128(executableVariantScript)
+		serializeScript(ser, e)
+	default:
+		ser.SetError(fmt.Errorf("unsupported inner executable type: %T", executable))
+	}
+}
+
+func serializeExtraConfig(ser *bcs.Serializer, p *TransactionInnerPayload) {
+	ser.Uleb128(extraConfigVariantV1)
+	bcs.SerializeOption(ser, p.MultisigAddress, func(ser *bcs.Serializer, addr AccountAddress) {
+		addr.MarshalBCS(ser)
+	})
+	bcs.SerializeOption(ser, p.ReplayProtectionNonce, func(ser *bcs.Serializer, nonce uint64) {
+		ser.U64(nonce)
+	})
+}
+
+// deserializeInnerPayload reads the inner-payload body (the TransactionPayload
+// variant tag has already been consumed).
+func deserializeInnerPayload(des *bcs.Deserializer) *TransactionInnerPayload {
+	if v := des.Uleb128(); v != innerPayloadVariantV1 {
+		des.SetError(fmt.Errorf("unknown inner payload variant: %d", v))
+		return nil
+	}
+
+	p := &TransactionInnerPayload{}
+	p.Executable = deserializeExecutable(des)
+
+	if v := des.Uleb128(); v != extraConfigVariantV1 {
+		des.SetError(fmt.Errorf("unknown extra config variant: %d", v))
+		return nil
+	}
+	p.MultisigAddress = bcs.DeserializeOption(des, func(des *bcs.Deserializer) AccountAddress {
+		var addr AccountAddress
+		addr.UnmarshalBCS(des)
+		return addr
+	})
+	p.ReplayProtectionNonce = bcs.DeserializeOption(des, func(des *bcs.Deserializer) uint64 {
+		return des.U64()
+	})
+
+	return p
+}
+
+func deserializeExecutable(des *bcs.Deserializer) Payload {
+	switch v := des.Uleb128(); v {
+	case executableVariantEmpty:
+		return nil
+	case executableVariantEntryFunction:
+		return deserializeEntryFunction(des)
+	case executableVariantScript:
+		return deserializeScript(des)
+	default:
+		des.SetError(fmt.Errorf("unknown inner executable variant: %d", v))
+		return nil
+	}
+}

--- a/v2/inner_payload_test.go
+++ b/v2/inner_payload_test.go
@@ -1,0 +1,118 @@
+package aptos
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/aptos-labs/aptos-go-sdk/v2/internal/bcs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sampleEntryFunction() *EntryFunctionPayload {
+	return &EntryFunctionPayload{
+		Module:   ModuleID{Address: AccountOne, Name: "aptos_account"},
+		Function: "transfer",
+		Args:     []any{AccountTwo, uint64(100)},
+	}
+}
+
+func TestTransactionInnerPayload_RoundTrip(t *testing.T) {
+	t.Parallel()
+	nonce := uint64(0xdeadbeef)
+	txn := &RawTransaction{
+		Sender:                     AccountOne,
+		SequenceNumber:             math.MaxUint64,
+		MaxGasAmount:               10000,
+		GasUnitPrice:               100,
+		ExpirationTimestampSeconds: 1700000000,
+		ChainID:                    4,
+		Payload: &TransactionInnerPayload{
+			Executable:            sampleEntryFunction(),
+			ReplayProtectionNonce: &nonce,
+		},
+	}
+
+	raw, err := bcs.Serialize(txn)
+	require.NoError(t, err)
+
+	out := &RawTransaction{}
+	require.NoError(t, bcs.Deserialize(out, raw))
+
+	inner, ok := out.Payload.(*TransactionInnerPayload)
+	require.True(t, ok, "payload should deserialize as *TransactionInnerPayload, got %T", out.Payload)
+	require.NotNil(t, inner.ReplayProtectionNonce)
+	assert.Equal(t, nonce, *inner.ReplayProtectionNonce)
+	assert.Nil(t, inner.MultisigAddress)
+
+	ef, ok := inner.Executable.(*EntryFunctionPayload)
+	require.True(t, ok, "executable should be an entry function, got %T", inner.Executable)
+	assert.Equal(t, "aptos_account", ef.Module.Name)
+	assert.Equal(t, "transfer", ef.Function)
+
+	// Re-serializing the round-tripped transaction must be byte-identical.
+	raw2, err := bcs.Serialize(out)
+	require.NoError(t, err)
+	assert.Equal(t, raw, raw2)
+}
+
+func TestTransactionInnerPayload_UsesPayloadVariant4(t *testing.T) {
+	t.Parallel()
+	txn := &RawTransaction{
+		Sender:  AccountOne,
+		Payload: &TransactionInnerPayload{Executable: sampleEntryFunction()},
+	}
+	raw, err := bcs.Serialize(txn)
+	require.NoError(t, err)
+
+	// Layout: sender (32 bytes) || sequence_number (8 bytes) || payload variant.
+	require.Greater(t, len(raw), 40)
+	assert.Equal(t, byte(4), raw[40], "inner payload must use TransactionPayload variant 4")
+}
+
+func TestBuildTransaction_Orderless(t *testing.T) {
+	t.Parallel()
+	// ChainID is cached from the network config (4), and no gas estimation is
+	// requested, so BuildTransaction makes no HTTP calls for an orderless txn.
+	client := newTestClient(t, jsonHandler(nil))
+	nonce := uint64(42)
+
+	txn, err := client.BuildTransaction(
+		context.Background(),
+		AccountOne,
+		sampleEntryFunction(),
+		WithReplayProtectionNonce(nonce),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(math.MaxUint64), txn.SequenceNumber, "orderless txns use u64::MAX as the sequence number")
+
+	inner, ok := txn.Payload.(*TransactionInnerPayload)
+	require.True(t, ok, "payload should be wrapped in *TransactionInnerPayload, got %T", txn.Payload)
+	require.NotNil(t, inner.ReplayProtectionNonce)
+	assert.Equal(t, nonce, *inner.ReplayProtectionNonce)
+
+	_, ok = inner.Executable.(*EntryFunctionPayload)
+	assert.True(t, ok, "original entry function should be the executable")
+}
+
+func TestBuildTransaction_OrderlessDoesNotDoubleWrap(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, jsonHandler(nil))
+	nonce := uint64(7)
+	pre := &TransactionInnerPayload{Executable: sampleEntryFunction(), ReplayProtectionNonce: &nonce}
+
+	txn, err := client.BuildTransaction(
+		context.Background(),
+		AccountOne,
+		pre,
+		WithReplayProtectionNonce(nonce),
+	)
+	require.NoError(t, err)
+
+	inner, ok := txn.Payload.(*TransactionInnerPayload)
+	require.True(t, ok)
+	_, nested := inner.Executable.(*TransactionInnerPayload)
+	assert.False(t, nested, "an already-inner payload must not be wrapped again")
+}

--- a/v2/inner_payload_test.go
+++ b/v2/inner_payload_test.go
@@ -116,3 +116,134 @@ func TestBuildTransaction_OrderlessDoesNotDoubleWrap(t *testing.T) {
 	_, nested := inner.Executable.(*TransactionInnerPayload)
 	assert.False(t, nested, "an already-inner payload must not be wrapped again")
 }
+
+func TestWrapOrderless_SetsNonceOnExistingInnerWithoutOne(t *testing.T) {
+	t.Parallel()
+	// An inner payload that arrives without a nonce should have the supplied
+	// nonce applied in place, rather than being wrapped again.
+	inner := &TransactionInnerPayload{Executable: sampleEntryFunction()}
+	nonce := uint64(99)
+
+	wrapped := wrapOrderless(inner, &nonce)
+
+	assert.Same(t, inner, wrapped, "existing inner payload should be reused, not re-wrapped")
+	require.NotNil(t, inner.ReplayProtectionNonce)
+	assert.Equal(t, nonce, *inner.ReplayProtectionNonce)
+}
+
+func TestTransactionInnerPayload_PayloadType(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "inner_payload", (&TransactionInnerPayload{}).payloadType())
+}
+
+func TestTransactionInnerPayload_ScriptExecutable_RoundTrip(t *testing.T) {
+	t.Parallel()
+	nonce := uint64(1)
+	txn := &RawTransaction{
+		Sender:         AccountOne,
+		SequenceNumber: math.MaxUint64,
+		Payload: &TransactionInnerPayload{
+			Executable: &ScriptPayload{
+				Code: []byte{0xa1, 0x02, 0x03},
+				Args: []any{uint64(7), AccountTwo},
+			},
+			ReplayProtectionNonce: &nonce,
+		},
+	}
+
+	raw, err := bcs.Serialize(txn)
+	require.NoError(t, err)
+
+	out := &RawTransaction{}
+	require.NoError(t, bcs.Deserialize(out, raw))
+
+	inner, ok := out.Payload.(*TransactionInnerPayload)
+	require.True(t, ok)
+	script, ok := inner.Executable.(*ScriptPayload)
+	require.True(t, ok, "executable should round-trip as a script, got %T", inner.Executable)
+	assert.Equal(t, []byte{0xa1, 0x02, 0x03}, script.Code)
+	require.Len(t, script.Args, 2)
+	assert.Equal(t, uint64(7), script.Args[0])
+	assert.Equal(t, AccountTwo, script.Args[1])
+}
+
+func TestTransactionInnerPayload_EmptyExecutable_RoundTrip(t *testing.T) {
+	t.Parallel()
+	txn := &RawTransaction{
+		Sender:         AccountOne,
+		SequenceNumber: math.MaxUint64,
+		Payload:        &TransactionInnerPayload{Executable: nil},
+	}
+
+	raw, err := bcs.Serialize(txn)
+	require.NoError(t, err)
+
+	out := &RawTransaction{}
+	require.NoError(t, bcs.Deserialize(out, raw))
+
+	inner, ok := out.Payload.(*TransactionInnerPayload)
+	require.True(t, ok)
+	assert.Nil(t, inner.Executable, "empty executable should round-trip as nil")
+}
+
+func TestTransactionInnerPayload_MultisigAddress_RoundTrip(t *testing.T) {
+	t.Parallel()
+	multisig := AccountThree
+	nonce := uint64(0x1234)
+	txn := &RawTransaction{
+		Sender:         AccountOne,
+		SequenceNumber: math.MaxUint64,
+		Payload: &TransactionInnerPayload{
+			Executable:            sampleEntryFunction(),
+			MultisigAddress:       &multisig,
+			ReplayProtectionNonce: &nonce,
+		},
+	}
+
+	raw, err := bcs.Serialize(txn)
+	require.NoError(t, err)
+
+	out := &RawTransaction{}
+	require.NoError(t, bcs.Deserialize(out, raw))
+
+	inner, ok := out.Payload.(*TransactionInnerPayload)
+	require.True(t, ok)
+	require.NotNil(t, inner.MultisigAddress)
+	assert.Equal(t, multisig, *inner.MultisigAddress)
+	require.NotNil(t, inner.ReplayProtectionNonce)
+	assert.Equal(t, nonce, *inner.ReplayProtectionNonce)
+}
+
+func TestSerializeExecutable_UnsupportedTypeErrors(t *testing.T) {
+	t.Parallel()
+	ser := bcs.NewSerializer()
+	// A nested inner payload is a Payload but not a valid executable.
+	serializeExecutable(ser, &TransactionInnerPayload{})
+	require.Error(t, ser.Error())
+	assert.Contains(t, ser.Error().Error(), "unsupported inner executable type")
+}
+
+func TestDeserializeInnerPayload_BadInnerVariant(t *testing.T) {
+	t.Parallel()
+	des := bcs.NewDeserializer([]byte{0x01}) // inner variant 1 is unknown
+	deserializeInnerPayload(des)
+	require.Error(t, des.Error())
+	assert.Contains(t, des.Error().Error(), "unknown inner payload variant")
+}
+
+func TestDeserializeInnerPayload_BadExtraConfigVariant(t *testing.T) {
+	t.Parallel()
+	// inner variant 0, empty executable (2), then an unknown extra-config variant.
+	des := bcs.NewDeserializer([]byte{0x00, 0x02, 0x05})
+	deserializeInnerPayload(des)
+	require.Error(t, des.Error())
+	assert.Contains(t, des.Error().Error(), "unknown extra config variant")
+}
+
+func TestDeserializeExecutable_BadVariant(t *testing.T) {
+	t.Parallel()
+	des := bcs.NewDeserializer([]byte{0x09}) // no such executable variant
+	assert.Nil(t, deserializeExecutable(des))
+	require.Error(t, des.Error())
+	assert.Contains(t, des.Error().Error(), "unknown inner executable variant")
+}

--- a/v2/integration_test.go
+++ b/v2/integration_test.go
@@ -9,6 +9,7 @@ package aptos
 import (
 	"context"
 	"errors"
+	"math"
 	"net/http"
 	"os"
 	"strings"
@@ -742,6 +743,90 @@ func TestIntegration_TransferAPT(t *testing.T) {
 	assert.Less(t, gasPaid, transferAmount, "gas should be smaller than the transfer amount")
 
 	t.Logf("Transfer succeeded: hash=%s, gas_paid=%d octas", result.Hash, gasPaid)
+}
+
+// TestIntegration_OrderlessTransfer exercises the full orderless-transaction
+// lifecycle against a network with a faucet (intended for localnet via
+// APTOS_NETWORK=localnet). It submits a transfer built with
+// WithReplayProtectionNonce, which wraps the payload in a
+// TransactionInnerPayload and uses u64::MAX as the sequence number, then
+// verifies:
+//   - the transaction commits successfully and moves funds,
+//   - the committed record carries u64::MAX as its sequence number (the
+//     on-chain marker of an orderless transaction), and
+//   - replaying the exact same nonce is rejected (replay protection works).
+//
+// This is the on-chain counterpart to the BCS round-trip and cross-version
+// byte-equality tests: it proves the wire format the SDK produces is accepted
+// and validated by a real node.
+func TestIntegration_OrderlessTransfer(t *testing.T) {
+	skipIfShort(t)
+	t.Parallel()
+
+	cfg := testNetwork()
+	if cfg.Name != Localnet.Name {
+		t.Skip("orderless end-to-end test only runs against localnet (set APTOS_NETWORK=localnet)")
+	}
+	if cfg.FaucetURL == "" {
+		t.Skip("test requires a network with a faucet")
+	}
+
+	client := createTestClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	sender, err := account.NewEd25519()
+	require.NoError(t, err, "failed to generate sender")
+	receiver, err := account.NewEd25519()
+	require.NoError(t, err, "failed to generate receiver")
+
+	const senderInitial = uint64(200_000_000) // 2 APT
+	const receiverInitial = uint64(100_000_000)
+	const transferAmount = uint64(50_000_000)
+
+	require.NoError(t, client.Fund(ctx, sender.Address(), senderInitial), "fund sender")
+	require.NoError(t, client.Fund(ctx, receiver.Address(), receiverInitial), "fund receiver")
+
+	receiverBalanceBefore, err := client.AccountBalance(ctx, receiver.Address())
+	require.NoError(t, err, "get receiver balance before")
+
+	receiverAddr := receiver.Address()
+	payload := &EntryFunctionPayload{
+		Module:   ModuleID{Address: AccountOne, Name: "aptos_account"},
+		Function: "transfer",
+		Args:     []any{receiverAddr, transferAmount},
+	}
+
+	// A unique nonce per run avoids collisions with prior runs against a
+	// long-lived localnet within the transaction's expiration window.
+	nonce := uint64(time.Now().UnixNano())
+
+	result, err := client.SignAndSubmitTransaction(ctx, sender, payload, WithReplayProtectionNonce(nonce))
+	require.NoError(t, err, "submit orderless transfer")
+	require.NotEmpty(t, result.Hash, "submit should return a hash")
+
+	committed, err := client.WaitForTransaction(ctx, result.Hash)
+	require.NoError(t, err, "wait for orderless transfer")
+	require.True(t, committed.Success, "orderless transfer should succeed: vm_status=%s", committed.VMStatus)
+	require.Equal(t, "user_transaction", committed.Type)
+
+	// The on-chain marker of an orderless transaction: the sequence number is
+	// u64::MAX rather than the sender's account sequence number.
+	assert.Equal(t, uint64(math.MaxUint64), committed.SequenceNumber,
+		"orderless transactions are recorded with u64::MAX as the sequence number")
+
+	receiverBalanceAfter, err := client.AccountBalance(ctx, receiver.Address())
+	require.NoError(t, err, "get receiver balance after")
+	assert.Equal(t, receiverBalanceBefore+transferAmount, receiverBalanceAfter,
+		"receiver balance should increase by exactly the transfer amount")
+
+	// Replay protection: resubmitting with the same nonce must be rejected.
+	// The failure may surface either at submission (mempool) or as a rejected
+	// build; either way the second attempt must not commit successfully.
+	_, replayErr := client.SignAndSubmitTransaction(ctx, sender, payload, WithReplayProtectionNonce(nonce))
+	assert.Error(t, replayErr, "replaying the same nonce must be rejected")
+
+	t.Logf("Orderless transfer succeeded: hash=%s, nonce=%d", result.Hash, nonce)
 }
 
 // TestIntegration_Mainnet tests connectivity to mainnet specifically.

--- a/v2/node_client.go
+++ b/v2/node_client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"iter"
 	"log/slog"
+	"math"
 	"math/big"
 	"net/http"
 	"net/url"
@@ -186,11 +187,17 @@ func (c *nodeClient) AccountBalance(ctx context.Context, address AccountAddress,
 		return 0, errors.New("view function returned no values")
 	}
 
-	switch v := values[0].(type) {
+	return parseU64Balance(values[0])
+}
+
+// parseU64Balance converts a JSON-decoded balance value (a stringified u64 or,
+// defensively, a JSON number) into a uint64.
+func parseU64Balance(value any) (uint64, error) {
+	switch v := value.(type) {
 	case string:
 		return strconv.ParseUint(v, 10, 64)
 	case float64:
-		// JSON numbers decode to float64. The node *should* return APT
+		// JSON numbers decode to float64. The node *should* return
 		// balances as stringified u64 (and does today), but we accept a
 		// numeric response defensively. float64 can exactly represent
 		// integers only up to 2^53 — about 9.0×10^16 octas, i.e. ~90M
@@ -210,7 +217,7 @@ func (c *nodeClient) AccountBalance(ctx context.Context, address AccountAddress,
 		}
 		return uint64(v), nil
 	default:
-		return 0, fmt.Errorf("unexpected balance value type %T", values[0])
+		return 0, fmt.Errorf("unexpected balance value type %T", value)
 	}
 }
 
@@ -224,9 +231,14 @@ func (c *nodeClient) BuildTransaction(ctx context.Context, sender AccountAddress
 		opt(config)
 	}
 
-	// Get sequence number if not provided
+	// Orderless transactions are validated by a one-time nonce rather than the
+	// account's sequence number, so we wrap the payload and use u64::MAX as the
+	// sequence number without fetching the account.
 	var seqNum uint64
-	if config.SequenceNumber != nil {
+	if config.ReplayProtectionNonce != nil {
+		payload = wrapOrderless(payload, config.ReplayProtectionNonce)
+		seqNum = math.MaxUint64
+	} else if config.SequenceNumber != nil {
 		seqNum = *config.SequenceNumber
 	} else {
 		info, err := c.Account(ctx, sender)
@@ -968,15 +980,23 @@ func (c *nodeClient) postBCS(ctx context.Context, path string, body []byte, resu
 }
 
 func (c *nodeClient) doRequest(ctx context.Context, req *http.Request, result any) error {
+	_, err := c.doRequestReturningHeaders(ctx, req, result)
+	return err
+}
+
+// doRequestReturningHeaders is like doRequest but also returns the response
+// headers on success. It is used by paginated endpoints that carry their next
+// cursor in a response header (X-Aptos-Cursor).
+func (c *nodeClient) doRequestReturningHeaders(ctx context.Context, req *http.Request, result any) (http.Header, error) {
 	resp, err := c.httpClient.Do(ctx, req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("failed to read response body: %w", err)
+		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -1000,16 +1020,16 @@ func (c *nodeClient) doRequest(ctx context.Context, req *http.Request, result an
 			apiErr.Message = string(body)
 		}
 
-		return apiErr
+		return nil, apiErr
 	}
 
 	if result != nil {
 		if err := json.Unmarshal(body, result); err != nil {
-			return fmt.Errorf("failed to unmarshal response: %w", err)
+			return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 		}
 	}
 
-	return nil
+	return resp.Header, nil
 }
 
 // isAPIError checks if err is an APIError and assigns it to target if so.

--- a/v2/node_extras.go
+++ b/v2/node_extras.go
@@ -1,0 +1,123 @@
+package aptos
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// modulesPageSize is the number of modules requested per page when listing an
+// account's modules. The node caps page sizes, so this is only an upper bound.
+const modulesPageSize = 100
+
+// TableItemRequest identifies a single item within an on-chain Move table.
+//
+// KeyType and ValueType are the fully-qualified Move types of the table's key
+// and value (for example "address", "u64", or "0x1::string::String"). Key is
+// the key value encoded the way the node's JSON API expects it — a string for
+// integers and addresses, or a nested object for struct keys.
+type TableItemRequest struct {
+	KeyType   string `json:"key_type"`
+	ValueType string `json:"value_type"`
+	Key       any    `json:"key"`
+}
+
+// GetTableItem reads a single item from an on-chain Move table by its handle
+// and key, decoding the JSON-encoded value into result.
+//
+// Reading table items directly is discouraged for most applications: table
+// handles are an implementation detail of the Move modules that own them and
+// can change, and the indexer usually exposes the same data in a more stable
+// form. It is provided for the cases where a direct read is unavoidable.
+func (c *nodeClient) GetTableItem(ctx context.Context, handle string, req TableItemRequest, result any, opts ...ResourceOption) error {
+	config := &ResourceConfig{}
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	path := fmt.Sprintf("tables/%s/item", url.PathEscape(handle))
+	if config.LedgerVersion != nil {
+		path += fmt.Sprintf("?ledger_version=%d", *config.LedgerVersion)
+	}
+
+	return c.post(ctx, path, req, result)
+}
+
+// AccountBalanceOf returns an account's balance of an arbitrary asset.
+//
+// asset may be either a coin type's fully-qualified struct id (for example
+// "0x1::aptos_coin::AptosCoin") or the address of a fungible asset's metadata
+// object (for example "0xa" for APT). The node transparently handles both the
+// legacy coin representation and the fungible-asset representation, so this
+// works for coins that have migrated to the fungible-asset standard.
+//
+// For the plain APT balance, AccountBalance is a convenient shorthand.
+func (c *nodeClient) AccountBalanceOf(ctx context.Context, address AccountAddress, asset string, opts ...ResourceOption) (uint64, error) {
+	config := &ResourceConfig{}
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	path := fmt.Sprintf("accounts/%s/balance/%s", address.String(), url.PathEscape(asset))
+	if config.LedgerVersion != nil {
+		path += fmt.Sprintf("?ledger_version=%d", *config.LedgerVersion)
+	}
+
+	var value any
+	if err := c.get(ctx, path, &value); err != nil {
+		return 0, err
+	}
+	return parseU64Balance(value)
+}
+
+// AccountModules returns every Move module published under an address.
+//
+// The node returns modules one page at a time and reports the next page's
+// cursor in the X-Aptos-Cursor response header; this method follows that
+// cursor until the account is exhausted and returns the concatenated result.
+func (c *nodeClient) AccountModules(ctx context.Context, address AccountAddress, opts ...ResourceOption) ([]*ModuleBytecode, error) {
+	config := &ResourceConfig{}
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	var modules []*ModuleBytecode
+	cursor := ""
+	for {
+		params := url.Values{}
+		params.Set("limit", strconv.Itoa(modulesPageSize))
+		if cursor != "" {
+			params.Set("start", cursor)
+		}
+		if config.LedgerVersion != nil {
+			params.Set("ledger_version", strconv.FormatUint(*config.LedgerVersion, 10))
+		}
+		path := fmt.Sprintf("accounts/%s/modules?%s", address.String(), params.Encode())
+
+		var page []*ModuleBytecode
+		headers, err := c.getReturningHeaders(ctx, path, &page)
+		if err != nil {
+			return nil, err
+		}
+		modules = append(modules, page...)
+
+		cursor = headers.Get("X-Aptos-Cursor")
+		if cursor == "" {
+			return modules, nil
+		}
+	}
+}
+
+// getReturningHeaders issues a GET and returns the response headers alongside
+// the decoded body, for endpoints paginated via a cursor header.
+func (c *nodeClient) getReturningHeaders(ctx context.Context, path string, result any) (http.Header, error) {
+	reqURL := c.buildURL(path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	return c.doRequestReturningHeaders(ctx, req, result)
+}

--- a/v2/node_extras_test.go
+++ b/v2/node_extras_test.go
@@ -82,6 +82,67 @@ func TestNodeClient_AccountBalanceOf_CoinType(t *testing.T) {
 	assert.Equal(t, uint64(7), bal)
 }
 
+func TestNodeClient_AccountBalanceOf_LedgerVersion(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "ledger_version=55", r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`"9"`))
+	}))
+
+	bal, err := client.AccountBalanceOf(context.Background(), AccountOne, "0xa", AtResourceLedgerVersion(55))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(9), bal)
+}
+
+func TestNodeClient_AccountModules_LedgerVersion(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "77", r.URL.Query().Get("ledger_version"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]ModuleBytecode{{Bytecode: "0x01", ABI: &ModuleABI{Name: "a"}}})
+	}))
+
+	modules, err := client.AccountModules(context.Background(), AccountOne, AtResourceLedgerVersion(77))
+	require.NoError(t, err)
+	require.Len(t, modules, 1)
+}
+
+func TestNodeClient_AccountBalanceOf_Error(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"no such asset"}`, http.StatusNotFound)
+	}))
+
+	_, err := client.AccountBalanceOf(context.Background(), AccountOne, "0x1::aptos_coin::AptosCoin")
+	require.Error(t, err)
+}
+
+func TestNodeClient_AccountModules_Error(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+	}))
+
+	_, err := client.AccountModules(context.Background(), AccountOne)
+	require.Error(t, err)
+}
+
+func TestNodeClient_GetTableItem_Error(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"table item not found"}`, http.StatusNotFound)
+	}))
+
+	var out string
+	err := client.GetTableItem(context.Background(), "0xhandle", TableItemRequest{
+		KeyType:   "address",
+		ValueType: "u64",
+		Key:       "0x1",
+	}, &out)
+	require.Error(t, err)
+}
+
 func TestNodeClient_AccountModules_SinglePage(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/v2/node_extras_test.go
+++ b/v2/node_extras_test.go
@@ -1,0 +1,126 @@
+package aptos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeClient_GetTableItem(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/tables/0xhandle/item", r.URL.Path)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "address", body["key_type"])
+		assert.Equal(t, "u64", body["value_type"])
+		assert.Equal(t, "0x1", body["key"])
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode("42")
+	}))
+
+	var out string
+	err := client.GetTableItem(context.Background(), "0xhandle", TableItemRequest{
+		KeyType:   "address",
+		ValueType: "u64",
+		Key:       "0x1",
+	}, &out)
+	require.NoError(t, err)
+	assert.Equal(t, "42", out)
+}
+
+func TestNodeClient_GetTableItem_LedgerVersion(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "ledger_version=99", r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode("0")
+	}))
+
+	var out string
+	err := client.GetTableItem(context.Background(), "0xhandle", TableItemRequest{
+		KeyType:   "u64",
+		ValueType: "u64",
+		Key:       "1",
+	}, &out, AtResourceLedgerVersion(99))
+	require.NoError(t, err)
+}
+
+func TestNodeClient_AccountBalanceOf(t *testing.T) {
+	t.Parallel()
+	const fa = "0xa"
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/accounts/"+AccountOne.String()+"/balance/"+fa, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		// The node serializes u64 balances as JSON strings.
+		_, _ = w.Write([]byte(`"123456789"`))
+	}))
+
+	bal, err := client.AccountBalanceOf(context.Background(), AccountOne, fa)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(123456789), bal)
+}
+
+func TestNodeClient_AccountBalanceOf_CoinType(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// A fully-qualified coin struct id must survive path-escaping intact.
+		assert.Contains(t, r.URL.Path, "/balance/0x1::aptos_coin::AptosCoin")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`"7"`))
+	}))
+
+	bal, err := client.AccountBalanceOf(context.Background(), AccountOne, "0x1::aptos_coin::AptosCoin")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(7), bal)
+}
+
+func TestNodeClient_AccountModules_SinglePage(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/accounts/"+AccountOne.String()+"/modules", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]ModuleBytecode{
+			{Bytecode: "0x01", ABI: &ModuleABI{Name: "a"}},
+			{Bytecode: "0x02", ABI: &ModuleABI{Name: "b"}},
+		})
+	}))
+
+	modules, err := client.AccountModules(context.Background(), AccountOne)
+	require.NoError(t, err)
+	require.Len(t, modules, 2)
+	assert.Equal(t, "a", modules[0].ABI.Name)
+	assert.Equal(t, "b", modules[1].ABI.Name)
+}
+
+func TestNodeClient_AccountModules_Paginates(t *testing.T) {
+	t.Parallel()
+	var calls int
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("start") {
+		case "": // first page: return a module and a cursor pointing at the next
+			w.Header().Set("X-Aptos-Cursor", "cursor1")
+			_ = json.NewEncoder(w).Encode([]ModuleBytecode{{Bytecode: "0x01", ABI: &ModuleABI{Name: "a"}}})
+		case "cursor1": // last page: no cursor header, iteration stops
+			_ = json.NewEncoder(w).Encode([]ModuleBytecode{{Bytecode: "0x02", ABI: &ModuleABI{Name: "b"}}})
+		default:
+			t.Fatalf("unexpected start cursor %q", r.URL.Query().Get("start"))
+		}
+	}))
+
+	modules, err := client.AccountModules(context.Background(), AccountOne)
+	require.NoError(t, err)
+	require.Len(t, modules, 2)
+	assert.Equal(t, "a", modules[0].ABI.Name)
+	assert.Equal(t, "b", modules[1].ABI.Name)
+	assert.Equal(t, 2, calls, "should follow the cursor for exactly one extra page")
+}

--- a/v2/object.go
+++ b/v2/object.go
@@ -1,0 +1,108 @@
+package aptos
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+)
+
+// ObjectCoreResourceType is the fully-qualified type of the resource every
+// Aptos object carries.
+const ObjectCoreResourceType = "0x1::object::ObjectCore"
+
+// objectCoreTypeTag is the 0x1::object::ObjectCore struct type, used as the
+// default type argument for 0x1::object::transfer.
+var objectCoreTypeTag = TypeTag{Value: &StructTag{
+	Address: AccountOne,
+	Module:  "object",
+	Name:    "ObjectCore",
+}}
+
+// ObjectCore mirrors the on-chain 0x1::object::ObjectCore resource, describing
+// an object's ownership and transferability.
+type ObjectCore struct {
+	// Owner is the current owner of the object.
+	Owner AccountAddress
+	// AllowUngatedTransfer reports whether the object can be transferred with a
+	// plain 0x1::object::transfer (false for soul-bound / gated objects).
+	AllowUngatedTransfer bool
+	// GuidCreationNum is the object's GUID creation counter.
+	GuidCreationNum uint64
+}
+
+// GetObjectCore reads the 0x1::object::ObjectCore resource for an object
+// address, returning its ownership and transfer configuration.
+func GetObjectCore(ctx context.Context, client Client, object AccountAddress, opts ...ResourceOption) (*ObjectCore, error) {
+	resource, err := client.AccountResource(ctx, object, ObjectCoreResourceType, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return parseObjectCore(resource.Data)
+}
+
+// parseObjectCore converts a decoded ObjectCore resource's data map into a
+// typed ObjectCore.
+func parseObjectCore(data map[string]any) (*ObjectCore, error) {
+	ownerStr, ok := data["owner"].(string)
+	if !ok {
+		return nil, fmt.Errorf("object core missing owner field")
+	}
+	owner, err := ParseAddress(ownerStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid object owner %q: %w", ownerStr, err)
+	}
+
+	core := &ObjectCore{Owner: owner}
+
+	if v, ok := data["allow_ungated_transfer"].(bool); ok {
+		core.AllowUngatedTransfer = v
+	}
+
+	// guid_creation_num is a u64 and is serialized as a JSON string.
+	if guidStr, ok := data["guid_creation_num"].(string); ok {
+		guid, err := strconv.ParseUint(guidStr, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid guid_creation_num %q: %w", guidStr, err)
+		}
+		core.GuidCreationNum = guid
+	}
+
+	return core, nil
+}
+
+// ObjectOwner returns the current owner of an object.
+func ObjectOwner(ctx context.Context, client Client, object AccountAddress, opts ...ResourceOption) (AccountAddress, error) {
+	core, err := GetObjectCore(ctx, client, object, opts...)
+	if err != nil {
+		return AccountAddress{}, err
+	}
+	return core.Owner, nil
+}
+
+// IsObjectOwner reports whether owner is the current owner of an object.
+func IsObjectOwner(ctx context.Context, client Client, object AccountAddress, owner AccountAddress, opts ...ResourceOption) (bool, error) {
+	actual, err := ObjectOwner(ctx, client, object, opts...)
+	if err != nil {
+		return false, err
+	}
+	return actual == owner, nil
+}
+
+// ObjectTransferPayload builds an entry-function payload that transfers an
+// object to a new owner via 0x1::object::transfer, using 0x1::object::ObjectCore
+// as the object type. This works for any transferable object; for typed objects
+// that require a more specific type argument, use ObjectTransferPayloadOf.
+func ObjectTransferPayload(object AccountAddress, to AccountAddress) *EntryFunctionPayload {
+	return ObjectTransferPayloadOf(object, to, objectCoreTypeTag)
+}
+
+// ObjectTransferPayloadOf builds a 0x1::object::transfer payload with an
+// explicit object type argument.
+func ObjectTransferPayloadOf(object AccountAddress, to AccountAddress, objectType TypeTag) *EntryFunctionPayload {
+	return &EntryFunctionPayload{
+		Module:   ModuleID{Address: AccountOne, Name: "object"},
+		Function: "transfer",
+		TypeArgs: []TypeTag{objectType},
+		Args:     []any{object, to},
+	}
+}

--- a/v2/object_test.go
+++ b/v2/object_test.go
@@ -1,0 +1,69 @@
+package aptos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func objectCoreHandler(t *testing.T, owner string, allowUngated bool) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/resource/")
+		assert.Contains(t, r.URL.Path, "0x1::object::ObjectCore")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Resource{
+			Type: ObjectCoreResourceType,
+			Data: map[string]any{
+				"owner":                  owner,
+				"allow_ungated_transfer": allowUngated,
+				"guid_creation_num":      "1125899906842625",
+			},
+		})
+	}
+}
+
+func TestGetObjectCore(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, objectCoreHandler(t, AccountOne.String(), true))
+
+	core, err := GetObjectCore(context.Background(), client, AccountTwo)
+	require.NoError(t, err)
+	assert.Equal(t, AccountOne, core.Owner)
+	assert.True(t, core.AllowUngatedTransfer)
+	assert.Equal(t, uint64(1125899906842625), core.GuidCreationNum)
+}
+
+func TestIsObjectOwner(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, objectCoreHandler(t, AccountOne.String(), true))
+
+	yes, err := IsObjectOwner(context.Background(), client, AccountTwo, AccountOne)
+	require.NoError(t, err)
+	assert.True(t, yes)
+
+	no, err := IsObjectOwner(context.Background(), client, AccountTwo, AccountThree)
+	require.NoError(t, err)
+	assert.False(t, no)
+}
+
+func TestObjectTransferPayload(t *testing.T) {
+	t.Parallel()
+	object := AccountTwo
+	recipient := AccountThree
+
+	payload := ObjectTransferPayload(object, recipient)
+
+	assert.Equal(t, AccountOne, payload.Module.Address)
+	assert.Equal(t, "object", payload.Module.Name)
+	assert.Equal(t, "transfer", payload.Function)
+	require.Len(t, payload.TypeArgs, 1)
+	assert.Equal(t, "0x1::object::ObjectCore", payload.TypeArgs[0].String())
+	require.Len(t, payload.Args, 2)
+	assert.Equal(t, object, payload.Args[0])
+	assert.Equal(t, recipient, payload.Args[1])
+}

--- a/v2/object_test.go
+++ b/v2/object_test.go
@@ -51,6 +51,71 @@ func TestIsObjectOwner(t *testing.T) {
 	assert.False(t, no)
 }
 
+func TestParseObjectCore_MissingOwner(t *testing.T) {
+	t.Parallel()
+	_, err := parseObjectCore(map[string]any{"allow_ungated_transfer": true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing owner")
+}
+
+func TestParseObjectCore_InvalidOwner(t *testing.T) {
+	t.Parallel()
+	_, err := parseObjectCore(map[string]any{"owner": "not-an-address"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid object owner")
+}
+
+func TestParseObjectCore_InvalidGuid(t *testing.T) {
+	t.Parallel()
+	_, err := parseObjectCore(map[string]any{
+		"owner":             AccountOne.String(),
+		"guid_creation_num": "not-a-number",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid guid_creation_num")
+}
+
+func TestGetObjectCore_ClientError(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+	}))
+
+	_, err := GetObjectCore(context.Background(), client, AccountTwo)
+	require.Error(t, err)
+}
+
+func TestObjectOwner_PropagatesError(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+	}))
+
+	_, err := ObjectOwner(context.Background(), client, AccountTwo)
+	require.Error(t, err)
+}
+
+func TestIsObjectOwner_PropagatesError(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+	}))
+
+	ok, err := IsObjectOwner(context.Background(), client, AccountTwo, AccountOne)
+	require.Error(t, err)
+	assert.False(t, ok)
+}
+
+func TestObjectTransferPayloadOf_UsesGivenType(t *testing.T) {
+	t.Parallel()
+	custom := TypeTag{Value: &StructTag{Address: AccountOne, Module: "my_module", Name: "MyToken"}}
+
+	payload := ObjectTransferPayloadOf(AccountTwo, AccountThree, custom)
+
+	require.Len(t, payload.TypeArgs, 1)
+	assert.Equal(t, "0x1::my_module::MyToken", payload.TypeArgs[0].String())
+}
+
 func TestObjectTransferPayload(t *testing.T) {
 	t.Parallel()
 	object := AccountTwo

--- a/v2/options.go
+++ b/v2/options.go
@@ -174,6 +174,11 @@ type TransactionConfig struct {
 
 	// FeePayer is the fee payer address for sponsored transactions.
 	FeePayer *AccountAddress
+
+	// ReplayProtectionNonce, when set, builds an orderless transaction: the
+	// payload is wrapped in a TransactionInnerPayload carrying this nonce and
+	// the sequence number is set to u64::MAX.
+	ReplayProtectionNonce *uint64
 }
 
 // WithMaxGas sets the maximum gas amount.
@@ -240,6 +245,17 @@ func WithFeePayer(feePayer AccountAddress) TransactionOption {
 	}
 }
 
+// WithReplayProtectionNonce builds an orderless transaction protected by a
+// one-time nonce instead of the sender's sequence number. The nonce must be
+// unique per sender within the transaction's expiration window. BuildTransaction
+// wraps the payload in a TransactionInnerPayload and sets the sequence number to
+// u64::MAX automatically.
+func WithReplayProtectionNonce(nonce uint64) TransactionOption {
+	return func(c *TransactionConfig) {
+		c.ReplayProtectionNonce = &nonce
+	}
+}
+
 // ViewOption is a functional option for view function calls.
 type ViewOption func(*ViewConfig)
 
@@ -258,6 +274,14 @@ func AtLedgerVersion(version uint64) ViewOption {
 
 // ResourceOption is a functional option for resource queries.
 type ResourceOption func(*ResourceConfig)
+
+// AtResourceLedgerVersion queries a resource, module, table item, or balance at
+// a specific ledger version rather than the latest state.
+func AtResourceLedgerVersion(version uint64) ResourceOption {
+	return func(c *ResourceConfig) {
+		c.LedgerVersion = &version
+	}
+}
 
 // ResourceConfig holds configuration for resource queries.
 type ResourceConfig struct {

--- a/v2/testutil/fake_client.go
+++ b/v2/testutil/fake_client.go
@@ -294,6 +294,19 @@ func (c *FakeClient) AccountBalance(ctx context.Context, address aptos.AccountAd
 	return balance, nil
 }
 
+// AccountBalanceOf returns the configured balance for an account, ignoring the
+// asset. The stub does not track per-asset balances; configure balances with
+// WithBalance and use the same value for every asset.
+func (c *FakeClient) AccountBalanceOf(ctx context.Context, address aptos.AccountAddress, asset string, opts ...aptos.ResourceOption) (uint64, error) {
+	c.record("AccountBalanceOf", address, asset)
+	if err := c.getError("AccountBalanceOf"); err != nil {
+		return 0, err
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.balances[address], nil
+}
+
 // BuildTransaction builds a transaction.
 func (c *FakeClient) BuildTransaction(ctx context.Context, sender aptos.AccountAddress, payload aptos.Payload, opts ...aptos.TransactionOption) (*aptos.RawTransaction, error) {
 	c.record("BuildTransaction", sender, payload)
@@ -597,6 +610,17 @@ func (c *FakeClient) AccountModule(ctx context.Context, address aptos.AccountAdd
 	}, nil
 }
 
+// AccountModules returns all modules published under an address.
+// The stub records the call, honors any configured error, and returns an
+// empty slice.
+func (c *FakeClient) AccountModules(ctx context.Context, address aptos.AccountAddress, opts ...aptos.ResourceOption) ([]*aptos.ModuleBytecode, error) {
+	c.record("AccountModules", address)
+	if err := c.getError("AccountModules"); err != nil {
+		return nil, err
+	}
+	return []*aptos.ModuleBytecode{}, nil
+}
+
 // AccountTransactions returns transactions sent by an account.
 func (c *FakeClient) AccountTransactions(ctx context.Context, address aptos.AccountAddress, start *uint64, limit *uint64) ([]*aptos.Transaction, error) {
 	c.record("AccountTransactions", address, start, limit)
@@ -622,6 +646,14 @@ func (c *FakeClient) EventsByCreationNumber(ctx context.Context, address aptos.A
 		return nil, err
 	}
 	return []aptos.Event{}, nil
+}
+
+// GetTableItem reads a single item from an on-chain Move table.
+// The stub records the call and honors any configured error; it does not
+// populate result.
+func (c *FakeClient) GetTableItem(ctx context.Context, handle string, req aptos.TableItemRequest, result any, opts ...aptos.ResourceOption) error {
+	c.record("GetTableItem", handle, req)
+	return c.getError("GetTableItem")
 }
 
 // Ensure FakeClient implements Client

--- a/v2/transaction_types.go
+++ b/v2/transaction_types.go
@@ -157,6 +157,9 @@ func serializePayload(ser *bcs.Serializer, payload Payload) {
 	case *ScriptPayload:
 		ser.Uleb128(PayloadVariantScript)
 		serializeScript(ser, p)
+	case *TransactionInnerPayload:
+		ser.Uleb128(PayloadVariantInner)
+		serializeInnerPayload(ser, p)
 	default:
 		ser.SetError(fmt.Errorf("unsupported payload type: %T", payload))
 	}
@@ -170,6 +173,8 @@ func deserializePayload(des *bcs.Deserializer) Payload {
 		return deserializeEntryFunction(des)
 	case PayloadVariantScript:
 		return deserializeScript(des)
+	case PayloadVariantInner:
+		return deserializeInnerPayload(des)
 	default:
 		des.SetError(fmt.Errorf("unknown payload variant: %d", variant))
 		return nil


### PR DESCRIPTION
## Summary

Fills five feature gaps in the **v2** module, identified by auditing coverage against the canonical Aptos TypeScript SDK. All work is v2-only; the v1 root module is untouched.

| # | Feature | API added |
|---|---------|-----------|
| 1 | **Object client (REST)** | `GetObjectCore`, `ObjectOwner`, `IsObjectOwner`, `ObjectTransferPayload`/`ObjectTransferPayloadOf`, `ObjectCore` type |
| 2 | **Orderless transactions** | `TransactionInnerPayload` (BCS payload variant 4) + `WithReplayProtectionNonce(nonce)` wired into `BuildTransaction` (auto-wraps payload, sets seq to `u64::MAX`) |
| 3 | **Table item lookup** | `Client.GetTableItem(handle, TableItemRequest, &out, ...)` |
| 4 | **Arbitrary coin/FA balance** | `Client.AccountBalanceOf(addr, asset, ...)` — accepts a coin struct id or FA metadata address |
| 5 | **List all modules** | `Client.AccountModules(addr, ...)` — auto-paginates via the `X-Aptos-Cursor` header |

## Notes

- **Object client is REST-based**: reads `0x1::object::ObjectCore` and builds a `0x1::object::transfer` payload. Indexer-only bits (owned-objects listing, `state_key_hash`) are out of scope — v2 has no GraphQL layer. Object helpers are free functions taking `Client`, so no interface change is needed.
- Features 3–5 are added to the `Client` interface, `nodeClient`, and `testutil.FakeClient` (kept in sync with its `var _ aptos.Client` assertion).
- Added `AtResourceLedgerVersion(v)` — v2 had a `ResourceConfig.LedgerVersion` field with no setter; table/balance/modules/resource reads now support historical queries.
- Small refactors: extracted `parseU64Balance` (shared by `AccountBalance`/`AccountBalanceOf`) and `doRequestReturningHeaders` (for cursor pagination). Existing callers unchanged.

## Testing

- TDD throughout (test-first, red → green).
- `go test -race ./...` passes; `gofumpt` clean; `golangci-lint run ./...` reports 0 issues.
- Orderless is the only feature whose bytes hit the chain, so **`TestCrossVersion_OrderlessInnerPayload_BCS`** in the `compatibility/` suite builds the same orderless txn in v1 and v2 and asserts **byte-identical BCS**. v1's inner-payload format is the production-validated reference.

## Not included (flagging)

The orderless `TransactionExtraConfigV1` also supports a `MultisigAddress` option — the field is present and serializes correctly, but there is no high-level helper for the multisig+orderless combination.
